### PR TITLE
Bump version to 0.3.0 and add version consistency checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,11 @@ jobs:
 
       - name: Deploy server to localhost
         run: |
+          # Extract version from elisp source (single source of truth)
+          VERSION=$(grep -oP 'tramp-rpc-deploy-version "\K[^"]+' lisp/tramp-rpc-deploy.el)
+          echo "Deploying version: $VERSION"
           mkdir -p ~/.cache/tramp-rpc
-          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/
+          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/tramp-rpc-server-${VERSION}
 
       - name: Run full test suite
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: 'Version to release (without v prefix)'
         required: true
-        default: '0.2.0'
+        default: '0.3.0'
 
 env:
   CARGO_TERM_COLOR: always
@@ -80,6 +80,19 @@ jobs:
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Verify version matches elisp
+        run: |
+          ELISP_VERSION=$(grep -oP 'tramp-rpc-deploy-version "\K[^"]+' lisp/tramp-rpc-deploy.el)
+          TAG_VERSION=${{ steps.version.outputs.version }}
+          echo "Elisp version: $ELISP_VERSION"
+          echo "Tag version: $TAG_VERSION"
+          if [ "$ELISP_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch! Tag is v${TAG_VERSION} but lisp/tramp-rpc-deploy.el has version ${ELISP_VERSION}"
+            echo "Please update tramp-rpc-deploy-version in lisp/tramp-rpc-deploy.el to match the release tag."
+            exit 1
+          fi
+          echo "Version check passed!"
 
       - name: List artifacts
         run: ls -la artifacts/

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -36,7 +36,7 @@
   "Deployment settings for TRAMP-RPC."
   :group 'tramp)
 
-(defconst tramp-rpc-deploy-version "0.2.0"
+(defconst tramp-rpc-deploy-version "0.3.0"
   "Current version of tramp-rpc-server.")
 
 (defconst tramp-rpc-deploy-binary-name "tramp-rpc-server"


### PR DESCRIPTION
- Update tramp-rpc-deploy-version to 0.3.0
- CI: Extract version from elisp file dynamically for test deployment
- Release: Add verification step to ensure tag matches elisp version