### PR TITLE
fix: use emacs subdirectory under XDG_CACHE_HOME for remote deploy

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -78,7 +78,7 @@ Used for building from source.  Set to nil to disable source builds."
 This is useful for development - binaries built by scripts/build-all.sh
 are placed here and used directly without needing to download or cache.")
 
-(defcustom tramp-rpc-deploy-remote-directory "~/.cache/tramp-rpc"
+(defcustom tramp-rpc-deploy-remote-directory "~/.cache/emacs/tramp-rpc"
   "Remote directory where the server binary will be installed."
   :type 'string
   :group 'tramp-rpc-deploy)


### PR DESCRIPTION
Follow XDG convention of using the application name as subdirectory
under $XDG_CACHE_HOME (~/.cache/emacs/tramp-rpc instead of
~/.cache/tramp-rpc).

Suggested-by: Michael Albinus <michael.albinus@gmx.de>