### PR TITLE
Fix copy-file to directory destination (Issue #45)

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1488,6 +1488,9 @@ Supported switches: -a -t -S -r -h --group-directories-first."
   "Like `copy-file' for TRAMP-RPC files."
   (setq filename (expand-file-name filename)
         newname (expand-file-name newname))
+  ;; If newname is a directory, copy the file INTO it
+  (when (file-directory-p newname)
+    (setq newname (expand-file-name (file-name-nondirectory filename) newname)))
   (let ((source-remote (tramp-tramp-file-p filename))
         (dest-remote (tramp-tramp-file-p newname)))
     (cond

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -547,6 +547,31 @@ This tests Issue #13: Chinese characters decode incorrectly."
                              (buffer-string)))))
         (ignore-errors (delete-file dest))))))
 
+(ert-deftest tramp-rpc-test06-copy-file-to-directory ()
+  "Test `copy-file' to a directory destination (issue #45)."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-file src "source content for dir copy"
+    (let ((dest-dir (tramp-rpc-test--make-temp-name)))
+      (unwind-protect
+          (progn
+            ;; Create destination directory
+            (make-directory dest-dir)
+            (should (file-directory-p dest-dir))
+            ;; Copy file to directory - should copy INTO the directory
+            (copy-file src dest-dir)
+            ;; File should now exist inside the directory with original name
+            (let ((expected-dest (expand-file-name
+                                  (file-name-nondirectory src) dest-dir)))
+              (should (file-exists-p expected-dest))
+              (should (equal (with-temp-buffer
+                               (insert-file-contents src)
+                               (buffer-string))
+                             (with-temp-buffer
+                               (insert-file-contents expected-dest)
+                               (buffer-string))))))
+        (ignore-errors (delete-directory dest-dir t))))))
+
 (ert-deftest tramp-rpc-test06-rename-file ()
   "Test `rename-file' for TRAMP RPC files."
   (skip-unless (tramp-rpc-test-enabled))


### PR DESCRIPTION
When copying a file to a directory path, both the Emacs handler and Rust
server now correctly append the source filename to the destination path,
matching standard copy-file behavior.