### PR TITLE
fix: create stderr cat relay in make-process to match native contract

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -226,16 +226,17 @@ STDERR-BUFFER is the separate stderr buffer, or nil to mix with stdout."
       ;; Deliver stderr
       (when (and stderr (> (length stderr) 0))
         (tramp-rpc--debug "DELIVER stderr %d bytes" (length stderr))
-        (cond
-         ((bufferp stderr-buffer)
-          (when (buffer-live-p stderr-buffer)
-            (with-current-buffer stderr-buffer
-              (let ((inhibit-read-only t))
-                (goto-char (point-max))
-                (insert stderr)))))
-         ;; Mix with stdout if no separate stderr buffer - write to cat relay
-         (t
-          (process-send-string local-process stderr)))))))
+        (let ((stderr-process
+               (when stderr-buffer
+                 (plist-get (gethash local-process tramp-rpc--async-processes)
+                            :stderr-process))))
+          (cond
+           ;; Write to stderr cat relay if available, triggering proper I/O events
+           ((and stderr-process (process-live-p stderr-process))
+            (process-send-string stderr-process stderr))
+           ;; Mix with stdout if no separate stderr buffer - write to cat relay
+           (t
+            (process-send-string local-process stderr))))))))
 
 (defun tramp-rpc--pipe-process-sentinel (proc event user-sentinel)
   "Sentinel for pipe relay processes.
@@ -261,6 +262,10 @@ process's exit status rather than cat's."
         (when (and vec pid)
           (ignore-errors
             (tramp-rpc--kill-remote-process vec pid 9))))
+      ;; Clean up stderr relay process
+      (when-let* ((stderr-process (plist-get info :stderr-process)))
+        (when (process-live-p stderr-process)
+          (ignore-errors (delete-process stderr-process))))
       ;; Remove from tracking
       (remhash proc tramp-rpc--async-processes)))
   ;; Use the remote exit code for the event string when available,
@@ -337,6 +342,10 @@ before the cat relay drains its pipe causes a stale FD that makes
       ;; `process-live-p' return nil and would prevent the EOF below
       ;; from being sent.
       (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
+      ;; Send EOF to the stderr cat relay so it exits cleanly.
+      (when-let* ((stderr-process (plist-get info :stderr-process)))
+        (when (process-live-p stderr-process)
+          (ignore-errors (process-send-eof stderr-process))))
       ;; Send EOF to the LOCAL cat relay (not the remote process).
       ;; Bind `tramp-rpc--closing-local-relay' so the `process-send-eof'
       ;; advice calls the original function instead of routing to the
@@ -444,7 +453,19 @@ Resolves program path and loads direnv environment from working directory."
                  (stderr-buffer (cond
                                  ((bufferp stderr) stderr)
                                  ((stringp stderr) (get-buffer-create stderr))
-                                 (t nil))))
+                                 (t nil)))
+                 ;; Create a stderr cat relay so that
+                 ;; (get-buffer-process stderr-buffer) returns a process,
+                 ;; matching the contract of native `make-process' with :stderr.
+                 (stderr-process
+                  (when stderr-buffer
+                    (let* ((process-connection-type nil)
+                           (proc (start-process
+                                  (format "%s-stderr" (or name "tramp-rpc-async"))
+                                  stderr-buffer
+                                  "cat")))
+                      (set-process-query-on-exit-flag proc nil)
+                      proc))))
 
           ;; Configure the local relay process
           (when coding
@@ -467,7 +488,8 @@ Resolves program path and loads direnv environment from working directory."
           (puthash local-process
                    (list :vec v
                          :pid remote-pid
-                         :stderr-buffer stderr-buffer)
+                         :stderr-buffer stderr-buffer
+                         :stderr-process stderr-process)
                    tramp-rpc--async-processes)
 
           (tramp-rpc--debug "MAKE-PROCESS created local=%s remote-pid=%s program=%s"
@@ -979,6 +1001,10 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
        ;; Cancel timer
        (when-let* ((timer (plist-get info :timer)))
          (cancel-timer timer))
+       ;; Kill stderr relay process
+       (when-let* ((stderr-process (plist-get info :stderr-process)))
+         (when (process-live-p stderr-process)
+           (ignore-errors (delete-process stderr-process))))
        ;; Kill local process
        (when (process-live-p local-process)
          (delete-process local-process))

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1252,10 +1252,118 @@ This matches the upstream `tramp-test28-process-file' test."
       (ignore-errors (delete-file file)))))
 
 ;;; ============================================================================
-;;; Test 18: Empty File Handling
+;;; Test 18: make-process :stderr contract (lsp-mode compatibility)
 ;;; ============================================================================
 
