### PR TITLE
feat(handlers): Add tilde expansion support for all path parameters

### DIFF
--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -370,7 +370,7 @@ pub async fn completions(params: &Value) -> HandlerResult {
     let params: Params =
         from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let directory = params.directory.clone();
+    let directory = super::expand_tilde(&params.directory);
     let prefix = params.prefix.clone();
 
     // Use synchronous I/O in blocking task - d_type gives us directory detection for free

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -81,7 +81,7 @@ pub async fn run(params: &Value) -> HandlerResult {
     cmd.args(&params.args);
 
     if let Some(cwd) = &params.cwd {
-        cmd.current_dir(cwd);
+        cmd.current_dir(super::expand_tilde(cwd));
     }
 
     if params.clear_env {
@@ -158,7 +158,7 @@ pub async fn start(params: &Value) -> HandlerResult {
     cmd.args(&params.args);
 
     if let Some(cwd) = &params.cwd {
-        cmd.current_dir(cwd);
+        cmd.current_dir(super::expand_tilde(cwd));
     }
 
     if params.clear_env {
@@ -552,7 +552,7 @@ fn do_fork_exec(params: PtyStartParams) -> Result<ForkResult2, RpcError> {
                 let _ = close(slave.as_raw_fd());
             }
             if let Some(cwd) = &params.cwd {
-                let _ = std::env::set_current_dir(cwd);
+                let _ = std::env::set_current_dir(super::expand_tilde(cwd));
             }
             if params.clear_env {
                 for (key, _) in std::env::vars() {

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -260,14 +260,16 @@ pub fn handle_add(params: &Value) -> HandlerResult {
     let params: Params =
         from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    let expanded = crate::handlers::expand_tilde(&params.path);
+
     let manager = get().ok_or_else(|| RpcError::internal_error("File watcher not available"))?;
 
     manager
-        .watch(Path::new(&params.path), params.recursive)
+        .watch(Path::new(&expanded), params.recursive)
         .map_err(|e| RpcError::internal_error(format!("Failed to watch: {}", e)))?;
 
     Ok(msgpack_map! {
-        "path" => params.path.clone(),
+        "path" => expanded.clone(),
         "recursive" => Value::Boolean(params.recursive)
     })
 }
@@ -284,10 +286,12 @@ pub fn handle_remove(params: &Value) -> HandlerResult {
     let params: Params =
         from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    let expanded = crate::handlers::expand_tilde(&params.path);
+
     let manager = get().ok_or_else(|| RpcError::internal_error("File watcher not available"))?;
 
     manager
-        .unwatch(Path::new(&params.path))
+        .unwatch(Path::new(&expanded))
         .map_err(|e| RpcError::internal_error(format!("Failed to unwatch: {}", e)))?;
 
     Ok(Value::Boolean(true))


### PR DESCRIPTION
Apply home directory expansion (~/) to all user-provided paths across
commands, file operations, process spawning, and file watching handlers
to ensure consistent path resolution.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>