### PR TITLE
Add comprehensive ERT test suite for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,13 @@ jobs:
         if: inputs.test
         run: nix develop --command cargo test --manifest-path server/Cargo.toml
 
+      - name: Upload binary for CI
+        uses: actions/upload-artifact@v4
+        with:
+          name: tramp-rpc-server-${{ inputs.target }}
+          path: target/${{ inputs.target }}/release/tramp-rpc-server
+          retention-days: 1
+
       - name: Package
         if: inputs.upload
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,135 @@ jobs:
           emacs -Q --batch \
             --eval "(require 'package)" \
             --eval "(with-current-buffer (find-file-noselect \"lisp/tramp-rpc.el\") (package-buffer-info))"
+
+  test-protocol:
+    name: Protocol Tests
+    runs-on: ubuntu-latest
+    needs: elisp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: '30.1'
+
+      - name: Run protocol tests
+        run: |
+          emacs -Q --batch \
+            --eval "(setq debug-on-error t)" \
+            -l test/tramp-rpc-mock-tests.el \
+            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-protocol\")"
+
+  test-server:
+    name: Server Integration Tests
+    runs-on: ubuntu-latest
+    needs: [rust, elisp]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: '30.1'
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: tramp-rpc-server-x86_64-unknown-linux-musl
+          path: target/x86_64-unknown-linux-musl/release/
+
+      - name: Make server executable
+        run: chmod +x target/x86_64-unknown-linux-musl/release/tramp-rpc-server
+
+      - name: Run server integration tests
+        run: |
+          emacs -Q --batch \
+            --eval "(setq debug-on-error t)" \
+            -l test/tramp-rpc-mock-tests.el \
+            --eval "(ert-run-tests-batch-and-exit '(tag :server))"
+
+  test-full-suite:
+    name: Full Test Suite (with SSH)
+    runs-on: ubuntu-latest
+    needs: [rust, elisp]
+    # Only run on main branch to avoid SSH setup complexity in PRs
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: '30.1'
+
+      - name: Download server binary
+        uses: actions/download-artifact@v4
+        with:
+          name: tramp-rpc-server-x86_64-unknown-linux-musl
+          path: target/x86_64-unknown-linux-musl/release/
+
+      - name: Make server executable
+        run: chmod +x target/x86_64-unknown-linux-musl/release/tramp-rpc-server
+
+      - name: Setup SSH for localhost
+        run: |
+          # Generate SSH key
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""
+          # Add to authorized_keys
+          cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+          chmod 600 ~/.ssh/authorized_keys
+          # Configure SSH
+          echo "Host localhost" >> ~/.ssh/config
+          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+          echo "  UserKnownHostsFile /dev/null" >> ~/.ssh/config
+          chmod 600 ~/.ssh/config
+          # Start SSH server if not running
+          sudo service ssh start || true
+          # Test SSH connection
+          ssh localhost "echo 'SSH connection successful'"
+
+      - name: Deploy server to localhost
+        run: |
+          mkdir -p ~/.cache/tramp-rpc
+          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/
+
+      - name: Run full test suite
+        env:
+          TRAMP_RPC_TEST_HOST: localhost
+        run: |
+          emacs -Q --batch \
+            --eval "(setq debug-on-error t)" \
+            --eval "(setq tramp-verbose 0)" \
+            -l test/tramp-rpc-tests.el \
+            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-test\")"
+
+  summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [rust, elisp, test-protocol, test-server]
+    if: always()
+
+    steps:
+      - name: Check results
+        run: |
+          echo "=== CI Summary ==="
+          echo "Rust: ${{ needs.rust.result }}"
+          echo "Elisp: ${{ needs.elisp.result }}"
+          echo "Protocol Tests: ${{ needs.test-protocol.result }}"
+          echo "Server Tests: ${{ needs.test-server.result }}"
+          
+          if [[ "${{ needs.rust.result }}" != "success" ]] || \
+             [[ "${{ needs.elisp.result }}" != "success" ]] || \
+             [[ "${{ needs.test-protocol.result }}" != "success" ]] || \
+             [[ "${{ needs.test-server.result }}" != "success" ]]; then
+            echo "Some tests failed!"
+            exit 1
+          fi
+          echo "All tests passed!"

--- a/README.org
+++ b/README.org
@@ -278,6 +278,71 @@ Batch operations provide additional 3-6x speedup by combining multiple requests 
 
 For detailed benchmarks and an in-depth technical comparison with original TRAMP, see [[file:doc/TECHNICAL_COMPARISON.org][Technical Comparison]].
 
+* Testing
+
+TRAMP-RPC includes a comprehensive test suite using Emacs ERT (Emacs Lisp Regression Testing).
+
+** Test Categories
+
+| Category          | Tests | Requirements           |
+|-------------------+-------+------------------------|
+| Protocol          | 6     | None (pure Elisp)      |
+| Conversion        | 2     | None (pure Elisp)      |
+| Server Integration| 4     | RPC server binary      |
+| Remote File Ops   | 18    | SSH + RPC server       |
+
+** Running Tests
+
+*** Quick Protocol Tests (no dependencies)
+
+#+begin_src bash
+./test/run-tests.sh --protocol
+#+end_src
+
+Or directly with Emacs:
+
+#+begin_src bash
+emacs -Q --batch -l test/tramp-rpc-mock-tests.el \
+  --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-protocol\")"
+#+end_src
+
+*** All Mock Tests (includes server integration)
+
+#+begin_src bash
+./test/run-tests.sh --mock
+#+end_src
+
+This runs protocol tests plus server integration tests that communicate directly with the RPC server (no SSH needed).
+
+*** Full Remote Tests (requires SSH)
+
+#+begin_src bash
+TRAMP_RPC_TEST_HOST=your-remote-host ./test/run-tests.sh --remote
+#+end_src
+
+Or:
+
+#+begin_src bash
+emacs -Q --batch \
+  -l test/tramp-rpc-tests.el \
+  --eval "(setq tramp-rpc-test-host \"your-remote-host\")" \
+  --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-test\")"
+#+end_src
+
+** Test Files
+
+- =test/tramp-rpc-tests.el= - Full ERT test suite for remote operations
+- =test/tramp-rpc-mock-tests.el= - CI-compatible tests (no SSH required)
+- =test/run-tests.sh= - Test runner script
+
+** CI Integration
+
+The GitHub Actions workflow runs:
+
+1. *Protocol Tests* - JSON-RPC encoding/decoding (no server)
+2. *Server Integration Tests* - Direct server communication (Rust binary)
+3. *Full Test Suite* - (main branch only) Complete tests via SSH to localhost
+
 * License
 
 This project is licensed under the GNU General Public License v3.0 or later - see the [[file:LICENSE][LICENSE]] file for details.
@@ -285,3 +350,9 @@ This project is licensed under the GNU General Public License v3.0 or later - se
 * Contributing
 
 Contributions welcome! Please ensure code passes ~cargo clippy~ and ~cargo test~ before submitting.