-(ert-deftest tramp-rpc-test18-empty-file ()
+(ert-deftest tramp-rpc-test18-make-process-stderr-buffer-has-process ()
+  "Test that make-process with :stderr creates a process on the stderr buffer.
+Native `make-process' with `:stderr BUFFER' creates a pipe process
+associated with that buffer, so `(get-buffer-process BUFFER)' returns
+a process object.  lsp-mode relies on this contract:
+
+  (set-process-query-on-exit-flag (get-buffer-process stderr-buf) nil)
+
+Without a stderr relay process, `get-buffer-process' returns nil and
+`set-process-query-on-exit-flag' signals `wrong-type-argument processp nil'.
+This is the root cause of the lsp-mode crash reported with tramp-rpc."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (stderr-buf (generate-new-buffer "*test-stderr*"))
+         (proc (make-process
+                :name "test-stderr-relay"
+                :command '("sh" "-c" "echo stdout-msg; echo stderr-msg >&2")
+                :connection-type 'pipe
+                :buffer (generate-new-buffer "*test-stdout*")
+                :stderr stderr-buf
+                :noquery t
+                :file-handler t)))
+    (unwind-protect
+        (progn
+          ;; KEY ASSERTION: get-buffer-process must return non-nil,
+          ;; exactly matching native make-process contract
+          (should (get-buffer-process stderr-buf))
+          ;; This is the exact call lsp-mode makes that crashed:
+          (should (progn
+                    (set-process-query-on-exit-flag
+                     (get-buffer-process stderr-buf) nil)
+                    t))
+          ;; Wait for the command to finish
+          (with-timeout (10 (error "Process timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          ;; Verify stderr output was delivered to the stderr buffer
+          (with-timeout (2 nil)
+            (while (= 0 (buffer-size stderr-buf))
+              (accept-process-output nil 0.1)))
+          (with-current-buffer stderr-buf
+            (should (string-match-p "stderr-msg" (buffer-string)))))
+      (ignore-errors (delete-process proc))
+      (ignore-errors (kill-buffer (process-buffer proc)))
+      (ignore-errors
+        (when-let* ((stderr-proc (get-buffer-process stderr-buf)))
+          (delete-process stderr-proc)))
+      (ignore-errors (kill-buffer stderr-buf)))))
+
+(ert-deftest tramp-rpc-test18-make-process-stderr-string ()
+  "Test that make-process with :stderr as a string also works."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (stderr-name "*test-stderr-string*")
+         (proc (make-process
+                :name "test-stderr-string"
+                :command '("sh" "-c" "echo stderr-out >&2; exit 0")
+                :connection-type 'pipe
+                :stderr stderr-name
+                :noquery t
+                :file-handler t)))
+    (unwind-protect
+        (progn
+          ;; Buffer should have been created
+          (should (get-buffer stderr-name))
+          ;; And should have a process
+          (should (get-buffer-process (get-buffer stderr-name)))
+          ;; Wait for completion
+          (with-timeout (10 (error "Process timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1))))
+      (ignore-errors (delete-process proc))
+      (ignore-errors
+        (when-let* ((buf (get-buffer stderr-name)))
+          (when-let* ((p (get-buffer-process buf)))
+            (delete-process p))
+          (kill-buffer buf))))))
+
+(ert-deftest tramp-rpc-test18-make-process-no-stderr ()
+  "Test that make-process without :stderr still works (no regression)."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (output "")
+         (proc (make-process
+                :name "test-no-stderr"
+                :command '("echo" "hello")
+                :connection-type 'pipe
+                :filter (lambda (_proc str) (setq output (concat output str)))
+                :noquery t
+                :file-handler t)))
+    (unwind-protect
+        (progn
+          (with-timeout (10 (error "Process timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          (should (string-match-p "hello" output)))
+      (ignore-errors (delete-process proc)))))
+
+;;; ============================================================================
+;;; Test 19: Empty File Handling
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test19-empty-file ()
   "Test handling of empty files."
   (skip-unless (tramp-rpc-test-enabled))
 


### PR DESCRIPTION
Native `make-process' with `:stderr buffer' creates a pipe process
associated with that buffer, so `(get-buffer-process stderr-buf)'
returns a process object.  tramp-rpc's handler was inserting stderr
directly into the buffer without an associated process, causing
callers like lsp-mode to crash when calling
`set-process-query-on-exit-flag' on the nil result.

Changes:
- Create a local cat relay process for stderr (same pattern used
  for stdout), associated with the stderr buffer
- Route stderr output through the relay via process-send-string
  instead of raw buffer insert, triggering proper I/O events
- Send EOF to stderr relay on process exit for clean shutdown
- Clean up stderr relay in sentinel and cleanup functions

Based on PR #89 by Yongwei Yuan.