### PR TITLE
fix(tramp-rpc-advice): Add process type check before accessing process properties

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -196,7 +196,7 @@
 
 (defun tramp-rpc--process-status-advice (orig-fun process)
   "Advice for `process-status' to handle TRAMP-RPC processes."
-  (if (process-get process :tramp-rpc-pid)
+  (if (and (processp process) (process-get process :tramp-rpc-pid))
       (cond
        ((process-get process :tramp-rpc-exited) 'exit)
        ;; Use orig-fun to check live status, not process-live-p (which would recurse)
@@ -206,7 +206,7 @@
 
 (defun tramp-rpc--process-exit-status-advice (orig-fun process)
   "Advice for `process-exit-status' to handle TRAMP-RPC processes."
-  (if (process-get process :tramp-rpc-pid)
+  (if (and (processp process) (process-get process :tramp-rpc-pid))
       (or (process-get process :tramp-rpc-exit-code) 0)
     (funcall orig-fun process)))
 


### PR DESCRIPTION
Add `processp` guard to prevent errors when non-process objects are passed to
`process-status` and `process-exit-status` advice functions.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>