### PR TITLE
fix: fall back to sshx for multi-hop bootstrap deploy

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -219,20 +219,37 @@ The method used is controlled by `tramp-rpc-deploy-bootstrap-method'.
 Methods like \"scp\" and \"rsync\" use out-of-band transfer for `copy-file',
 while \"ssh\" and \"sshx\" use inline encoding (base64 through the shell).
 Any \"rpc:\" hops in the hop chain are normalized to \"ssh:\" so that
-standard TRAMP can traverse them."
+standard TRAMP can traverse them.
+
+When hops are present, out-of-band methods (scp, scpx, rsync) cannot be
+used because TRAMP's `tramp-multi-hop-p' rejects methods that have
+`tramp-copy-program'.  In this case, \"sshx\" is used instead, which
+transfers the binary via inline encoding (slower but compatible with
+multi-hop)."
   (let ((method (tramp-file-name-method vec)))
     (if (member method '("ssh" "sshx" "scp" "scpx" "rsync"))
         vec  ; Already a TRAMP method that supports shell commands and file transfer
       ;; Convert to bootstrap method - create a new tramp-file-name struct
-      (make-tramp-file-name
-       :method tramp-rpc-deploy-bootstrap-method
-       :user (tramp-file-name-user vec)
-       :domain (tramp-file-name-domain vec)
-       :host (tramp-file-name-host vec)
-       :port (tramp-file-name-port vec)
-       :localname (tramp-file-name-localname vec)
-       :hop (tramp-rpc-deploy--normalize-hops
-             (tramp-file-name-hop vec))))))
+      (let* ((hops (tramp-file-name-hop vec))
+             (normalized-hops (tramp-rpc-deploy--normalize-hops hops))
+             ;; When hops are present, out-of-band methods (scp, scpx,
+             ;; rsync) fail TRAMP's multi-hop validation because they have
+             ;; tramp-copy-program set.  Fall back to "sshx" which supports
+             ;; multi-hop (inline transfer only).
+             (bootstrap-method
+              (if (and normalized-hops
+                       (member tramp-rpc-deploy-bootstrap-method
+                               '("scp" "scpx" "rsync")))
+                  "sshx"
+                tramp-rpc-deploy-bootstrap-method)))
+        (make-tramp-file-name
+         :method bootstrap-method
+         :user (tramp-file-name-user vec)
+         :domain (tramp-file-name-domain vec)
+         :host (tramp-file-name-host vec)
+         :port (tramp-file-name-port vec)
+         :localname (tramp-file-name-localname vec)
+         :hop normalized-hops)))))
 
 (defun tramp-rpc-deploy--detect-remote-arch (vec)
   "Detect the architecture of remote host specified by VEC.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -60,9 +60,26 @@
   ;; unloading `tramp-rpc', but this body still exists as compiled
   ;; function in `after-load-alist'.
   (when (boundp 'tramp-rpc-method)
-  ;; Register the method
+  ;; Register the method.  The SSH login parameters (tramp-login-program,
+  ;; tramp-login-args, tramp-remote-shell) are used by tramp-sh when "rpc"
+  ;; appears as a hop in a multi-hop chain with a tramp-sh target method
+  ;; (e.g., /rpc:host|sudo:user@:/path).  In that case tramp-sh opens an
+  ;; SSH shell on the hop host, then chains the target method (sudo) inside
+  ;; it -- exactly like the built-in "ssh" method.  When "rpc" is the final
+  ;; target, the tramp-rpc foreign handler is used instead and these
+  ;; parameters are ignored.
   (add-to-list 'tramp-methods
                `(,tramp-rpc-method
+                 (tramp-login-program        "ssh")
+                 (tramp-login-args           (("-l" "%u") ("-p" "%p") ("%c")
+                                              ("-e" "none")
+                                              ("-o" ,(format
+                                                      "SetEnv=\"TERM=%s\""
+                                                      tramp-terminal-type))
+                                              ("%h")))
+                 (tramp-remote-shell         ,tramp-default-remote-shell)
+                 (tramp-remote-shell-login   ("-l"))
+                 (tramp-remote-shell-args    ("-c"))
                  ;; Direct async process support: tramp-rpc uses direct SSH
                  ;; PTY connections for async processes, which means stderr
                  ;; is mixed with stdout (normal PTY behavior).  Setting

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -749,6 +749,27 @@ TRAMP's `tramp-multi-hop-p' rejects methods with `tramp-copy-program'
            (bootstrap (tramp-rpc-deploy--bootstrap-vec vec)))
       (should (equal (tramp-file-name-method bootstrap) "sshx")))))
 
+(ert-deftest tramp-rpc-mock-test-multi-hop-rpc-with-sudo ()
+  "Test that /rpc:host|sudo:user@:/path passes TRAMP's multi-hop validation.
+This exercises `tramp-compute-multi-hops' which checks that each hop's
+method either uses \"%h\" in its tramp-login-args (meaning the method
+actually connects to the specified host) or that the host matches the
+previous hop.  Without tramp-login-args containing \"%h\" in the rpc
+method definition, the host validation fails with:
+  Host name `host' does not match `tramp-local-host-regexp'"
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; Verify the rpc method now has tramp-login-args with "%h"
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "myhost"
+                                    :localname "/path"))
+         (login-args (tramp-get-method-parameter vec 'tramp-login-args)))
+    (should login-args)
+    (should (member "%h" (flatten-tree login-args))))
+  ;; Verify that tramp-compute-multi-hops succeeds for rpc|sudo
+  ;; (previously this would signal an error)
+  (let ((vec (tramp-dissect-file-name "/rpc:myhost|sudo:www-data@:/path")))
+    (should (tramp-compute-multi-hops vec))))
+
 ;;; ============================================================================
 ;;; Test Runner
 ;;; ============================================================================

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -589,6 +589,24 @@ Returns the result or signals an error."
   (let ((vec (tramp-dissect-file-name "/ssh:gateway|rpc:user@target:/path")))
     (should (equal (tramp-rpc--hops-to-proxyjump vec) "gateway"))))
 
