### PR TITLE
Switch from JSON-RPC to MessagePack-RPC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build
         run: |
           nix develop --command bash -c '
-          RUSTFLAGS="-C target-feature=+crt-static -Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort" \
+          RUSTFLAGS="-D warnings -C target-feature=+crt-static -Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort" \
           cargo build --release --target ${{ inputs.target }} \
             --manifest-path server/Cargo.toml \
             -Z build-std=std,panic_abort \
@@ -74,6 +74,8 @@ jobs:
       - name: Test
         if: inputs.test
         run: nix develop --command cargo test --manifest-path server/Cargo.toml
+        env:
+          RUSTFLAGS: "-D warnings"
 
       - name: Upload binary for CI
         if: ${{ !inputs.upload }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,21 @@ jobs:
         with:
           version: ${{ matrix.emacs_version }}
 
+      - name: Install dependencies
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'msgpack)"
+
       - name: Byte-compile
         run: |
           emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
             --eval "(setq byte-compile-error-on-warn t)" \
             --eval "(push \"$(pwd)/lisp\" load-path)" \
             -f batch-byte-compile lisp/*.el
@@ -93,9 +105,21 @@ jobs:
         with:
           version: '30.1'
 
+      - name: Install dependencies
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'msgpack)"
+
       - name: Run protocol tests
         run: |
           emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             -l test/tramp-rpc-mock-tests.el \
             --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-protocol\")"
@@ -123,9 +147,21 @@ jobs:
       - name: Make server executable
         run: chmod +x target/x86_64-unknown-linux-musl/release/tramp-rpc-server
 
+      - name: Install dependencies
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'msgpack)"
+
       - name: Run server integration tests
         run: |
           emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             -l test/tramp-rpc-mock-tests.el \
             --eval "(ert-run-tests-batch-and-exit '(tag :server))"
@@ -180,11 +216,23 @@ jobs:
           mkdir -p ~/.cache/tramp-rpc
           cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/tramp-rpc-server-${VERSION}
 
+      - name: Install dependencies
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'msgpack)"
+
       - name: Run full test suite
         env:
           TRAMP_RPC_TEST_HOST: localhost
         run: |
           emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             --eval "(setq tramp-verbose 0)" \
             -l test/tramp-rpc-tests.el \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "base64"
-version = "0.22.1"
+name = "autocfg"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -132,12 +132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +206,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +243,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -230,19 +273,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -333,12 +363,13 @@ dependencies = [
 name = "tramp-rpc-server"
 version = "0.2.0"
 dependencies = [
- "base64",
  "futures",
  "libc",
  "nix",
+ "rmp-serde",
+ "rmpv",
  "serde",
- "serde_json",
+ "serde_bytes",
  "thiserror",
  "tokio",
 ]
@@ -443,9 +474,3 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "zmij"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ authors = ["Arthur Heymans <arthur@aheymans.xyz>"]
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-base64 = "0.22"
+rmp-serde = "1.3"
+rmpv = { version = "1.3", features = ["with-serde"] }
+serde_bytes = "0.11"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "process", "sync", "time", "net"] }
 futures = "0.3"

--- a/README.org
+++ b/README.org
@@ -8,13 +8,13 @@ A high-performance TRAMP backend for Emacs that uses a binary RPC server instead
 
 Traditional TRAMP works by piping shell commands over SSH and parsing their output. This approach is robust but slow, especially for operations that require many round-trips (like directory listings or VC operations).
 
-TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote host. Emacs communicates with it using JSON-RPC 2.0 over SSH, resulting in significantly faster file operations.
+TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote host. Emacs communicates with it using MessagePack-RPC over SSH, resulting in significantly faster file operations.
 
 ** Why TRAMP-RPC?
 
 | Aspect           | Original TRAMP           | TRAMP-RPC                |
 |------------------+--------------------------+--------------------------|
-| Communication    | Shell commands + parsing | JSON-RPC protocol        |
+| Communication    | Shell commands + parsing | MessagePack-RPC protocol |
 | Latency          | Multiple round-trips     | Single round-trip        |
 | Batching         | Not supported            | Multiple ops per request |
 | Shell dependency | Required on remote       | Not needed               |
@@ -33,6 +33,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 * Requirements
 
 - Emacs 30.1 or later
+- =msgpack.el= package (installed automatically from MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)
 
@@ -84,10 +85,10 @@ The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cach
 * Architecture
 
 #+begin_example
-┌─────────────┐     SSH/JSON-RPC     ┌──────────────────┐
-│   Emacs     │ ◄──────────────────► │ tramp-rpc-server │
-│ (tramp-rpc) │                      │     (Rust)       │
-└─────────────┘                      └──────────────────┘
+┌─────────────┐   SSH/MessagePack-RPC  ┌──────────────────┐
+│   Emacs     │ ◄────────────────────► │ tramp-rpc-server │
+│ (tramp-rpc) │                        │     (Rust)       │
+└─────────────┘                        └──────────────────┘
 #+end_example
 
 The server exposes RPC methods for:
@@ -250,17 +251,63 @@ If GitHub downloads fail (corporate firewall, etc.), you can:
 
 * Protocol
 
-TRAMP-RPC uses JSON-RPC 2.0 over stdin/stdout.
+TRAMP-RPC uses MessagePack-RPC over stdin/stdout with length-prefixed binary framing.
 
-Example request:
-#+begin_src json
-{"jsonrpc":"2.0","id":1,"method":"file.stat","params":{"path":"/etc/passwd"}}
+** Protocol History
+
+TRAMP-RPC originally used JSON-RPC with newline-delimited messages. This was changed to MessagePack-RPC for several reasons:
+
+| Aspect              | JSON-RPC (old)              | MessagePack-RPC (current)     |
+|---------------------+-----------------------------+-------------------------------|
+| Binary data         | Base64 encoded (~33% overhead) | Native binary type (no overhead) |
+| Message framing     | Newline-delimited           | Length-prefixed binary        |
+| Non-UTF8 filenames  | Required escaping/encoding  | Native binary support         |
+| Boolean false       | JSON ~false~                | MessagePack false (0xc2)      |
+| Message size        | Larger (text format)        | ~33% smaller (binary format)  |
+
+The switch eliminates encoding overhead for file transfers and fixes edge cases with non-UTF8 filenames that are valid on Unix filesystems.
+
+** Why MessagePack?
+
+MessagePack is a binary serialization format that provides:
+- Native binary data support (no base64 encoding needed for file content)
+- ~33% smaller messages compared to JSON
+- Faster serialization/deserialization
+- Proper distinction between null and false values
+
+** Framing
+
+Each message is prefixed with a 4-byte big-endian length:
+
+#+begin_example
+<4-byte length><MessagePack payload>
+#+end_example
+
+** Message Format
+
+Request (conceptual structure):
+#+begin_src elisp
+((version . "2.0")
+ (id . 1)
+ (method . "file.stat")
+ (params . ((path . "/etc/passwd"))))
 #+end_src
 
-Example response:
-#+begin_src json
-{"jsonrpc":"2.0","id":1,"result":{"type":"file","size":2847,"mode":420}}
+Response (conceptual structure):
+#+begin_src elisp
+((version . "2.0")
+ (id . 1)
+ (result . ((type . "file")
+            (size . 2847)
+            (mode . 420))))
 #+end_src
+
+** Binary Data
+
+File content, paths, and process I/O are transmitted as raw binary (MessagePack bin type), eliminating encoding overhead and ensuring correct handling of:
+- Non-UTF8 filenames
+- Binary file content
+- Arbitrary byte sequences in process output
 
 * Performance
 
@@ -339,7 +386,7 @@ emacs -Q --batch \
 
 The GitHub Actions workflow runs:
 
-1. *Protocol Tests* - JSON-RPC encoding/decoding (no server)
+1. *Protocol Tests* - MessagePack-RPC encoding/decoding (no server)
 2. *Server Integration Tests* - Direct server communication (Rust binary)
 3. *Full Test Suite* - (main branch only) Complete tests via SSH to localhost
 

--- a/benchmark/benchmark.el
+++ b/benchmark/benchmark.el
@@ -238,7 +238,7 @@ Simulates what magit does: multiple different git commands in one batch."
            ("file.stat" . ((path . ,localname)))
            ("file.readable" . ((path . ,localname)))
            ("file.writable" . ((path . ,localname)))
-           ("dir.list" . ((path . ,localname) (include_attrs . :json-false)))))))))
+           ("dir.list" . ((path . ,localname) (include_attrs . :msgpack-false)))))))))
 
 (defun tramp-rpc-benchmark--sequential-mixed-ops (method)
   "Benchmark sequential mixed operations for METHOD.

--- a/doc/TECHNICAL_COMPARISON.org
+++ b/doc/TECHNICAL_COMPARISON.org
@@ -5,7 +5,7 @@
 
 * Executive Summary
 
-TRAMP-RPC is a high-performance alternative TRAMP backend that replaces shell command parsing with a binary JSON-RPC server. This document provides an in-depth technical comparison between TRAMP-RPC and the original TRAMP implementation (tramp-sh).
+TRAMP-RPC is a high-performance alternative TRAMP backend that replaces shell command parsing with a binary MessagePack-RPC server. This document provides an in-depth technical comparison between TRAMP-RPC and the original TRAMP implementation (tramp-sh).
 
 Key findings:
 - *2-14x faster* for most file operations
@@ -71,8 +71,8 @@ TRAMP-RPC uses a binary RPC server architecture:
 │   Emacs     │      │              Remote Host                      │
 │ (tramp-rpc) │◄────►│  tramp-rpc-server (Rust binary)               │
 │             │      │       │                                       │
-│  JSON-RPC   │      │       ├─► Native syscalls (stat, read, ...)   │
-│  Protocol   │      │       └─► Process spawning (tokio)            │
+│ MessagePack │      │       ├─► Native syscalls (stat, read, ...)   │
+│ RPC Protocol│      │       └─► Process spawning (tokio)            │
 └─────────────┘      └───────────────────────────────────────────────┘
 #+end_example
 
@@ -81,18 +81,18 @@ TRAMP-RPC uses a binary RPC server architecture:
 1. *Binary Deployment*: On first connection, deploys a pre-compiled binary
 2. *Single Process*: The server handles all operations via RPC
 3. *Native Operations*: Uses direct syscalls instead of shell commands
-4. *Structured Data*: Returns JSON responses, no parsing needed
+4. *Structured Data*: Returns MessagePack responses, no parsing needed
 
-For example, to get file attributes, TRAMP-RPC sends:
+For example, to get file attributes, TRAMP-RPC sends (MessagePack-encoded):
 
-#+begin_src json
-{"jsonrpc":"2.0","id":1,"method":"file.stat","params":{"path":"/path/to/file"}}
+#+begin_src elisp
+((version . "2.0") (id . 1) (method . "file.stat") (params . ((path . "/path/to/file"))))
 #+end_src
 
-And receives:
+And receives (MessagePack-encoded):
 
-#+begin_src json
-{"jsonrpc":"2.0","id":1,"result":{"type":"file","size":1234,"mode":420,...}}
+#+begin_src elisp
+((version . "2.0") (id . 1) (result . ((type . "file") (size . 1234) (mode . 420) ...)))
 #+end_src
 
 *** TRAMP-RPC Source Structure
@@ -100,7 +100,7 @@ And receives:
 | Component                  | Lines  | Purpose                            |
 |----------------------------+--------+------------------------------------|
 | lisp/tramp-rpc.el          | ~2200  | Main Emacs integration             |
-| lisp/tramp-rpc-protocol.el | ~125   | JSON-RPC protocol handling         |
+| lisp/tramp-rpc-protocol.el | ~125   | MessagePack-RPC protocol handling  |
 | lisp/tramp-rpc-deploy.el   | ~260   | Binary deployment                  |
 | server/src/main.rs         | ~100   | Server entry point (Rust)          |
 | server/src/handlers/       | ~1200  | RPC method implementations         |
@@ -133,18 +133,18 @@ Challenges:
 
 ** TRAMP-RPC Protocol
 
-TRAMP-RPC uses JSON-RPC 2.0 over stdin/stdout:
+TRAMP-RPC uses MessagePack-RPC over stdin/stdout with length-prefixed binary framing:
 
 #+begin_src
 Emacs → SSH → tramp-rpc-server stdin
-Request: {"jsonrpc":"2.0","id":1,"method":"file.exists","params":{"path":"/path"}}
-Response: {"jsonrpc":"2.0","id":1,"result":true}
+Request: <length-prefix><msgpack: {version:"2.0",id:1,method:"file.exists",params:{path:"/path"}}>
+Response: <length-prefix><msgpack: {version:"2.0",id:1,result:true}>
 #+end_src
 
 Advantages:
-- Deterministic protocol
+- Deterministic binary protocol
 - No shell quoting issues
-- Strongly typed parameters and responses
+- Native binary data support (no base64 overhead)
 - Support for concurrent/pipelined requests
 
 *** RPC Methods
@@ -254,7 +254,7 @@ Tests performed on WiFi network between two Linux hosts (x220-nixos target).
 
 1. *Reduced Protocol Overhead*
    - Original: prompt wait → send command → wait for output → parse
-   - RPC: send JSON → receive JSON (single round-trip)
+   - RPC: send request → receive response (single round-trip)
 
 2. *Native Syscalls*
    - Original: ~stat --format='...' file~ → parse text
@@ -262,7 +262,7 @@ Tests performed on WiFi network between two Linux hosts (x220-nixos target).
 
 3. *No Shell Quoting*
    - Original: Must escape paths with special characters
-   - RPC: Paths are JSON strings, no escaping needed
+   - RPC: Paths are binary data, no escaping needed
 
 4. *Batch Operations*
    - Original: N operations = N round-trips

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true
-base64.workspace = true
+rmp-serde.workspace = true
+rmpv.workspace = true
+serde_bytes.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 futures.workspace = true

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -1,12 +1,13 @@
 //! Process execution operations
 
-use crate::protocol::{OutputEncoding, ProcessResult, RpcError};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use crate::msgpack_map;
+use crate::protocol::{from_value, ProcessResult, RpcError};
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::{openpty, OpenptyResult};
 use nix::sys::signal::Signal;
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
 use nix::unistd::{close, dup2, execvp, fork, setsid, tcgetpgrp, ForkResult, Pid};
+use rmpv::Value;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::ffi::CString;
@@ -17,23 +18,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-type HandlerResult = Result<serde_json::Value, RpcError>;
-
-/// Encode bytes smartly: use raw text if valid UTF-8, otherwise base64.
-/// Returns (encoded_string, encoding_type).
-fn smart_encode(data: &[u8]) -> (String, OutputEncoding) {
-    // Try to interpret as UTF-8
-    match std::str::from_utf8(data) {
-        Ok(text) => {
-            // Valid UTF-8 - use raw text (serde_json will escape as needed)
-            (text.to_string(), OutputEncoding::Text)
-        }
-        Err(_) => {
-            // Not valid UTF-8 - use base64
-            (BASE64.encode(data), OutputEncoding::Base64)
-        }
-    }
-}
+use super::HandlerResult;
 
 // ============================================================================
 // Process management for async processes
@@ -67,7 +52,7 @@ struct ManagedProcess {
 // ============================================================================
 
 /// Run a command and wait for it to complete
-pub async fn run(params: &serde_json::Value) -> HandlerResult {
+pub async fn run(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         /// Command to run
@@ -81,16 +66,16 @@ pub async fn run(params: &serde_json::Value) -> HandlerResult {
         /// Environment variables to set
         #[serde(default)]
         env: Option<HashMap<String, String>>,
-        /// Base64-encoded stdin input
-        #[serde(default)]
-        stdin: Option<String>,
+        /// Stdin input as binary
+        #[serde(default, with = "serde_bytes")]
+        stdin: Option<Vec<u8>>,
         /// Clear environment before setting env vars
         #[serde(default)]
         clear_env: bool,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut cmd = Command::new(&params.cmd);
     cmd.args(&params.args);
@@ -123,14 +108,10 @@ pub async fn run(params: &serde_json::Value) -> HandlerResult {
         data: None,
     })?;
 
-    // Write stdin if provided
+    // Write stdin if provided (no base64 decoding needed!)
     if let Some(stdin_data) = params.stdin {
-        let decoded = BASE64
-            .decode(&stdin_data)
-            .map_err(|e| RpcError::invalid_params(format!("Invalid base64 stdin: {}", e)))?;
-
         if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(&decoded).await;
+            let _ = stdin.write_all(&stdin_data).await;
         }
     }
 
@@ -141,19 +122,14 @@ pub async fn run(params: &serde_json::Value) -> HandlerResult {
         data: None,
     })?;
 
-    // Smart encode: use text if valid UTF-8, base64 otherwise
-    let (stdout, stdout_encoding) = smart_encode(&output.stdout);
-    let (stderr, stderr_encoding) = smart_encode(&output.stderr);
-
+    // Return binary data directly (no encoding needed!)
     let result = ProcessResult {
         exit_code: output.status.code().unwrap_or(-1),
-        stdout,
-        stderr,
-        stdout_encoding,
-        stderr_encoding,
+        stdout: output.stdout,
+        stderr: output.stderr,
     };
 
-    Ok(serde_json::to_value(result).unwrap())
+    Ok(result.to_value())
 }
 
 // ============================================================================
@@ -161,7 +137,7 @@ pub async fn run(params: &serde_json::Value) -> HandlerResult {
 // ============================================================================
 
 /// Start an async process
-pub async fn start(params: &serde_json::Value) -> HandlerResult {
+pub async fn start(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         cmd: String,
@@ -175,8 +151,8 @@ pub async fn start(params: &serde_json::Value) -> HandlerResult {
         clear_env: bool,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut cmd = Command::new(&params.cmd);
     cmd.args(&params.args);
@@ -214,26 +190,26 @@ pub async fn start(params: &serde_json::Value) -> HandlerResult {
 
     get_process_map().lock().await.insert(pid, managed);
 
-    Ok(serde_json::json!({
-        "pid": pid
-    }))
+    Ok(msgpack_map! {
+        "pid" => pid
+    })
 }
 
 /// Write to an async process's stdin
-pub async fn write(params: &serde_json::Value) -> HandlerResult {
+pub async fn write(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
-        /// Base64-encoded data to write
-        data: String,
+        /// Binary data to write
+        #[serde(with = "serde_bytes")]
+        data: Vec<u8>,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let decoded = BASE64
-        .decode(&params.data)
-        .map_err(|e| RpcError::invalid_params(format!("Invalid base64: {}", e)))?;
+    // Data is already binary, no decoding needed!
+    let data = params.data;
 
     let mut processes = get_process_map().lock().await;
     let managed = processes.get_mut(&params.pid).ok_or_else(|| RpcError {
@@ -243,20 +219,20 @@ pub async fn write(params: &serde_json::Value) -> HandlerResult {
     })?;
 
     if let Some(stdin) = managed.child.stdin.as_mut() {
-        stdin.write_all(&decoded).await.map_err(|e| RpcError {
+        stdin.write_all(&data).await.map_err(|e| RpcError {
             code: RpcError::PROCESS_ERROR,
             message: format!("Failed to write to stdin: {}", e),
             data: None,
         })?;
     }
 
-    Ok(serde_json::json!({
-        "written": decoded.len()
-    }))
+    Ok(msgpack_map! {
+        "written" => data.len()
+    })
 }
 
 /// Read from an async process's stdout/stderr
-pub async fn read(params: &serde_json::Value) -> HandlerResult {
+pub async fn read(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
@@ -272,8 +248,8 @@ pub async fn read(params: &serde_json::Value) -> HandlerResult {
         65536
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let timeout = params.timeout_ms.unwrap_or(0);
 
@@ -301,34 +277,28 @@ pub async fn read(params: &serde_json::Value) -> HandlerResult {
     // Check if process has exited
     let exit_status = managed.child.try_wait().ok().flatten();
 
-    // Smart encode stdout and stderr
-    let (stdout_val, stdout_enc) = if stdout_data.is_empty() {
-        (serde_json::Value::Null, None)
+    // Return binary data directly (no encoding!)
+    let stdout_val = if stdout_data.is_empty() {
+        Value::Nil
     } else {
-        let (s, enc) = smart_encode(&stdout_data);
-        (serde_json::Value::String(s), Some(enc))
+        Value::Binary(stdout_data)
     };
 
-    let (stderr_val, stderr_enc) = if stderr_data.is_empty() {
-        (serde_json::Value::Null, None)
+    let stderr_val = if stderr_data.is_empty() {
+        Value::Nil
     } else {
-        let (s, enc) = smart_encode(&stderr_data);
-        (serde_json::Value::String(s), Some(enc))
+        Value::Binary(stderr_data)
     };
 
-    Ok(serde_json::json!({
-        "stdout": stdout_val,
-        "stderr": stderr_val,
-        "stdout_encoding": stdout_enc,
-        "stderr_encoding": stderr_enc,
-        "exited": exit_status.is_some(),
-        "exit_code": exit_status.and_then(|s| s.code())
-    }))
+    Ok(msgpack_map! {
+        "stdout" => stdout_val,
+        "stderr" => stderr_val,
+        "exited" => exit_status.is_some(),
+        "exit_code" => exit_status.and_then(|s| s.code()).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+    })
 }
 
 /// Try to read from an async reader with configurable timeout
-/// If timeout_ms is 0, returns immediately (non-blocking).
-/// Otherwise blocks for up to timeout_ms milliseconds waiting for data.
 async fn try_read_async_with_timeout<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut R,
     max_bytes: usize,
@@ -355,14 +325,14 @@ async fn try_read_async_with_timeout<R: tokio::io::AsyncRead + Unpin>(
 }
 
 /// Close the stdin of an async process (signals EOF)
-pub async fn close_stdin(params: &serde_json::Value) -> HandlerResult {
+pub async fn close_stdin(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut processes = get_process_map().lock().await;
     let managed = processes.get_mut(&params.pid).ok_or_else(|| RpcError {
@@ -374,11 +344,11 @@ pub async fn close_stdin(params: &serde_json::Value) -> HandlerResult {
     // Drop stdin to close it
     managed.child.stdin.take();
 
-    Ok(serde_json::json!(true))
+    Ok(Value::Boolean(true))
 }
 
 /// Kill an async process
-pub async fn kill(params: &serde_json::Value) -> HandlerResult {
+pub async fn kill(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
@@ -391,8 +361,8 @@ pub async fn kill(params: &serde_json::Value) -> HandlerResult {
         libc::SIGTERM
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut processes = get_process_map().lock().await;
     let managed = processes.get_mut(&params.pid).ok_or_else(|| RpcError {
@@ -424,28 +394,28 @@ pub async fn kill(params: &serde_json::Value) -> HandlerResult {
         processes.remove(&params.pid);
     }
 
-    Ok(serde_json::json!(true))
+    Ok(Value::Boolean(true))
 }
 
 /// List all managed async processes
-pub async fn list(_params: &serde_json::Value) -> HandlerResult {
+pub async fn list(_params: &Value) -> HandlerResult {
     let mut processes = get_process_map().lock().await;
 
-    let list: Vec<serde_json::Value> = processes
+    let list: Vec<Value> = processes
         .iter_mut()
         .map(|(pid, managed)| {
             let exited = managed.child.try_wait().ok().flatten();
-            serde_json::json!({
-                "pid": pid,
-                "os_pid": managed.child.id(),
-                "cmd": managed.cmd,
-                "exited": exited.is_some(),
-                "exit_code": exited.and_then(|s| s.code())
-            })
+            msgpack_map! {
+                "pid" => *pid,
+                "os_pid" => managed.child.id().map(|id| Value::Integer((id as i64).into())).unwrap_or(Value::Nil),
+                "cmd" => managed.cmd.clone(),
+                "exited" => exited.is_some(),
+                "exit_code" => exited.and_then(|s| s.code()).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+            }
         })
         .collect();
 
-    Ok(serde_json::to_value(list).unwrap())
+    Ok(Value::Array(list))
 }
 
 // ============================================================================
@@ -464,7 +434,7 @@ fn get_pty_process_map() -> &'static Mutex<HashMap<u32, ManagedPtyProcess>> {
 }
 
 async fn get_next_pty_pid() -> u32 {
-    let counter = PTY_PID_COUNTER.get_or_init(|| Mutex::new(10000)); // Start at 10000 to distinguish from regular PIDs
+    let counter = PTY_PID_COUNTER.get_or_init(|| Mutex::new(10000));
     let mut pid = counter.lock().await;
     let current = *pid;
     *pid += 1;
@@ -472,17 +442,12 @@ async fn get_next_pty_pid() -> u32 {
 }
 
 struct ManagedPtyProcess {
-    /// The master file descriptor for the PTY (wrapped for async I/O)
     async_fd: AsyncFd<OwnedFd>,
-    /// The child process PID
     child_pid: Pid,
-    /// Command that was run
     cmd: String,
-    /// Cached exit status (if process has exited)
     exit_status: Option<i32>,
 }
 
-/// Set a file descriptor to non-blocking mode using nix
 fn set_fd_nonblocking(fd: RawFd) -> Result<(), nix::Error> {
     let flags = fcntl(fd, FcntlArg::F_GETFL)?;
     let new_flags = OFlag::from_bits_truncate(flags) | OFlag::O_NONBLOCK;
@@ -490,7 +455,6 @@ fn set_fd_nonblocking(fd: RawFd) -> Result<(), nix::Error> {
     Ok(())
 }
 
-/// Set terminal window size
 fn set_window_size(fd: RawFd, rows: u16, cols: u16) -> Result<(), std::io::Error> {
     let ws = libc::winsize {
         ws_row: rows,
@@ -506,7 +470,6 @@ fn set_window_size(fd: RawFd, rows: u16, cols: u16) -> Result<(), std::io::Error
     }
 }
 
-/// Parameters for starting a PTY process (used across thread boundary)
 #[derive(Clone)]
 struct PtyStartParams {
     cmd: String,
@@ -518,23 +481,19 @@ struct PtyStartParams {
     cols: u16,
 }
 
-/// Result of fork operation
 struct ForkResult2 {
     master_fd: RawFd,
     child_pid: Pid,
     tty_name: String,
 }
 
-/// Perform the fork/exec in a blocking context
 fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
-    // Open a PTY pair
     let OpenptyResult { master, slave } = openpty(None, None).map_err(|e| RpcError {
         code: RpcError::PROCESS_ERROR,
         message: format!("Failed to open PTY: {}", e),
         data: None,
     })?;
 
-    // Get the tty name from the slave fd before forking
     let tty_name = {
         let mut buf = vec![0u8; 256];
         let ret = unsafe {
@@ -558,14 +517,12 @@ fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
         String::from_utf8_lossy(&buf[..nul_pos]).into_owned()
     };
 
-    // Set initial window size
     set_window_size(master.as_raw_fd(), params.rows, params.cols).map_err(|e| RpcError {
         code: RpcError::PROCESS_ERROR,
         message: format!("Failed to set window size: {}", e),
         data: None,
     })?;
 
-    // Prepare command and args for execvp
     let cmd_cstring = CString::new(params.cmd.clone()).map_err(|e| RpcError {
         code: RpcError::INVALID_PARAMS,
         message: format!("Invalid command: {}", e),
@@ -581,37 +538,22 @@ fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
         })?);
     }
 
-    // Fork
     match unsafe { fork() } {
         Ok(ForkResult::Child) => {
-            // Child process
-            // Close master side
             let _ = close(master.as_raw_fd());
-
-            // Create new session and set controlling terminal
             let _ = setsid();
-
-            // Set the slave as controlling terminal
             unsafe {
                 libc::ioctl(slave.as_raw_fd(), libc::TIOCSCTTY as _, 0);
             }
-
-            // Duplicate slave to stdin, stdout, stderr
             let _ = dup2(slave.as_raw_fd(), 0);
             let _ = dup2(slave.as_raw_fd(), 1);
             let _ = dup2(slave.as_raw_fd(), 2);
-
-            // Close the original slave fd if it's not one of 0, 1, 2
             if slave.as_raw_fd() > 2 {
                 let _ = close(slave.as_raw_fd());
             }
-
-            // Change directory if specified
             if let Some(cwd) = &params.cwd {
                 let _ = std::env::set_current_dir(cwd);
             }
-
-            // Set environment variables
             if params.clear_env {
                 for (key, _) in std::env::vars() {
                     std::env::remove_var(key);
@@ -622,23 +564,13 @@ fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
                     std::env::set_var(key, value);
                 }
             }
-
-            // Execute the command
             let _ = execvp(&cmd_cstring, &args_cstrings);
-
-            // If execvp returns, it failed
             std::process::exit(127);
         }
         Ok(ForkResult::Parent { child }) => {
-            // Parent process
-            // Close slave side - we don't need it
             drop(slave);
-
             let master_fd = master.as_raw_fd();
-
-            // Prevent the OwnedFd from closing the fd when dropped
             std::mem::forget(master);
-
             Ok(ForkResult2 {
                 master_fd,
                 child_pid: child,
@@ -654,7 +586,7 @@ fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
 }
 
 /// Start a process with a PTY (pseudo-terminal)
-pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn start_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         cmd: String,
@@ -666,10 +598,8 @@ pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
         env: Option<HashMap<String, String>>,
         #[serde(default)]
         clear_env: bool,
-        /// Terminal rows (default 24)
         #[serde(default = "default_rows")]
         rows: u16,
-        /// Terminal columns (default 80)
         #[serde(default = "default_cols")]
         cols: u16,
     }
@@ -681,8 +611,8 @@ pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
         80
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let start_params = PtyStartParams {
         cmd: params.cmd.clone(),
@@ -694,7 +624,6 @@ pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
         cols: params.cols,
     };
 
-    // Run fork/exec in a blocking task to avoid blocking the async runtime
     let fork_result = tokio::task::spawn_blocking(move || do_fork_exec(start_params))
         .await
         .map_err(|e| RpcError {
@@ -703,14 +632,12 @@ pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
             data: None,
         })??;
 
-    // Set non-blocking mode for async I/O
     set_fd_nonblocking(fork_result.master_fd).map_err(|e| RpcError {
         code: RpcError::PROCESS_ERROR,
         message: format!("Failed to set non-blocking: {}", e),
         data: None,
     })?;
 
-    // Wrap the fd in OwnedFd and AsyncFd for async I/O
     let owned_fd = unsafe { OwnedFd::from_raw_fd(fork_result.master_fd) };
     let async_fd = AsyncFd::new(owned_fd).map_err(|e| RpcError {
         code: RpcError::PROCESS_ERROR,
@@ -729,15 +656,15 @@ pub async fn start_pty(params: &serde_json::Value) -> HandlerResult {
 
     get_pty_process_map().lock().await.insert(our_pid, managed);
 
-    Ok(serde_json::json!({
-        "pid": our_pid,
-        "os_pid": fork_result.child_pid.as_raw(),
-        "tty_name": fork_result.tty_name
-    }))
+    Ok(msgpack_map! {
+        "pid" => our_pid,
+        "os_pid" => fork_result.child_pid.as_raw(),
+        "tty_name" => fork_result.tty_name
+    })
 }
 
 /// Resize a PTY terminal
-pub async fn resize_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn resize_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
@@ -745,8 +672,8 @@ pub async fn resize_pty(params: &serde_json::Value) -> HandlerResult {
         cols: u16,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let processes = get_pty_process_map().lock().await;
     let managed = processes.get(&params.pid).ok_or_else(|| RpcError {
@@ -763,17 +690,11 @@ pub async fn resize_pty(params: &serde_json::Value) -> HandlerResult {
         data: None,
     })?;
 
-    // Get the foreground process group and send SIGWINCH to it
-    // This ensures the signal reaches the currently active process (e.g., bash at prompt)
-    // rather than just the shell's process group
-    // SAFETY: fd is valid for the duration of this call as we hold the lock on the process map
     match tcgetpgrp(unsafe { BorrowedFd::borrow_raw(fd) }) {
         Ok(fg_pgrp) => {
-            // Send to the foreground process group (negative PID = process group)
             let _ = nix::sys::signal::kill(Pid::from_raw(-fg_pgrp.as_raw()), Signal::SIGWINCH);
         }
         Err(_) => {
-            // Fallback: send to the original child's process group
             let _ = nix::sys::signal::kill(
                 Pid::from_raw(-managed.child_pid.as_raw()),
                 Signal::SIGWINCH,
@@ -781,17 +702,16 @@ pub async fn resize_pty(params: &serde_json::Value) -> HandlerResult {
         }
     }
 
-    Ok(serde_json::json!(true))
+    Ok(Value::Boolean(true))
 }
 
 /// Read from a PTY process with optional blocking
-pub async fn read_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn read_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
         #[serde(default = "default_max_read")]
         max_bytes: usize,
-        /// Timeout in milliseconds to wait for data. If 0 or not specified, returns immediately.
         #[serde(default)]
         timeout_ms: Option<u64>,
     }
@@ -800,52 +720,44 @@ pub async fn read_pty(params: &serde_json::Value) -> HandlerResult {
         65536
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let timeout = params.timeout_ms.unwrap_or(0);
     let mut buf = vec![0u8; params.max_bytes];
 
-    // Try to read, optionally waiting for data
     let read_result = {
         let mut processes = get_pty_process_map().lock().await;
         let managed = match processes.get_mut(&params.pid) {
             Some(m) => m,
             None => {
-                return Ok(serde_json::json!({
-                    "output": serde_json::Value::Null,
-                    "output_encoding": serde_json::Value::Null,
-                    "exited": true,
-                    "exit_code": serde_json::Value::Null
-                }));
+                return Ok(msgpack_map! {
+                    "output" => Value::Nil,
+                    "exited" => true,
+                    "exit_code" => Value::Nil
+                });
             }
         };
 
-        // First try non-blocking read
         let fd = managed.async_fd.get_ref().as_raw_fd();
         let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
 
         if n > 0 {
-            // Got data immediately
             buf.truncate(n as usize);
             Some((buf.clone(), false, None))
         } else if timeout == 0 {
-            // No data and no timeout requested
             Some((vec![], false, None))
         } else {
-            // No data - we need to wait, but first check exit status
             let (exited, exit_code) = check_exit_status(managed);
             if exited {
                 Some((vec![], true, exit_code))
             } else {
-                None // Signal that we need to wait
+                None
             }
         }
     };
 
-    // If we got a result, return it
     if let Some((output, exited, exit_code)) = read_result {
-        // Check exit status if not already exited
         let (exited, exit_code) = if exited {
             (exited, exit_code)
         } else {
@@ -857,44 +769,38 @@ pub async fn read_pty(params: &serde_json::Value) -> HandlerResult {
             }
         };
 
-        let (output_val, output_enc) = if output.is_empty() {
-            (serde_json::Value::Null, None)
+        let output_val = if output.is_empty() {
+            Value::Nil
         } else {
-            let (s, enc) = smart_encode(&output);
-            (serde_json::Value::String(s), Some(enc))
+            Value::Binary(output)
         };
 
-        return Ok(serde_json::json!({
-            "output": output_val,
-            "output_encoding": output_enc,
-            "exited": exited,
-            "exit_code": exit_code
-        }));
+        return Ok(msgpack_map! {
+            "output" => output_val,
+            "exited" => exited,
+            "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        });
     }
 
-    // Need to wait for data - use async wait with timeout
     let wait_result = tokio::time::timeout(
         std::time::Duration::from_millis(timeout),
         wait_for_pty_readable(params.pid),
     )
     .await;
 
-    // After waiting, try to read again
     let mut processes = get_pty_process_map().lock().await;
     let managed = match processes.get_mut(&params.pid) {
         Some(m) => m,
         None => {
-            return Ok(serde_json::json!({
-                "output": serde_json::Value::Null,
-                "output_encoding": serde_json::Value::Null,
-                "exited": true,
-                "exit_code": serde_json::Value::Null
-            }));
+            return Ok(msgpack_map! {
+                "output" => Value::Nil,
+                "exited" => true,
+                "exit_code" => Value::Nil
+            });
         }
     };
 
     let output = if wait_result.is_ok() {
-        // Wait succeeded, try to read
         let fd = managed.async_fd.get_ref().as_raw_fd();
         let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
         if n > 0 {
@@ -904,25 +810,22 @@ pub async fn read_pty(params: &serde_json::Value) -> HandlerResult {
             vec![]
         }
     } else {
-        // Timeout - return empty
         vec![]
     };
 
     let (exited, exit_code) = check_exit_status(managed);
 
-    let (output_val, output_enc) = if output.is_empty() {
-        (serde_json::Value::Null, None)
+    let output_val = if output.is_empty() {
+        Value::Nil
     } else {
-        let (s, enc) = smart_encode(&output);
-        (serde_json::Value::String(s), Some(enc))
+        Value::Binary(output)
     };
 
-    Ok(serde_json::json!({
-        "output": output_val,
-        "output_encoding": output_enc,
-        "exited": exited,
-        "exit_code": exit_code
-    }))
+    Ok(msgpack_map! {
+        "output" => output_val,
+        "exited" => exited,
+        "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+    })
 }
 
 fn check_exit_status(managed: &mut ManagedPtyProcess) -> (bool, Option<i32>) {
@@ -946,7 +849,6 @@ fn check_exit_status(managed: &mut ManagedPtyProcess) -> (bool, Option<i32>) {
 }
 
 async fn wait_for_pty_readable(pid: u32) -> bool {
-    // Get the raw fd without holding the lock long
     let fd = {
         let processes = get_pty_process_map().lock().await;
         match processes.get(&pid) {
@@ -955,7 +857,6 @@ async fn wait_for_pty_readable(pid: u32) -> bool {
         }
     };
 
-    // Loop polling until data is available (outer timeout will cancel us)
     loop {
         let ready = tokio::task::spawn_blocking(move || {
             let mut pollfd = libc::pollfd {
@@ -963,7 +864,6 @@ async fn wait_for_pty_readable(pid: u32) -> bool {
                 events: libc::POLLIN,
                 revents: 0,
             };
-            // Poll with 100ms timeout
             let ret = unsafe { libc::poll(&mut pollfd, 1, 100) };
             ret > 0 && (pollfd.revents & libc::POLLIN) != 0
         })
@@ -974,31 +874,29 @@ async fn wait_for_pty_readable(pid: u32) -> bool {
             return true;
         }
 
-        // Check if process still exists before looping
         let processes = get_pty_process_map().lock().await;
         if !processes.contains_key(&pid) {
             return false;
         }
-        // Small yield to avoid busy spinning
         tokio::task::yield_now().await;
     }
 }
 
 /// Write to a PTY process (async)
-pub async fn write_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn write_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
-        /// Base64-encoded data to write
-        data: String,
+        /// Binary data to write
+        #[serde(with = "serde_bytes")]
+        data: Vec<u8>,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let decoded = BASE64
-        .decode(&params.data)
-        .map_err(|e| RpcError::invalid_params(format!("Invalid base64: {}", e)))?;
+    // Data is already binary, no decoding needed!
+    let data = params.data;
 
     let processes = get_pty_process_map().lock().await;
     let managed = processes.get(&params.pid).ok_or_else(|| RpcError {
@@ -1007,7 +905,6 @@ pub async fn write_pty(params: &serde_json::Value) -> HandlerResult {
         data: None,
     })?;
 
-    // Wait for writable and write
     let mut guard = managed
         .async_fd
         .ready(Interest::WRITABLE)
@@ -1022,8 +919,8 @@ pub async fn write_pty(params: &serde_json::Value) -> HandlerResult {
         let n = unsafe {
             libc::write(
                 inner.get_ref().as_raw_fd(),
-                decoded.as_ptr() as *const libc::c_void,
-                decoded.len(),
+                data.as_ptr() as *const libc::c_void,
+                data.len(),
             )
         };
         if n >= 0 {
@@ -1043,13 +940,13 @@ pub async fn write_pty(params: &serde_json::Value) -> HandlerResult {
         Err(_would_block) => 0,
     };
 
-    Ok(serde_json::json!({
-        "written": written
-    }))
+    Ok(msgpack_map! {
+        "written" => written
+    })
 }
 
 /// Kill a PTY process
-pub async fn kill_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn kill_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
@@ -1061,8 +958,8 @@ pub async fn kill_pty(params: &serde_json::Value) -> HandlerResult {
         libc::SIGTERM
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut processes = get_pty_process_map().lock().await;
     let managed = processes.get(&params.pid).ok_or_else(|| RpcError {
@@ -1071,46 +968,40 @@ pub async fn kill_pty(params: &serde_json::Value) -> HandlerResult {
         data: None,
     })?;
 
-    // Convert signal number to Signal enum
     let signal = Signal::try_from(params.signal).map_err(|_| RpcError {
         code: RpcError::INVALID_PARAMS,
         message: format!("Invalid signal: {}", params.signal),
         data: None,
     })?;
 
-    // Send signal to the process
     nix::sys::signal::kill(managed.child_pid, signal).map_err(|e| RpcError {
         code: RpcError::PROCESS_ERROR,
         message: format!("Failed to send signal: {}", e),
         data: None,
     })?;
 
-    // If SIGKILL, also close and remove
     if params.signal == libc::SIGKILL {
         processes.remove(&params.pid);
-        // AsyncFd and OwnedFd will be dropped, closing the fd
     }
 
-    Ok(serde_json::json!(true))
+    Ok(Value::Boolean(true))
 }
 
 /// Close a PTY process and clean up
-pub async fn close_pty(params: &serde_json::Value) -> HandlerResult {
+pub async fn close_pty(params: &Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         pid: u32,
     }
 
-    let params: Params = serde_json::from_value(params.clone())
-        .map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let mut processes = get_pty_process_map().lock().await;
 
     if let Some(managed) = processes.remove(&params.pid) {
-        // Kill the process if still running
         let _ = nix::sys::signal::kill(managed.child_pid, Signal::SIGKILL);
-        // AsyncFd and OwnedFd will be dropped, closing the fd
-        Ok(serde_json::json!(true))
+        Ok(Value::Boolean(true))
     } else {
         Err(RpcError {
             code: RpcError::PROCESS_ERROR,
@@ -1121,13 +1012,12 @@ pub async fn close_pty(params: &serde_json::Value) -> HandlerResult {
 }
 
 /// List all PTY processes
-pub async fn list_pty(_params: &serde_json::Value) -> HandlerResult {
+pub async fn list_pty(_params: &Value) -> HandlerResult {
     let mut processes = get_pty_process_map().lock().await;
 
-    let list: Vec<serde_json::Value> = processes
+    let list: Vec<Value> = processes
         .iter_mut()
         .map(|(pid, managed)| {
-            // Check if process has exited
             let (exited, exit_code) = if managed.exit_status.is_some() {
                 (true, managed.exit_status)
             } else {
@@ -1145,15 +1035,15 @@ pub async fn list_pty(_params: &serde_json::Value) -> HandlerResult {
                 }
             };
 
-            serde_json::json!({
-                "pid": pid,
-                "os_pid": managed.child_pid.as_raw(),
-                "cmd": managed.cmd,
-                "exited": exited,
-                "exit_code": exit_code
-            })
+            msgpack_map! {
+                "pid" => *pid,
+                "os_pid" => managed.child_pid.as_raw(),
+                "cmd" => managed.cmd.clone(),
+                "exited" => exited,
+                "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+            }
         })
         .collect();
 
-    Ok(serde_json::to_value(list).unwrap())
+    Ok(Value::Array(list))
 }

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -65,6 +65,17 @@
 (let ((lisp-dir (expand-file-name "lisp" tramp-rpc-test--project-root)))
   (add-to-list 'load-path lisp-dir))
 
+;; Install msgpack from MELPA if not available (required by tramp-rpc-protocol)
+(unless (require 'msgpack nil t)
+  (require 'package)
+  (add-to-list 'package-archives
+               '("melpa" . "https://melpa.org/packages/") t)
+  (package-initialize)
+  (unless package-archive-contents
+    (package-refresh-contents))
+  (package-install 'msgpack)
+  (require 'msgpack))
+
 (require 'tramp-rpc)
 
 ;;; ============================================================================
@@ -190,7 +201,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test00-availability ()
   "Test availability of TRAMP RPC functions."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
   (let ((dir (tramp-rpc-test--remote-directory)))
     (should (file-remote-p dir))
@@ -231,7 +241,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test02-file-exists-p ()
   "Test `file-exists-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Test directory exists
@@ -247,7 +256,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test02-file-readable-p ()
   "Test `file-readable-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "test content"
@@ -255,7 +263,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test02-file-writable-p ()
   "Test `file-writable-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Existing file
@@ -272,7 +279,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test03-file-directory-p ()
   "Test `file-directory-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Test directory
@@ -288,7 +294,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test03-file-regular-p ()
   "Test `file-regular-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Regular file
@@ -300,7 +305,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test03-file-symlink-p ()
   "Test `file-symlink-p' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file target "target content"
@@ -323,7 +327,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test04-file-attributes ()
   "Test `file-attributes' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "test content"
@@ -345,7 +348,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test04-file-attributes-directory ()
   "Test `file-attributes' for TRAMP RPC directories."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-dir subdir
@@ -356,7 +358,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test04-file-modes ()
   "Test `file-modes' and `set-file-modes' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "test content"
@@ -375,7 +376,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test05-write-region ()
   "Test `write-region' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Simple write
@@ -392,7 +392,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test05-write-region-multiline ()
   "Test `write-region' with multiline content."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -407,7 +406,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test05-write-region-binary ()
   "Test `write-region' with binary content."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -428,7 +426,6 @@ The directory is deleted after BODY completes."
 
 (ert-deftest tramp-rpc-test05-write-region-utf8 ()
   "Test `write-region' with UTF-8 content."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -444,7 +441,6 @@ The directory is deleted after BODY completes."
 (ert-deftest tramp-rpc-test05-write-region-chinese ()
   "Test `write-region' with Chinese characters.
 This tests Issue #13: Chinese characters decode incorrectly."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -463,7 +459,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test05-write-region-mixed-unicode ()
   "Test `write-region' with mixed Unicode content."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -479,7 +474,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test05-write-region-append ()
   "Test `write-region' with append."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -498,7 +492,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test05-write-region-large ()
   "Test `write-region' with large file."
   :tags '(:expensive-test)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name))
@@ -515,7 +508,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test05-insert-file-contents ()
   "Test `insert-file-contents' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "test content"
@@ -525,7 +517,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test05-insert-file-contents-partial ()
   "Test partial `insert-file-contents' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "0123456789"
@@ -540,7 +531,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test06-copy-file ()
   "Test `copy-file' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file src "source content"
@@ -559,7 +549,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test06-rename-file ()
   "Test `rename-file' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((src (tramp-rpc-test--make-temp-name))
@@ -579,7 +568,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test06-delete-file ()
   "Test `delete-file' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name)))
@@ -594,7 +582,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-make-directory ()
   "Test `make-directory' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((dir (tramp-rpc-test--make-temp-name)))
@@ -606,7 +593,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-make-directory-parents ()
   "Test `make-directory' with parents for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((dir (concat (tramp-rpc-test--make-temp-name) "/nested/path")))
@@ -619,7 +605,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-delete-directory ()
   "Test `delete-directory' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((dir (tramp-rpc-test--make-temp-name)))
@@ -630,7 +615,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-delete-directory-recursive ()
   "Test recursive `delete-directory' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((dir (tramp-rpc-test--make-temp-name)))
@@ -644,7 +628,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-directory-files ()
   "Test `directory-files' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-dir dir
@@ -668,7 +651,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test07-directory-files-and-attributes ()
   "Test `directory-files-and-attributes' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-dir dir
@@ -692,7 +674,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test08-make-symbolic-link ()
   "Test `make-symbolic-link' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file target "target content"
@@ -711,7 +692,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test08-file-truename ()
   "Test `file-truename' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file target "content"
@@ -733,7 +713,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test09-set-file-times ()
   "Test `set-file-times' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "content"
@@ -750,7 +729,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test10-process-file ()
   "Test `process-file' for TRAMP RPC files."
   :tags '(:process)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((default-directory (tramp-rpc-test--remote-directory)))
@@ -771,7 +749,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test10-process-file-with-stdin ()
   "Test `process-file' with stdin input."
   :tags '(:process)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((default-directory (tramp-rpc-test--remote-directory)))
@@ -790,7 +767,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test10-shell-command ()
   "Test shell command execution."
   :tags '(:process)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((default-directory (tramp-rpc-test--remote-directory)))
@@ -804,7 +780,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test11-expand-file-name ()
   "Test `expand-file-name' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((dir (tramp-rpc-test--remote-directory)))
@@ -833,7 +808,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test12-file-name-completion ()
   "Test file name completion for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-dir dir
@@ -852,7 +826,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test13-file-system-info ()
   "Test `file-system-info' for TRAMP RPC files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((info (file-system-info (tramp-rpc-test--remote-directory))))
@@ -871,7 +844,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test14-start-file-process ()
   "Test `start-file-process' for TRAMP RPC files."
   :tags '(:process :expensive-test)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let* ((default-directory (tramp-rpc-test--remote-directory))
@@ -891,7 +863,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test14-make-process ()
   "Test `make-process' for TRAMP RPC files."
   :tags '(:process :expensive-test)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let* ((default-directory (tramp-rpc-test--remote-directory))
@@ -918,7 +889,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test15-copy-local-to-remote ()
   "Test copying from local to remote."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((local-file (make-temp-file "local-test"))
@@ -937,7 +907,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test15-copy-remote-to-local ()
   "Test copying from remote to local."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((local-file (make-temp-file "local-test"))
@@ -957,7 +926,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 (ert-deftest tramp-rpc-test16-vc-registered ()
   "Test VC registration detection."
   :tags '(:expensive-test)
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   ;; Create a git repo in temp dir
@@ -976,7 +944,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test17-write-region-overwrite ()
   "Test overwriting existing file."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name)))
@@ -998,7 +965,6 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
 (ert-deftest tramp-rpc-test18-empty-file ()
   "Test handling of empty files."
-  :expected-result (if (tramp-rpc-test-enabled) :passed :failed)
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((file (tramp-rpc-test--make-temp-name)))


### PR DESCRIPTION
Replace JSON-RPC with newline-delimited messages with MessagePack-RPC
using length-prefixed binary framing. This eliminates the ~33% overhead
of base64 encoding for file transfers and fixes encoding issues with
non-UTF8 filenames and binary content.

Rust server changes:
- Replace serde_json + base64 with rmp-serde + rmpv + serde_bytes
- Use length-prefixed binary framing (<4-byte BE length><msgpack payload>)
- Add to_value() methods to serialize structs as maps with named fields
- Rename 'jsonrpc' field to 'version' in protocol

Elisp client changes:
- Rewrite tramp-rpc-protocol.el to use msgpack.el
- Add length-prefixed framing support
- Use :msgpack-false for boolean false values
- Send raw bytes instead of base64-encoded content

Documentation:
- Add Protocol History section explaining the change
- Update all JSON-RPC references to MessagePack-RPC
- Update message format examples