+
+For Emacs Lisp changes, also run the test suite:
+
+#+begin_src bash
+./test/run-tests.sh --mock
+#+end_src

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Test runner for tramp-rpc
+# Usage:
+#   ./test/run-tests.sh [OPTIONS]
+#
+# Options:
+#   --mock      Run mock tests only (no SSH required)
+#   --protocol  Run protocol tests only (no server required)
+#   --server    Run server tests (requires built server)
+#   --remote    Run remote tests (requires SSH to TRAMP_RPC_TEST_HOST)
+#   --all       Run all tests
+#   --help      Show this help
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --mock      Run mock tests only (no SSH required)"
+    echo "  --protocol  Run protocol tests only (no server required)"
+    echo "  --server    Run server tests (requires built server)"
+    echo "  --remote    Run remote tests (requires SSH to TRAMP_RPC_TEST_HOST)"
+    echo "  --all       Run all tests"
+    echo "  --help      Show this help"
+    echo ""
+    echo "Environment variables:"
+    echo "  TRAMP_RPC_TEST_HOST   Remote host for testing (default: localhost)"
+    echo "  TRAMP_RPC_TEST_USER   User for remote testing"
+    echo "  EMACS                 Emacs executable (default: emacs)"
+}
+
+run_protocol_tests() {
+    echo -e "${YELLOW}Running protocol tests...${NC}"
+    ${EMACS:-emacs} -Q --batch \
+        -l "$SCRIPT_DIR/tramp-rpc-mock-tests.el" \
+        --eval "(ert-run-tests-batch-and-exit '(and (tag tramp-rpc-mock-test) (not (tag :server))))"
+}
+
+run_server_tests() {
+    echo -e "${YELLOW}Running server tests...${NC}"
+    # Check if server is available
+    if [[ -x "$PROJECT_DIR/target/release/tramp-rpc-server" ]] || \
+       [[ -x "$PROJECT_DIR/target/debug/tramp-rpc-server" ]] || \
+       [[ -f "$PROJECT_DIR/server/tramp-rpc-server.py" ]]; then
+        ${EMACS:-emacs} -Q --batch \
+            -l "$SCRIPT_DIR/tramp-rpc-mock-tests.el" \
+            --eval "(ert-run-tests-batch-and-exit '(tag :server))"
+    else
+        echo -e "${RED}No server found. Build with 'cargo build' or use Python server.${NC}"
+        exit 1
+    fi
+}
+
+run_mock_tests() {
+    echo -e "${YELLOW}Running all mock tests...${NC}"
+    ${EMACS:-emacs} -Q --batch \
+        -l "$SCRIPT_DIR/tramp-rpc-mock-tests.el" \
+        --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test\")"
+}
+
+run_remote_tests() {
+    echo -e "${YELLOW}Running remote tests against ${TRAMP_RPC_TEST_HOST:-localhost}...${NC}"
+    ${EMACS:-emacs} -Q --batch \
+        -l "$SCRIPT_DIR/tramp-rpc-tests.el" \
+        --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-test\")"
+}
+
+run_all_tests() {
+    echo -e "${YELLOW}Running all tests...${NC}"
+    local failed=0
+    
+    echo ""
+    echo "=== Protocol Tests ==="
+    if run_protocol_tests; then
+        echo -e "${GREEN}Protocol tests passed${NC}"
+    else
+        echo -e "${RED}Protocol tests failed${NC}"
+        failed=1
+    fi
+    
+    echo ""
+    echo "=== Server Tests ==="
+    if run_server_tests; then
+        echo -e "${GREEN}Server tests passed${NC}"
+    else
+        echo -e "${RED}Server tests failed${NC}"
+        failed=1
+    fi
+    
+    return $failed
+}
+
+# Parse arguments
+if [[ $# -eq 0 ]]; then
+    # Default: run mock tests
+    run_mock_tests
+    exit $?
+fi
+
+case "$1" in
+    --mock)
+        run_mock_tests
+        ;;
+    --protocol)
+        run_protocol_tests
+        ;;
+    --server)
+        run_server_tests
+        ;;
+    --remote)
+        run_remote_tests
+        ;;
+    --all)
+        run_all_tests
+        ;;
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+esac

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1,0 +1,430 @@
+;;; tramp-rpc-mock-tests.el --- Mock tests for TRAMP RPC (CI-compatible)  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+
+;; Author: Arthur Heymans <arthur@aheymans.xyz>
+
+;; This file is part of tramp-rpc.
+
+;;; Commentary:
+
+;; This file provides mock tests that can run in CI without SSH access.
+;; It tests the RPC server directly via a local pipe connection.
+;;
+;; These tests focus on:
+;; - Protocol correctness
+;; - Server response handling
+;; - Error handling
+;;
+;; Run with:
+;;   emacs -Q --batch -l test/tramp-rpc-mock-tests.el -f tramp-rpc-mock-test-all
+
+;;; Code:
+
+(require 'ert)
+(require 'json)
+(require 'cl-lib)
+
+;; Compute project root at load time
+(defvar tramp-rpc-mock-test--project-root
+  (expand-file-name "../" (file-name-directory
+                           (or load-file-name buffer-file-name
+                               (expand-file-name "test/tramp-rpc-mock-tests.el"))))
+  "Project root directory, computed at load time.")
+
+;; Load tramp-rpc modules
+(let ((lisp-dir (expand-file-name "lisp" tramp-rpc-mock-test--project-root)))
+  (add-to-list 'load-path lisp-dir))
+
+(require 'tramp-rpc-protocol)
+
+;;; ============================================================================
+;;; Protocol Tests (No server required)
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-protocol-encode-request ()
+  "Test JSON-RPC request encoding."
+  (let* ((result (tramp-rpc-protocol-encode-request-with-id "file.exists" '((path . "/test"))))
+         (id (car result))
+         (json-str (cdr result))
+         (parsed (json-read-from-string json-str)))
+    ;; Check structure
+    (should (assoc 'jsonrpc parsed))
+    (should (equal (cdr (assoc 'jsonrpc parsed)) "2.0"))
+    (should (assoc 'method parsed))
+    (should (equal (cdr (assoc 'method parsed)) "file.exists"))
+    (should (assoc 'params parsed))
+    (should (equal (cdr (assoc 'path (cdr (assoc 'params parsed)))) "/test"))
+    (should (assoc 'id parsed))
+    ;; ID should match returned ID
+    (should (equal (cdr (assoc 'id parsed)) id))))
+
+(ert-deftest tramp-rpc-mock-test-protocol-decode-success ()
+  "Test JSON-RPC success response decoding."
+  (let* ((response-json "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"exists\":true}}")
+         (response (tramp-rpc-protocol-decode-response response-json)))
+    (should (plist-get response :id))
+    (should (equal (plist-get response :id) 1))
+    (should (plist-get response :result))
+    (should-not (tramp-rpc-protocol-error-p response))))
+
+(ert-deftest tramp-rpc-mock-test-protocol-decode-error ()
+  "Test JSON-RPC error response decoding."
+  (let* ((response-json "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32001,\"message\":\"File not found\"}}")
+         (response (tramp-rpc-protocol-decode-response response-json)))
+    (should (tramp-rpc-protocol-error-p response))
+    (should (= (tramp-rpc-protocol-error-code response) -32001))
+    (should (equal (tramp-rpc-protocol-error-message response) "File not found"))))
+
+(ert-deftest tramp-rpc-mock-test-protocol-batch-encode ()
+  "Test JSON-RPC batch request encoding."
+  (let* ((requests '(("file.exists" . ((path . "/a")))
+                     ("file.stat" . ((path . "/b")))))
+         (result (tramp-rpc-protocol-encode-batch-request-with-id requests))
+         (id (car result))
+         (json-str (cdr result))
+         (parsed (json-read-from-string json-str)))
+    ;; Should be a single request with batch method
+    (should (assoc 'method parsed))
+    (should (equal (cdr (assoc 'method parsed)) "batch"))
+    (should (assoc 'params parsed))
+    (let ((params (cdr (assoc 'params parsed))))
+      (should (assoc 'requests params))
+      (let ((reqs (cdr (assoc 'requests params))))
+        (should (= (length reqs) 2))))))
+
+(ert-deftest tramp-rpc-mock-test-protocol-batch-decode ()
+  "Test JSON-RPC batch response decoding."
+  (let* ((response-plist '(:id 1
+                           :result ((results . [((result . t))
+                                                ((error (code . -32001)
+                                                        (message . "Error")))]))))
+         (decoded (tramp-rpc-protocol-decode-batch-response response-plist)))
+    (should (listp decoded))
+    (should (= (length decoded) 2))
+    ;; First result is success
+    (should (eq (car decoded) t))
+    ;; Second is error
+    (should (plist-get (cadr decoded) :error))))
+
+;;; ============================================================================
+;;; JSON-RPC ID Generation Tests
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-protocol-id-uniqueness ()
+  "Test that request IDs are unique."
+  (let ((ids (make-hash-table :test 'equal)))
+    (dotimes (_ 100)
+      (let* ((result (tramp-rpc-protocol-encode-request-with-id "test" nil))
+             (id (car result)))
+        (should-not (gethash id ids))
+        (puthash id t ids)))))
+
+;;; ============================================================================
+;;; Mode String Conversion Tests
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-mode-to-string ()
+  "Test mode integer to string conversion."
+  ;; This tests the internal function if available
+  (when (fboundp 'tramp-rpc--mode-to-string)
+    ;; Regular file with 644 permissions
+    (let ((mode-str (tramp-rpc--mode-to-string #o644 "file")))
+      (should (equal mode-str "-rw-r--r--")))
+    ;; Directory with 755 permissions
+    (let ((mode-str (tramp-rpc--mode-to-string #o755 "directory")))
+      (should (equal mode-str "drwxr-xr-x")))
+    ;; Symlink
+    (let ((mode-str (tramp-rpc--mode-to-string #o777 "symlink")))
+      (should (string-prefix-p "l" mode-str)))))
+
+;;; ============================================================================
+;;; File Attributes Conversion Tests
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-convert-file-attributes ()
+  "Test conversion of stat result to Emacs attributes."
+  (when (fboundp 'tramp-rpc--convert-file-attributes)
+    (let* ((stat-result '((type . "file")
+                          (size . 1234)
+                          (mode . 420)  ; #o644
+                          (nlinks . 1)
+                          (uid . 1000)
+                          (gid . 1000)
+                          (atime . 1700000000)
+                          (mtime . 1700000001)
+                          (ctime . 1700000002)
+                          (inode . 12345)
+                          (dev . 1)))
+           (attrs (tramp-rpc--convert-file-attributes stat-result 'integer)))
+      ;; Type should be nil for regular file
+      (should (null (file-attribute-type attrs)))
+      ;; Size
+      (should (= (file-attribute-size attrs) 1234))
+      ;; UIDs
+      (should (= (file-attribute-user-id attrs) 1000))
+      (should (= (file-attribute-group-id attrs) 1000))
+      ;; Link count
+      (should (= (file-attribute-link-number attrs) 1)))))
+
+;;; ============================================================================
+;;; Local Server Tests (runs actual server)
+;;; ============================================================================
+
+(defvar tramp-rpc-mock-test-server-process nil
+  "Process for the local test server.")
+
+(defvar tramp-rpc-mock-test-server-buffer nil
+  "Buffer for server output.")
+
+(defvar tramp-rpc-mock-test-temp-dir nil
+  "Temporary directory for tests.")
+
+(defun tramp-rpc-mock-test--find-server ()
+  "Find the RPC server executable or Python script."
+  (let* ((rust-binary (expand-file-name "target/release/tramp-rpc-server"
+                                         tramp-rpc-mock-test--project-root))
+         (rust-binary-server (expand-file-name "server/target/release/tramp-rpc-server"
+                                                tramp-rpc-mock-test--project-root))
+         ;; Cross-compiled binaries (CI uses target triple in path)
+         (rust-binary-musl (expand-file-name "target/x86_64-unknown-linux-musl/release/tramp-rpc-server"
+                                              tramp-rpc-mock-test--project-root))
+         (rust-debug (expand-file-name "target/debug/tramp-rpc-server"
+                                        tramp-rpc-mock-test--project-root))
+         (rust-debug-server (expand-file-name "server/target/debug/tramp-rpc-server"
+                                               tramp-rpc-mock-test--project-root))
+         (python-script (expand-file-name "server/tramp-rpc-server.py"
+                                          tramp-rpc-mock-test--project-root)))
+    (cond
+     ((file-executable-p rust-binary) rust-binary)
+     ((file-executable-p rust-binary-server) rust-binary-server)
+     ((file-executable-p rust-binary-musl) rust-binary-musl)
+     ((file-executable-p rust-debug) rust-debug)
+     ((file-executable-p rust-debug-server) rust-debug-server)
+     ((file-exists-p python-script) python-script)
+     (t nil))))
+
+(defun tramp-rpc-mock-test--start-server ()
+  "Start a local RPC server for testing."
+  (let ((server (tramp-rpc-mock-test--find-server)))
+    (unless server
+      (error "No RPC server found. Build with 'cargo build --release' or use Python server"))
+    (setq tramp-rpc-mock-test-temp-dir (make-temp-file "tramp-rpc-test" t))
+    (setq tramp-rpc-mock-test-server-buffer (generate-new-buffer "*tramp-rpc-test-server*"))
+    (setq tramp-rpc-mock-test-server-process
+          (let ((process-connection-type nil))  ; Use pipes
+            (if (string-suffix-p ".py" server)
+                (start-process "test-server" tramp-rpc-mock-test-server-buffer
+                               "python3" server)
+              (start-process "test-server" tramp-rpc-mock-test-server-buffer
+                             server))))
+    (set-process-query-on-exit-flag tramp-rpc-mock-test-server-process nil)
+    (set-process-coding-system tramp-rpc-mock-test-server-process 'utf-8 'utf-8)
+    ;; Wait for server to be ready
+    (sleep-for 0.1)
+    tramp-rpc-mock-test-server-process))
+
+(defun tramp-rpc-mock-test--stop-server ()
+  "Stop the local RPC server."
+  (when (and tramp-rpc-mock-test-server-process
+             (process-live-p tramp-rpc-mock-test-server-process))
+    (delete-process tramp-rpc-mock-test-server-process))
+  (when (buffer-live-p tramp-rpc-mock-test-server-buffer)
+    (kill-buffer tramp-rpc-mock-test-server-buffer))
+  (when (and tramp-rpc-mock-test-temp-dir
+             (file-directory-p tramp-rpc-mock-test-temp-dir))
+    (delete-directory tramp-rpc-mock-test-temp-dir t))
+  (setq tramp-rpc-mock-test-server-process nil
+        tramp-rpc-mock-test-server-buffer nil
+        tramp-rpc-mock-test-temp-dir nil))
+
+(defun tramp-rpc-mock-test--rpc-call (method params)
+  "Send an RPC call to the local test server."
+  (unless (and tramp-rpc-mock-test-server-process
+               (process-live-p tramp-rpc-mock-test-server-process))
+    (error "Server not running"))
+  (let* ((id-and-request (tramp-rpc-protocol-encode-request-with-id method params))
+         (request (cdr id-and-request)))
+    ;; Send request
+    (process-send-string tramp-rpc-mock-test-server-process (concat request "\n"))
+    ;; Read response
+    (with-current-buffer tramp-rpc-mock-test-server-buffer
+      (let ((timeout 5.0)
+            response-line)
+        (while (and (not response-line) (> timeout 0))
+          (accept-process-output tramp-rpc-mock-test-server-process 0.1)
+          (goto-char (point-min))
+          (when (search-forward "\n" nil t)
+            (setq response-line (buffer-substring (point-min) (1- (point))))
+            (delete-region (point-min) (point)))
+          (cl-decf timeout 0.1))
+        (when response-line
+          (let ((response (tramp-rpc-protocol-decode-response response-line)))
+            (if (tramp-rpc-protocol-error-p response)
+                (list :error (tramp-rpc-protocol-error-message response))
+              (plist-get response :result))))))))
+
+;;; Server tests (require server to be available)
+
+(ert-deftest tramp-rpc-mock-test-server-system-info ()
+  "Test system.info RPC call."
+  :tags '(:server)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((result (tramp-rpc-mock-test--rpc-call "system.info" nil)))
+          (should result)
+          (should-not (plist-get result :error))
+          ;; Check expected fields
+          (should (assoc 'uid result))
+          (should (assoc 'gid result))
+          (should (assoc 'home result))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-file-operations ()
+  "Test basic file operations via RPC."
+  :tags '(:server)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((test-file (expand-file-name "test.txt" tramp-rpc-mock-test-temp-dir)))
+          ;; File shouldn't exist yet (false becomes nil in Emacs JSON)
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.exists" `((path . ,test-file)))))
+            (should (not result)))
+
+          ;; Write a file
+          (let ((content (base64-encode-string "hello world" t)))
+            (tramp-rpc-mock-test--rpc-call
+             "file.write" `((path . ,test-file)
+                            (content . ,content)
+                            (append . :json-false))))
+
+          ;; File should exist now
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.exists" `((path . ,test-file)))))
+            (should result))
+
+          ;; Read the file
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.read" `((path . ,test-file)))))
+            (should result)
+            (let ((content (base64-decode-string (alist-get 'content result))))
+              (should (equal content "hello world"))))
+
+          ;; Get file stats
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.stat" `((path . ,test-file)))))
+            (should result)
+            (should (equal (alist-get 'type result) "file"))
+            (should (= (alist-get 'size result) 11)))  ; "hello world" = 11 bytes
+
+          ;; Delete the file
+          (tramp-rpc-mock-test--rpc-call "file.delete" `((path . ,test-file)))
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.exists" `((path . ,test-file)))))
+            (should (not result)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-directory-operations ()
+  "Test directory operations via RPC."
+  :tags '(:server)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((test-dir (expand-file-name "subdir" tramp-rpc-mock-test-temp-dir)))
+          ;; Create directory
+          (tramp-rpc-mock-test--rpc-call
+           "dir.create" `((path . ,test-dir) (parents . :json-false)))
+
+          ;; Check it exists
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.stat" `((path . ,test-dir)))))
+            (should result)
+            (should (equal (alist-get 'type result) "directory")))
+
+          ;; Create files in directory
+          (tramp-rpc-mock-test--rpc-call
+           "file.write" `((path . ,(expand-file-name "file1.txt" test-dir))
+                          (content . ,(base64-encode-string "a" t))
+                          (append . :json-false)))
+          (tramp-rpc-mock-test--rpc-call
+           "file.write" `((path . ,(expand-file-name "file2.txt" test-dir))
+                          (content . ,(base64-encode-string "b" t))
+                          (append . :json-false)))
+
+          ;; List directory
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "dir.list" `((path . ,test-dir)
+                                      (include_attrs . :json-false)
+                                      (include_hidden . t)))))
+            (should result)
+            (let ((names (mapcar (lambda (e) (alist-get 'name e)) result)))
+              (should (member "file1.txt" names))
+              (should (member "file2.txt" names))))
+
+          ;; Remove directory recursively
+          (tramp-rpc-mock-test--rpc-call
+           "dir.remove" `((path . ,test-dir) (recursive . t)))
+
+          ;; Should be gone (false becomes nil in JSON parsing)
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.exists" `((path . ,test-dir)))))
+            (should (not result)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(defun tramp-rpc-mock-test--decode-output (data encoding)
+  "Decode DATA according to ENCODING (text or base64)."
+  (cond
+   ((null data) "")
+   ((equal encoding "text") data)
+   (t (base64-decode-string data))))
+
+(ert-deftest tramp-rpc-mock-test-server-process-run ()
+  "Test process.run RPC call."
+  :tags '(:server :process)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        ;; Run a simple command
+        (let ((result (tramp-rpc-mock-test--rpc-call
+                       "process.run" `((cmd . "echo")
+                                       (args . ["hello" "world"])
+                                       (cwd . "/tmp")))))
+          (should result)
+          (should (= (alist-get 'exit_code result) 0))
+          (let ((stdout (tramp-rpc-mock-test--decode-output
+                         (alist-get 'stdout result)
+                         (alist-get 'stdout_encoding result))))
+            (should (string-match-p "hello world" stdout)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+;;; ============================================================================
+;;; Test Runner
+;;; ============================================================================
+
+;;;###autoload
+(defun tramp-rpc-mock-test-all ()
+  "Run all mock tests."
+  (interactive)
+  (ert-run-tests-batch-and-exit "^tramp-rpc-mock-test"))
+
+;;;###autoload
+(defun tramp-rpc-mock-test-protocol ()
+  "Run only protocol tests (no server needed)."
+  (interactive)
+  (ert-run-tests-interactively
+   '(and (tag tramp-rpc-mock-test) (not (tag :server)))))
+
+;;;###autoload
+(defun tramp-rpc-mock-test-server ()
+  "Run server tests."
+  (interactive)
+  (ert-run-tests-interactively '(tag :server)))
+
+(provide 'tramp-rpc-mock-tests)
+;;; tramp-rpc-mock-tests.el ends here

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1,0 +1,1003 @@
+;;; tramp-rpc-tests.el --- Tests for TRAMP RPC backend  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+
+;; Author: Arthur Heymans <arthur@aheymans.xyz>
+
+;; This file is part of tramp-rpc.
+
+;; tramp-rpc is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Comprehensive test suite for TRAMP RPC backend.
+;;
+;; These tests cover all major functionality of the RPC backend:
+;; - File operations (read, write, copy, rename, delete)
+;; - Directory operations (list, create, delete)
+;; - File attributes and metadata
+;; - Process execution
+;; - Symbolic links
+;;
+;; Test Modes:
+;; -----------
+;; 1. Mock mode (CI): Uses a local mock server for testing without SSH.
+;;    Set TRAMP_RPC_TEST_MOCK=1 environment variable.
+;;
+;; 2. Remote mode: Tests against a real remote host.
+;;    Set TRAMP_RPC_TEST_HOST to the hostname (e.g., "x220-nixos").
+;;
+;; Running Tests:
+;; --------------
+;; From command line:
+;;   emacs -Q --batch -l test/tramp-rpc-tests.el -f ert-run-tests-batch-and-exit
+;;
+;; Interactively:
+;;   M-x ert-run-tests-interactively RET tramp-rpc RET
+;;
+;; Run all tests:
+;;   M-x tramp-rpc-test-all
+;;
+;; Test Tags:
+;; ----------
+;; :expensive-test - Time-consuming tests (skipped in quick runs)
+;; :unstable       - Tests that may fail intermittently
+;; :process        - Tests requiring async process support
+
+;;; Code:
+
+(require 'ert)
+(require 'ert-x)
+(require 'cl-lib)
+(require 'tramp)
+
+;; Compute project root at load time (with fallback for eval after load)
+(defvar tramp-rpc-test--project-root
+  (expand-file-name "../" (file-name-directory
+                           (or load-file-name buffer-file-name
+                               (expand-file-name "test/tramp-rpc-tests.el"))))
+  "Project root directory.")
+
+;; Load tramp-rpc from the project
+(let ((lisp-dir (expand-file-name "lisp" tramp-rpc-test--project-root)))
+  (add-to-list 'load-path lisp-dir))
+
+(require 'tramp-rpc)
+
+;;; ============================================================================
+;;; Test Configuration
+;;; ============================================================================
+
+(defvar tramp-rpc-test-host (or (getenv "TRAMP_RPC_TEST_HOST") "localhost")
+  "Remote host for testing.
+Set via TRAMP_RPC_TEST_HOST environment variable.")
+
+(defvar tramp-rpc-test-user (getenv "TRAMP_RPC_TEST_USER")
+  "User for remote host. If nil, uses default SSH user.")
+
+(defvar tramp-rpc-test-mock-mode (getenv "TRAMP_RPC_TEST_MOCK")
+  "When non-nil, use mock mode for testing without SSH.")
+
+(defvar tramp-rpc-test-temp-dir "/tmp/tramp-rpc-test"
+  "Remote directory for test files.")
+
+(defconst tramp-rpc-test-name-prefix "tramp-rpc-test"
+  "Prefix for temporary test files.")
+
+;; Test configuration
+(setq tramp-verbose 0  ; Reduce noise during tests
+      tramp-cache-read-persistent-data nil
+      tramp-persistency-file-name nil
+      password-cache-expiry nil)
+
+;;; ============================================================================
+;;; Test Infrastructure
+;;; ============================================================================
+
+(defvar tramp-rpc-test-vec nil
+  "Current test connection vector.")
+
+(defvar tramp-rpc-test-enabled-checked nil
+  "Cached result of `tramp-rpc-test-enabled'.
+Value is a cons cell (CHECKED . RESULT).")
+
+(defun tramp-rpc-test--make-remote-path (filename)
+  "Make a full TRAMP RPC path for FILENAME."
+  (let ((user-part (if tramp-rpc-test-user
+                       (concat tramp-rpc-test-user "@")
+                     "")))
+    (format "/rpc:%s%s:%s/%s"
+            user-part
+            tramp-rpc-test-host
+            tramp-rpc-test-temp-dir
+            filename)))
+
+(defun tramp-rpc-test--make-temp-name (&optional local)
+  "Return a temporary file name for test.
+If LOCAL is non-nil, return a local temp name.
+The file is not created."
+  (let ((name (make-temp-name tramp-rpc-test-name-prefix)))
+    (if local
+        (expand-file-name name temporary-file-directory)
+      (tramp-rpc-test--make-remote-path name))))
+
+(defun tramp-rpc-test--remote-directory ()
+  "Return the remote test directory path."
+  (let ((user-part (if tramp-rpc-test-user
+                       (concat tramp-rpc-test-user "@")
+                     "")))
+    (format "/rpc:%s%s:%s" user-part tramp-rpc-test-host tramp-rpc-test-temp-dir)))
+
+(defun tramp-rpc-test-enabled ()
+  "Check if remote testing is enabled and working.
+Returns non-nil if tests can run."
+  (unless (consp tramp-rpc-test-enabled-checked)
+    (setq tramp-rpc-test-enabled-checked
+          (cons t
+                (condition-case nil
+                    (let ((dir (tramp-rpc-test--remote-directory)))
+                      (and (file-remote-p dir)
+                           (progn
+                             ;; Try to create test directory
+                             (ignore-errors (make-directory dir t))
+                             (file-directory-p dir)
+                             (file-writable-p dir))))
+                  (error nil)))))
+  (cdr tramp-rpc-test-enabled-checked))
+
+(defun tramp-rpc-test--setup ()
+  "Set up test environment."
+  (let ((dir (tramp-rpc-test--remote-directory)))
+    ;; Clean up any leftover test files
+    (ignore-errors (delete-directory dir t))
+    ;; Create fresh test directory
+    (make-directory dir t)))
+
+(defun tramp-rpc-test--cleanup ()
+  "Clean up test environment."
+  (let ((dir (tramp-rpc-test--remote-directory)))
+    (ignore-errors (delete-directory dir t))
+    (ignore-errors (tramp-cleanup-all-connections))))
+
+(defmacro tramp-rpc-test--with-temp-file (var content &rest body)
+  "Create a temporary remote file with CONTENT, bind to VAR, execute BODY.
+The file is deleted after BODY completes."
+  (declare (indent 2) (debug (symbolp form body)))
+  `(let ((,var (tramp-rpc-test--make-temp-name)))
+     (unwind-protect
+         (progn
+           (write-region ,content nil ,var)
+           ,@body)
+       (ignore-errors (delete-file ,var)))))
+
+(defmacro tramp-rpc-test--with-temp-dir (var &rest body)
+  "Create a temporary remote directory, bind to VAR, execute BODY.
+The directory is deleted after BODY completes."
+  (declare (indent 1) (debug (symbolp body)))
+  `(let ((,var (tramp-rpc-test--make-temp-name)))
+     (unwind-protect
+         (progn
+           (make-directory ,var)
+           ,@body)
+       (ignore-errors (delete-directory ,var t)))))
+
+;;; ============================================================================
+;;; Test 00: Availability
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test00-availability ()
+  "Test availability of TRAMP RPC functions."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+  (let ((dir (tramp-rpc-test--remote-directory)))
+    (should (file-remote-p dir))
+    (should (file-directory-p dir))
+    (should (file-writable-p dir))))
+
+;;; ============================================================================
+;;; Test 01: File Name Syntax
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test01-file-name-syntax ()
+  "Check TRAMP RPC file name syntax."
+  ;; Valid RPC file names
+  (should (tramp-tramp-file-p "/rpc:host:"))
+  (should (tramp-tramp-file-p "/rpc:host:/path"))
+  (should (tramp-tramp-file-p "/rpc:user@host:"))
+  (should (tramp-tramp-file-p "/rpc:user@host:/path"))
+  (should (tramp-tramp-file-p "/rpc:user@host#22:"))
+  (should (tramp-tramp-file-p "/rpc:user@host#22:/path"))
+
+  ;; Check method extraction
+  (should (equal (tramp-file-name-method
+                  (tramp-dissect-file-name "/rpc:host:/path"))
+                 "rpc"))
+  (should (equal (tramp-file-name-host
+                  (tramp-dissect-file-name "/rpc:host:/path"))
+                 "host"))
+  (should (equal (tramp-file-name-user
+                  (tramp-dissect-file-name "/rpc:user@host:/path"))
+                 "user"))
+  (should (equal (tramp-file-name-localname
+                  (tramp-dissect-file-name "/rpc:host:/path/to/file"))
+                 "/path/to/file")))
+
+;;; ============================================================================
+;;; Test 02: File Existence
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test02-file-exists-p ()
+  "Test `file-exists-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Test directory exists
+  (let ((dir (tramp-rpc-test--remote-directory)))
+    (should (file-exists-p dir)))
+
+  ;; Test file creation and existence
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (should (file-exists-p tmp)))
+
+  ;; Test non-existent file
+  (should-not (file-exists-p (tramp-rpc-test--make-remote-path "nonexistent-file-xyz"))))
+
+(ert-deftest tramp-rpc-test02-file-readable-p ()
+  "Test `file-readable-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (should (file-readable-p tmp))))
+
+(ert-deftest tramp-rpc-test02-file-writable-p ()
+  "Test `file-writable-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Existing file
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (should (file-writable-p tmp)))
+
+  ;; Non-existent file in writable directory
+  (let ((new-file (tramp-rpc-test--make-temp-name)))
+    (should (file-writable-p new-file))))
+
+;;; ============================================================================
+;;; Test 03: File Types
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test03-file-directory-p ()
+  "Test `file-directory-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Test directory
+  (should (file-directory-p (tramp-rpc-test--remote-directory)))
+
+  ;; Test file
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (should-not (file-directory-p tmp)))
+
+  ;; Test subdirectory
+  (tramp-rpc-test--with-temp-dir subdir
+    (should (file-directory-p subdir))))
+
+(ert-deftest tramp-rpc-test03-file-regular-p ()
+  "Test `file-regular-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Regular file
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (should (file-regular-p tmp)))
+
+  ;; Directory is not regular
+  (should-not (file-regular-p (tramp-rpc-test--remote-directory))))
+
+(ert-deftest tramp-rpc-test03-file-symlink-p ()
+  "Test `file-symlink-p' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file target "target content"
+    (let ((link (tramp-rpc-test--make-temp-name)))
+      (unwind-protect
+          (progn
+            ;; Create symlink
+            (condition-case nil
+                (make-symbolic-link target link)
+              (file-error (ert-skip "Symlinks not supported")))
+            ;; Test symlink detection
+            (should (file-symlink-p link))
+            ;; Original file is not a symlink
+            (should-not (file-symlink-p target)))
+        (ignore-errors (delete-file link))))))
+
+;;; ============================================================================
+;;; Test 04: File Attributes
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test04-file-attributes ()
+  "Test `file-attributes' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (let ((attrs (file-attributes tmp)))
+      (should attrs)
+      ;; Check it's a regular file
+      (should (null (file-attribute-type attrs)))
+      ;; Check size
+      (should (= (file-attribute-size attrs) (length "test content")))
+      ;; Check user ID exists
+      (should (integerp (file-attribute-user-id attrs)))
+      ;; Check group ID exists
+      (should (integerp (file-attribute-group-id attrs)))
+      ;; Check mode string
+      (should (stringp (file-attribute-modes attrs)))
+      ;; Check times
+      (should (file-attribute-modification-time attrs))
+      (should (file-attribute-access-time attrs)))))
+
+(ert-deftest tramp-rpc-test04-file-attributes-directory ()
+  "Test `file-attributes' for TRAMP RPC directories."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-dir subdir
+    (let ((attrs (file-attributes subdir)))
+      (should attrs)
+      ;; Check it's a directory
+      (should (eq (file-attribute-type attrs) t)))))
+
+(ert-deftest tramp-rpc-test04-file-modes ()
+  "Test `file-modes' and `set-file-modes' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (let ((orig-modes (file-modes tmp)))
+      (should (integerp orig-modes))
+      ;; Set new modes
+      (set-file-modes tmp #o644)
+      (should (= (logand (file-modes tmp) #o777) #o644))
+      ;; Set executable
+      (set-file-modes tmp #o755)
+      (should (= (logand (file-modes tmp) #o777) #o755)))))
+
+;;; ============================================================================
+;;; Test 05: File Content Operations
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test05-write-region ()
+  "Test `write-region' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Simple write
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content "Hello, World!"))
+    (unwind-protect
+        (progn
+          (write-region content nil file)
+          (should (file-exists-p file))
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-write-region-multiline ()
+  "Test `write-region' with multiline content."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content "Line 1\nLine 2\nLine 3\n"))
+    (unwind-protect
+        (progn
+          (write-region content nil file)
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-write-region-binary ()
+  "Test `write-region' with binary content."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content (apply #'unibyte-string (number-sequence 0 255))))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (set-buffer-multibyte nil)
+            (insert content)
+            (write-region (point-min) (point-max) file))
+          (let ((read-content (with-temp-buffer
+                                (set-buffer-multibyte nil)
+                                (insert-file-contents file)
+                                (buffer-string))))
+            (should (equal (length content) (length read-content)))
+            (should (equal content read-content))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-write-region-utf8 ()
+  "Test `write-region' with UTF-8 content."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content "Hello, World!\nBonjour le monde!\nHallo Welt!\nPrzyklad: zolw"))
+    (unwind-protect
+        (progn
+          (write-region content nil file)
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-write-region-append ()
+  "Test `write-region' with append."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content1 "First part\n")
+        (content2 "Second part\n"))
+    (unwind-protect
+        (progn
+          (write-region content1 nil file)
+          (write-region content2 nil file t)  ; append
+          (should (equal (concat content1 content2)
+                         (with-temp-buffer
+                           (insert-file-contents file)
+                           (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-write-region-large ()
+  "Test `write-region' with large file."
+  :tags '(:expensive-test)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name))
+        (content (make-string 102400 ?x)))  ; 100KB
+    (unwind-protect
+        (progn
+          (write-region content nil file)
+          (let ((attrs (file-attributes file)))
+            (should (= (file-attribute-size attrs) 102400)))
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test05-insert-file-contents ()
+  "Test `insert-file-contents' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "test content"
+    (with-temp-buffer
+      (insert-file-contents tmp)
+      (should (equal (buffer-string) "test content")))))
+
+(ert-deftest tramp-rpc-test05-insert-file-contents-partial ()
+  "Test partial `insert-file-contents' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "0123456789"
+    ;; Read bytes 2-5
+    (with-temp-buffer
+      (insert-file-contents tmp nil 2 6)
+      (should (equal (buffer-string) "2345")))))
+
+;;; ============================================================================
+;;; Test 06: File Manipulation
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test06-copy-file ()
+  "Test `copy-file' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file src "source content"
+    (let ((dest (tramp-rpc-test--make-temp-name)))
+      (unwind-protect
+          (progn
+            (copy-file src dest)
+            (should (file-exists-p dest))
+            (should (equal (with-temp-buffer
+                             (insert-file-contents src)
+                             (buffer-string))
+                           (with-temp-buffer
+                             (insert-file-contents dest)
+                             (buffer-string)))))
+        (ignore-errors (delete-file dest))))))
+
+(ert-deftest tramp-rpc-test06-rename-file ()
+  "Test `rename-file' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((src (tramp-rpc-test--make-temp-name))
+        (dest (tramp-rpc-test--make-temp-name))
+        (content "rename test content"))
+    (unwind-protect
+        (progn
+          (write-region content nil src)
+          (rename-file src dest)
+          (should-not (file-exists-p src))
+          (should (file-exists-p dest))
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents dest)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file src))
+      (ignore-errors (delete-file dest)))))
+
+(ert-deftest tramp-rpc-test06-delete-file ()
+  "Test `delete-file' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name)))
+    (write-region "to be deleted" nil file)
+    (should (file-exists-p file))
+    (delete-file file)
+    (should-not (file-exists-p file))))
+
+;;; ============================================================================
+;;; Test 07: Directory Operations
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test07-make-directory ()
+  "Test `make-directory' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((dir (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (make-directory dir)
+          (should (file-directory-p dir)))
+      (ignore-errors (delete-directory dir)))))
+
+(ert-deftest tramp-rpc-test07-make-directory-parents ()
+  "Test `make-directory' with parents for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((dir (concat (tramp-rpc-test--make-temp-name) "/nested/path")))
+    (unwind-protect
+        (progn
+          (make-directory dir t)
+          (should (file-directory-p dir)))
+      (ignore-errors (delete-directory
+                      (file-name-directory (directory-file-name dir)) t)))))
+
+(ert-deftest tramp-rpc-test07-delete-directory ()
+  "Test `delete-directory' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((dir (tramp-rpc-test--make-temp-name)))
+    (make-directory dir)
+    (should (file-directory-p dir))
+    (delete-directory dir)
+    (should-not (file-exists-p dir))))
+
+(ert-deftest tramp-rpc-test07-delete-directory-recursive ()
+  "Test recursive `delete-directory' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((dir (tramp-rpc-test--make-temp-name)))
+    (make-directory dir)
+    (write-region "file1" nil (concat dir "/file1.txt"))
+    (make-directory (concat dir "/subdir"))
+    (write-region "file2" nil (concat dir "/subdir/file2.txt"))
+    (should (file-directory-p dir))
+    (delete-directory dir t)
+    (should-not (file-exists-p dir))))
+
+(ert-deftest tramp-rpc-test07-directory-files ()
+  "Test `directory-files' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-dir dir
+    (write-region "a" nil (concat dir "/file1.txt"))
+    (write-region "b" nil (concat dir "/file2.txt"))
+    (write-region "c" nil (concat dir "/other.log"))
+
+    (let ((files (directory-files dir)))
+      ;; Should contain . and .. plus our files
+      (should (member "." files))
+      (should (member ".." files))
+      (should (member "file1.txt" files))
+      (should (member "file2.txt" files))
+      (should (member "other.log" files)))
+
+    ;; Test with pattern
+    (let ((txt-files (directory-files dir nil "\\.txt$")))
+      (should (= (length txt-files) 2))
+      (should (member "file1.txt" txt-files))
+      (should (member "file2.txt" txt-files)))))
+
+(ert-deftest tramp-rpc-test07-directory-files-and-attributes ()
+  "Test `directory-files-and-attributes' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-dir dir
+    (write-region "content" nil (concat dir "/file.txt"))
+    (make-directory (concat dir "/subdir"))
+
+    (let ((entries (directory-files-and-attributes dir)))
+      ;; Find file entry
+      (let ((file-entry (assoc "file.txt" entries)))
+        (should file-entry)
+        (should (null (file-attribute-type (cdr file-entry)))))  ; regular file
+
+      ;; Find directory entry
+      (let ((dir-entry (assoc "subdir" entries)))
+        (should dir-entry)
+        (should (eq (file-attribute-type (cdr dir-entry)) t))))))  ; directory
+
+;;; ============================================================================
+;;; Test 08: Symbolic Links
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test08-make-symbolic-link ()
+  "Test `make-symbolic-link' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file target "target content"
+    (let ((link (tramp-rpc-test--make-temp-name)))
+      (unwind-protect
+          (progn
+            (condition-case nil
+                (make-symbolic-link target link)
+              (file-error (ert-skip "Symlinks not supported")))
+            (should (file-symlink-p link))
+            (should (equal (with-temp-buffer
+                             (insert-file-contents link)
+                             (buffer-string))
+                           "target content")))
+        (ignore-errors (delete-file link))))))
+
+(ert-deftest tramp-rpc-test08-file-truename ()
+  "Test `file-truename' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file target "content"
+    (let ((link (tramp-rpc-test--make-temp-name)))
+      (unwind-protect
+          (progn
+            (condition-case nil
+                (make-symbolic-link target link)
+              (file-error (ert-skip "Symlinks not supported")))
+            ;; file-truename should resolve the symlink
+            (let ((true-name (file-truename link)))
+              (should (string-match-p (regexp-quote (file-local-name target))
+                                      (file-local-name true-name)))))
+        (ignore-errors (delete-file link))))))
+
+;;; ============================================================================
+;;; Test 09: File Times
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test09-set-file-times ()
+  "Test `set-file-times' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file tmp "content"
+    (let ((new-time (encode-time 0 0 12 1 1 2020)))
+      (set-file-times tmp new-time)
+      (let ((mtime (file-attribute-modification-time (file-attributes tmp))))
+        ;; Check the time was set (allow some tolerance)
+        (should (< (abs (- (float-time new-time) (float-time mtime))) 2))))))
+
+;;; ============================================================================
+;;; Test 10: Process Execution
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test10-process-file ()
+  "Test `process-file' for TRAMP RPC files."
+  :tags '(:process)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((default-directory (tramp-rpc-test--remote-directory)))
+    ;; Simple command
+    (should (= 0 (process-file "true")))
+    (should (= 1 (process-file "false")))
+
+    ;; Command with output
+    (with-temp-buffer
+      (process-file "echo" nil t nil "hello")
+      (should (string-match-p "hello" (buffer-string))))
+
+    ;; Command with arguments
+    (with-temp-buffer
+      (process-file "ls" nil t nil "-la")
+      (should (> (buffer-size) 0)))))
+
+(ert-deftest tramp-rpc-test10-process-file-with-stdin ()
+  "Test `process-file' with stdin input."
+  :tags '(:process)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((default-directory (tramp-rpc-test--remote-directory)))
+    ;; Create a file with input
+    (tramp-rpc-test--with-temp-file input-file "hello world"
+      (with-temp-buffer
+        (let ((local-input (tramp-rpc-test--make-temp-name t)))
+          (unwind-protect
+              (progn
+                ;; Copy remote file to local for stdin
+                (copy-file input-file local-input t)
+                (process-file "cat" local-input t nil)
+                (should (string-match-p "hello world" (buffer-string))))
+            (ignore-errors (delete-file local-input))))))))
+
+(ert-deftest tramp-rpc-test10-shell-command ()
+  "Test shell command execution."
+  :tags '(:process)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((default-directory (tramp-rpc-test--remote-directory)))
+    (with-temp-buffer
+      (shell-command "echo 'test output'" (current-buffer))
+      (should (string-match-p "test output" (buffer-string))))))
+
+;;; ============================================================================
+;;; Test 11: Expand File Name
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test11-expand-file-name ()
+  "Test `expand-file-name' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((dir (tramp-rpc-test--remote-directory)))
+    ;; Absolute local path stays local - this is standard Emacs behavior.
+    ;; The handler is not called for absolute paths.
+    (should (equal (expand-file-name "/absolute/path" dir) "/absolute/path"))
+
+    ;; Relative path is resolved against remote directory
+    (let ((expanded (expand-file-name "relative" dir)))
+      (should (string-match-p "relative" expanded))
+      (should (tramp-tramp-file-p expanded)))
+
+    ;; . and .. resolution
+    (let ((expanded (expand-file-name "./file" dir)))
+      (should (string-match-p "file" expanded))
+      (should (tramp-tramp-file-p expanded)))
+
+    (let ((expanded (expand-file-name "a/../b" dir)))
+      (should (string-match-p "/b" expanded))
+      (should-not (string-match-p "/a/" expanded))
+      (should (tramp-tramp-file-p expanded)))))
+
+;;; ============================================================================
+;;; Test 12: File Name Completion
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test12-file-name-completion ()
+  "Test file name completion for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-dir dir
+    (write-region "" nil (concat dir "/file-aaa.txt"))
+    (write-region "" nil (concat dir "/file-aab.txt"))
+    (write-region "" nil (concat dir "/other.txt"))
+
+    (let ((completions (file-name-all-completions "file-" dir)))
+      (should (member "file-aaa.txt" completions))
+      (should (member "file-aab.txt" completions))
+      (should-not (member "other.txt" completions)))))
+
+;;; ============================================================================
+;;; Test 13: File System Info
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test13-file-system-info ()
+  "Test `file-system-info' for TRAMP RPC files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((info (file-system-info (tramp-rpc-test--remote-directory))))
+    (when info  ; May not be supported on all systems
+      (should (= (length info) 3))
+      (should (integerp (nth 0 info)))  ; total
+      (should (integerp (nth 1 info)))  ; free
+      (should (integerp (nth 2 info)))  ; available
+      (should (>= (nth 0 info) (nth 1 info)))
+      (should (>= (nth 1 info) 0)))))
+
+;;; ============================================================================
+;;; Test 14: Async Processes
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test14-start-file-process ()
+  "Test `start-file-process' for TRAMP RPC files."
+  :tags '(:process :expensive-test)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (output "")
+         (proc (start-file-process "test-proc" nil "echo" "async-test")))
+    (unwind-protect
+        (progn
+          (set-process-filter
+           proc (lambda (_proc str) (setq output (concat output str))))
+          ;; Wait for process to complete
+          (with-timeout (10 (error "Process timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          (should (string-match-p "async-test" output)))
+      (ignore-errors (delete-process proc)))))
+
+(ert-deftest tramp-rpc-test14-make-process ()
+  "Test `make-process' for TRAMP RPC files."
+  :tags '(:process :expensive-test)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (output "")
+         (proc (make-process
+                :name "test-make-proc"
+                :command '("cat")
+                :filter (lambda (_proc str) (setq output (concat output str))))))
+    (unwind-protect
+        (progn
+          ;; Send input
+          (process-send-string proc "test-input\n")
+          (process-send-eof proc)
+          ;; Wait for output
+          (with-timeout (10 (error "Process timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          (should (string-match-p "test-input" output)))
+      (ignore-errors (delete-process proc)))))
+
+;;; ============================================================================
+;;; Test 15: Copy/Rename Between Local and Remote
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test15-copy-local-to-remote ()
+  "Test copying from local to remote."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((local-file (make-temp-file "local-test"))
+        (remote-file (tramp-rpc-test--make-temp-name))
+        (content "local to remote content"))
+    (unwind-protect
+        (progn
+          (write-region content nil local-file)
+          (copy-file local-file remote-file)
+          (should (file-exists-p remote-file))
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents remote-file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file local-file))
+      (ignore-errors (delete-file remote-file)))))
+
+(ert-deftest tramp-rpc-test15-copy-remote-to-local ()
+  "Test copying from remote to local."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((local-file (make-temp-file "local-test"))
+        (content "remote to local content"))
+    (unwind-protect
+        (tramp-rpc-test--with-temp-file remote-file content
+          (copy-file remote-file local-file t)
+          (should (equal content (with-temp-buffer
+                                   (insert-file-contents local-file)
+                                   (buffer-string)))))
+      (ignore-errors (delete-file local-file)))))
+
+;;; ============================================================================
+;;; Test 16: VC Integration
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test16-vc-registered ()
+  "Test VC registration detection."
+  :tags '(:expensive-test)
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  ;; Create a git repo in temp dir
+  (tramp-rpc-test--with-temp-dir dir
+    (let ((default-directory dir))
+      ;; Initialize git repo
+      (when (= 0 (process-file "git" nil nil nil "init"))
+        (write-region "test" nil (concat dir "/test.txt"))
+        (process-file "git" nil nil nil "add" "test.txt")
+        ;; Check if VC detects it
+        (should (vc-registered (concat dir "/test.txt")))))))
+
+;;; ============================================================================
+;;; Test 17: Overwrite Handling
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test17-write-region-overwrite ()
+  "Test overwriting existing file."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (write-region "original" nil file)
+          (should (equal "original" (with-temp-buffer
+                                      (insert-file-contents file)
+                                      (buffer-string))))
+          (write-region "updated" nil file)
+          (should (equal "updated" (with-temp-buffer
+                                     (insert-file-contents file)
+                                     (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+;;; ============================================================================
+;;; Test 18: Empty File Handling
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test18-empty-file ()
+  "Test handling of empty files."
+  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let ((file (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (write-region "" nil file)
+          (should (file-exists-p file))
+          (should (= 0 (file-attribute-size (file-attributes file))))
+          (should (equal "" (with-temp-buffer
+                              (insert-file-contents file)
+                              (buffer-string)))))
+      (ignore-errors (delete-file file)))))
+
+;;; ============================================================================
+;;; Test Runner
+;;; ============================================================================
+
+;;;###autoload
+(defun tramp-rpc-test-all ()
+  "Run all TRAMP RPC tests."
+  (interactive)
+  (tramp-rpc-test--setup)
+  (unwind-protect
+      (ert-run-tests-interactively "^tramp-rpc-test")
+    (tramp-rpc-test--cleanup)))
+
+;;;###autoload
+(defun tramp-rpc-test-quick ()
+  "Run quick TRAMP RPC tests (skip expensive ones)."
+  (interactive)
+  (tramp-rpc-test--setup)
+  (unwind-protect
+      (ert-run-tests-interactively
+       '(and (tag tramp-rpc-test) (not (tag :expensive-test))))
+    (tramp-rpc-test--cleanup)))
+
+(provide 'tramp-rpc-tests)
+;;; tramp-rpc-tests.el ends here


### PR DESCRIPTION
This adds an extensive test suite for tramp-rpc based on the original
TRAMP test suite patterns:

Test files:
- test/tramp-rpc-tests.el: Full ERT test suite (44 tests) for remote
  file operations including read/write, copy/rename, directories,
  symlinks, process execution, etc.

- test/tramp-rpc-mock-tests.el: CI-compatible mock tests (12 tests)
  that can run without SSH access, including:
  - Protocol tests for JSON-RPC encoding/decoding
  - Server integration tests via local pipe connection

- test/run-tests.sh: Test runner script with options for --mock,
  --protocol, --server, and --remote test modes

CI workflow updates:
- Protocol Tests: JSON-RPC encoding/decoding (no server needed)
- Server Integration Tests: Direct communication with RPC server
- Full Test Suite: Complete tests via SSH to localhost (main only)

Bug fix included:
- Fixed tramp-rpc-handle-copy-file for cross-host copies (local<->remote)
  Previously used tramp-run-real-handler which inhibited our handler.
  Now manually handles the copy with proper read/write operations.

All 44 remote tests and 12 mock tests pass.