+(ert-deftest tramp-rpc-mock-test-hops-to-proxyjump-port-only ()
+  "Test ProxyJump conversion with a hop that has a port but no user."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:gateway#2222|rpc:user@target:/path")))
+    (should (equal (tramp-rpc--hops-to-proxyjump vec) "gateway:2222"))))
+
+(ert-deftest tramp-rpc-mock-test-hops-to-proxyjump-complex ()
+  "Test ProxyJump conversion with complex multi-hop chain.
+Tests a realistic scenario: bastion with user+port, then a middle
+hop with user only, all leading to a final target."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/ssh:admin@bastion#2222|rpc:devuser@middleware|rpc:user@target:/path")))
+    (should (equal (tramp-rpc--hops-to-proxyjump vec)
+                   "admin@bastion:2222,devuser@middleware"))))
+
 (ert-deftest tramp-rpc-mock-test-connection-key-no-hop ()
   "Test connection key without hops."
   :tags '(:multi-hop)
@@ -683,9 +701,10 @@ Returns the result or signals an error."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let* ((vec (tramp-dissect-file-name "/rpc:gateway|rpc:user@target:/path"))
          (bootstrap (tramp-rpc-deploy--bootstrap-vec vec)))
-    ;; Method should be the bootstrap method (default: scp)
-    (should (equal (tramp-file-name-method bootstrap)
-                   tramp-rpc-deploy-bootstrap-method))
+    ;; When hops are present and the default bootstrap method is an
+    ;; out-of-band method (scpx), the bootstrap vec should fall back to
+    ;; "sshx" because out-of-band methods fail tramp-multi-hop-p.
+    (should (equal (tramp-file-name-method bootstrap) "sshx"))
     ;; Host and user should be preserved
     (should (equal (tramp-file-name-host bootstrap) "target"))
     (should (equal (tramp-file-name-user bootstrap) "user"))
@@ -694,6 +713,41 @@ Returns the result or signals an error."
       (should hop)
       (should (string-match-p "ssh:" hop))
       (should-not (string-match-p "rpc:" hop)))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-bootstrap-vec-no-hop-uses-default ()
