### PR TITLE
Configure user and host name completion for rpc method

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -94,7 +94,10 @@
   ;; which isn't loaded yet.  The handler function itself is an autoload
   ;; stub that triggers loading of tramp-rpc.el on first use.
   (add-to-list 'tramp-foreign-file-name-handler-alist
-               '(tramp-rpc-file-name-p . tramp-rpc-file-name-handler)))
+               '(tramp-rpc-file-name-p . tramp-rpc-file-name-handler))
+
+  ;; Configure user and host name completion.
+  (tramp-set-completion-function "rpc" tramp-completion-function-alist-ssh))
 
 ;; Now the actual implementation
 (require 'cl-lib)


### PR DESCRIPTION
## Summary

- Adds `tramp-set-completion-function` call for the "rpc" method, using the same SSH completion defaults (`tramp-completion-function-alist-ssh`).
- Enables user and host name completion (e.g. from `~/.ssh/known_hosts`, `/etc/hosts`) when using `/rpc:` file names.

Patch from Michael Albinus.