### PR TITLE
fix: handle ENOTDIR in file-stat to avoid errors from editorconfig

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1243,9 +1243,11 @@ ELOOP errors to nil (the file effectively doesn't exist for stat)."
         (tramp-rpc--call vec "file.stat" params)
       (file-missing nil)
       (file-error
-       ;; Return nil for ELOOP (symlink loop) - file can't be resolved,
-       ;; so it effectively doesn't exist for stat purposes.
-       (if (string-match-p "Too many levels of symbolic links" (cadr err))
+       ;; Return nil for ELOOP (symlink loop) and ENOTDIR (path component
+       ;; is not a directory, e.g. "file.py/.editorconfig") - the file
+       ;; can't be resolved, so it effectively doesn't exist for stat purposes.
+       (if (or (string-match-p "Too many levels of symbolic links" (cadr err))
+               (string-match-p "Not a directory" (cadr err)))
            nil
          (signal (car err) (cdr err)))))))
 


### PR DESCRIPTION
## Summary

- Handle `ENOTDIR` (errno 20) in `tramp-rpc--call-file-stat` by returning `nil`, matching existing `ELOOP` handling
- When editorconfig probes paths like `file.py/.editorconfig`, the OS returns `ENOTDIR` because a path component is a regular file. This is semantically "file doesn't exist", so `file-stat` should return `nil` rather than signaling an error.
- This prevents errors that interrupt file loading and fontification when editorconfig is active

Fixes #91