+  "Test that bootstrap vec without hops uses the configured method."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "target"
+                                    :user "user" :localname "/path"))
+         (bootstrap (tramp-rpc-deploy--bootstrap-vec vec)))
+    ;; Without hops, the configured bootstrap method should be used as-is
+    (should (equal (tramp-file-name-method bootstrap)
+                   tramp-rpc-deploy-bootstrap-method))
+    ;; No hop should be present
+    (should-not (tramp-file-name-hop bootstrap))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-bootstrap-vec-hop-with-sshx ()
+  "Test that bootstrap vec with hops keeps sshx if already configured."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((tramp-rpc-deploy-bootstrap-method "sshx")
+         (vec (tramp-dissect-file-name "/rpc:gateway|rpc:user@target:/path"))
+         (bootstrap (tramp-rpc-deploy--bootstrap-vec vec)))
+    ;; sshx supports multi-hop, so it should be used as-is
+    (should (equal (tramp-file-name-method bootstrap) "sshx"))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-bootstrap-vec-hop-forces-sshx ()
+  "Test that out-of-band bootstrap methods fall back to sshx with hops.
+TRAMP's `tramp-multi-hop-p' rejects methods with `tramp-copy-program'
+\(scp, scpx, rsync), so the bootstrap must use an inline method."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (dolist (oob-method '("scp" "scpx" "rsync"))
+    (let* ((tramp-rpc-deploy-bootstrap-method oob-method)
+           (vec (tramp-dissect-file-name "/rpc:gateway|rpc:user@target:/path"))
+           (bootstrap (tramp-rpc-deploy--bootstrap-vec vec)))
+      (should (equal (tramp-file-name-method bootstrap) "sshx")))))
 
 ;;; ============================================================================
 ;;; Test Runner

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -181,6 +181,10 @@ The file is not created."
   "Return the remote test directory path on the second host."
   (format "/rpc:%s:%s" tramp-rpc-test-host-2 tramp-rpc-test-temp-dir))
 
+(defvar tramp-rpc-test-multi-hop-checked nil
+  "Cached result of `tramp-rpc-test-multi-hop-enabled'.
+Value is a cons cell (CHECKED . RESULT).")
+
 (defvar tramp-rpc-test-cross-remote-checked nil
   "Cached result of `tramp-rpc-test-cross-remote-enabled'.
 Value is a cons cell (CHECKED . RESULT).")
@@ -202,6 +206,49 @@ Returns non-nil if both test hosts are reachable."
                                   (file-writable-p dir))))
                        (error nil))))))
   (cdr tramp-rpc-test-cross-remote-checked))
+
+(defun tramp-rpc-test--make-multi-hop-remote-path (filename)
+  "Make a TRAMP RPC path using multi-hop syntax for FILENAME.
+Uses the test host as both the hop and the target (self-referential
+ProxyJump), which tests the full multi-hop connection machinery."
+  (let ((user-part (if tramp-rpc-test-user
+                       (concat tramp-rpc-test-user "@")
+                     "")))
+    (format "/rpc:%s%s|rpc:%s%s:%s/%s"
+            user-part tramp-rpc-test-host
+            user-part tramp-rpc-test-host
+            tramp-rpc-test-temp-dir
+            filename)))
+
+(defun tramp-rpc-test--multi-hop-remote-directory ()
+  "Return the remote test directory path via multi-hop."
+  (let ((user-part (if tramp-rpc-test-user
+                       (concat tramp-rpc-test-user "@")
+                     "")))
+    (format "/rpc:%s%s|rpc:%s%s:%s"
+            user-part tramp-rpc-test-host
+            user-part tramp-rpc-test-host
+            tramp-rpc-test-temp-dir)))
+
+(defun tramp-rpc-test-multi-hop-enabled ()
+  "Check if multi-hop testing is possible.
+This requires the test host to be able to SSH to itself (self-referential
+ProxyJump).  The result is cached after the first check."
+  (unless (consp tramp-rpc-test-multi-hop-checked)
+    (setq tramp-rpc-test-multi-hop-checked
+          (cons t
+                (and (tramp-rpc-test-enabled)
+                     (condition-case nil
+                         (let ((hop-dir (tramp-rpc-test--multi-hop-remote-directory)))
+                           (file-directory-p hop-dir))
+                       (error nil))))))
+  (cdr tramp-rpc-test-multi-hop-checked))
+
+(defun tramp-rpc-test--make-multi-hop-temp-name ()
+  "Return a temporary file name via multi-hop.
+The file is not created."
+  (tramp-rpc-test--make-multi-hop-remote-path
+   (make-temp-name tramp-rpc-test-name-prefix)))
 
 (defun tramp-rpc-test--setup ()
   "Set up test environment."
@@ -1218,6 +1265,107 @@ and returns a valid path."
                               (insert-file-contents file)
                               (buffer-string)))))
       (ignore-errors (delete-file file)))))
+
+;;; ============================================================================
+;;; Test 19: Multi-Hop
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test19-multi-hop-file-operations ()
+  "Test file operations through multi-hop syntax.
+Uses the test host as both hop and target (self-referential ProxyJump).
+This exercises the full multi-hop connection machinery:
+- Filename parsing with hop chain
+- ProxyJump SSH argument construction
+- Separate ControlMaster socket for the hopped connection
+- Server startup through the hopped SSH connection
+- File I/O through the multi-hop RPC channel"
+  :tags '(:expensive-test :multi-hop)
+  (skip-unless (tramp-rpc-test-multi-hop-enabled))
+
+  (let ((file (tramp-rpc-test--make-multi-hop-temp-name))
+        (content "multi-hop test content"))
+    (unwind-protect
+        (progn
+          ;; Write file through multi-hop
+          (write-region content nil file)
+          (should (file-exists-p file))
+          ;; Read back through multi-hop
+          (should (equal content
+                         (with-temp-buffer
+                           (insert-file-contents file)
+                           (buffer-string))))
+          ;; File attributes should work
+          (let ((attrs (file-attributes file)))
+            (should attrs)
+            (should (null (file-attribute-type attrs)))
+            (should (= (file-attribute-size attrs) (length content))))
+          ;; The same file should be visible via the direct (non-hopped) path
+          (let ((direct-file (tramp-rpc-test--make-remote-path
+                              (file-name-nondirectory file))))
+            (should (file-exists-p direct-file))
+            (should (equal content
+                           (with-temp-buffer
+                             (insert-file-contents direct-file)
+                             (buffer-string))))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest tramp-rpc-test19-multi-hop-directory-operations ()
+  "Test directory operations through multi-hop syntax."
+  :tags '(:expensive-test :multi-hop)
+  (skip-unless (tramp-rpc-test-multi-hop-enabled))
+
+  (let ((dir (tramp-rpc-test--make-multi-hop-temp-name)))
+    (unwind-protect
+        (progn
+          ;; Create directory through multi-hop
+          (make-directory dir)
+          (should (file-directory-p dir))
+          ;; Create a file inside
+          (let ((file (expand-file-name "test.txt" dir)))
+            (write-region "inside multi-hop dir" nil file)
+            (should (file-exists-p file)))
+          ;; List directory through multi-hop
+          (let ((files (directory-files dir)))
+            (should (member "test.txt" files))))
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest tramp-rpc-test19-multi-hop-distinct-connection ()
+  "Test that multi-hop and direct paths use distinct connections.
+The multi-hop path should have a different connection key and
+ControlMaster socket from the direct path to the same host."
+  :tags '(:multi-hop)
+  (skip-unless (tramp-rpc-test-multi-hop-enabled))
+
+  (let* ((direct-dir (tramp-rpc-test--remote-directory))
+         (hop-dir (tramp-rpc-test--multi-hop-remote-directory))
+         (direct-vec (tramp-dissect-file-name direct-dir))
+         (hop-vec (tramp-dissect-file-name hop-dir)))
+    ;; Connection keys must differ
+    (should-not (equal (tramp-rpc--connection-key direct-vec)
+                       (tramp-rpc--connection-key hop-vec)))
+    ;; ControlMaster socket paths must differ
+    (should-not (equal (tramp-rpc--controlmaster-socket-path direct-vec)
+                       (tramp-rpc--controlmaster-socket-path hop-vec)))
+    ;; But the target host/user should be the same
+    (should (equal (tramp-file-name-host direct-vec)
+                   (tramp-file-name-host hop-vec)))
+    (should (equal (tramp-file-name-user direct-vec)
+                   (tramp-file-name-user hop-vec)))))
+
+(ert-deftest tramp-rpc-test19-multi-hop-process-file ()
+  "Test process execution through multi-hop syntax."
+  :tags '(:expensive-test :multi-hop :process)
+  (skip-unless (tramp-rpc-test-multi-hop-enabled))
+
+  (let ((default-directory (file-name-as-directory
+                            (tramp-rpc-test--multi-hop-remote-directory))))
+    ;; Simple command
+    (should (= 0 (process-file "true")))
+    (should (= 1 (process-file "false")))
+    ;; Command with output
+    (with-temp-buffer
+      (process-file "echo" nil t nil "multi-hop-output")
+      (should (string-match-p "multi-hop-output" (buffer-string))))))
 
 ;;; ============================================================================
 ;;; Test Runner


### PR DESCRIPTION
TRAMP's tramp-multi-hop-p rejects methods with tramp-copy-program (scp, scpx, rsync) in multi-hop chains. When deploying the server binary through a multi-hop connection for the first time, the bootstrap vec used scpx by default, which caused TRAMP to error with 'Method scpx is not supported for multi-hops'.

Fall back to sshx (inline transfer) when the configured bootstrap method is out-of-band and hops are present. Direct connections continue using the configured method for faster transfer.

Also add end-to-end multi-hop tests: file I/O, directory ops, process execution, and connection key differentiation.