### PR TITLE
fix: expand empty localname to home directory instead of root

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2231,10 +2231,19 @@ would otherwise flood the echo area with \"Cannot expand tilde\"."
   ;; The generic `tramp-handle-expand-file-name' defaults non-absolute
   ;; localnames to "/" (root), but the ssh handler
   ;; (`tramp-sh-handle-expand-file-name') defaults to "~/" instead.
-  ;; This matches that behavior.
-  (when (and (tramp-tramp-file-p name)
-             (tramp-string-empty-or-nil-p (tramp-file-local-name name)))
-    (setq name (concat (file-remote-p name) "~")))
+  ;; This matches that behavior when a connection is available.
+  ;; Guard with `tramp-connectable-p' so that the tilde substitution is
+  ;; skipped during completion when no connection exists, avoiding a
+  ;; blocking connection attempt when `non-essential' is t.  When not
+  ;; connectable the generic handler falls through to "/" (root) rather
+  ;; than the home directory — acceptable for the completion case.
+  ;; Use `tramp-dissect-file-name' and `tramp-make-tramp-file-name'
+  ;; instead of `file-remote-p' to avoid re-entering expand-file-name.
+  (when (tramp-tramp-file-p name)
+    (let ((v (tramp-dissect-file-name name)))
+      (when (and (tramp-string-empty-or-nil-p (tramp-file-name-localname v))
+                 (tramp-connectable-p v))
+        (setq name (tramp-make-tramp-file-name v "~")))))
   (condition-case nil
       (let ((tramp-verbose 0))
         (tramp-handle-expand-file-name name dir))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2226,6 +2226,15 @@ signalling an error.
 `tramp-verbose' is suppressed during the first attempt because
 `tramp-error' logs a level-1 message before signalling, which
 would otherwise flood the echo area with \"Cannot expand tilde\"."
+  ;; When NAME has an empty localname (e.g. "/rpc:host:"), replace it
+  ;; with "~" so that the generic handler expands to the home directory.
+  ;; The generic `tramp-handle-expand-file-name' defaults non-absolute
+  ;; localnames to "/" (root), but the ssh handler
+  ;; (`tramp-sh-handle-expand-file-name') defaults to "~/" instead.
+  ;; This matches that behavior.
+  (when (and (tramp-tramp-file-p name)
+             (tramp-string-empty-or-nil-p (tramp-file-local-name name)))
+    (setq name (concat (file-remote-p name) "~")))
   (condition-case nil
       (let ((tramp-verbose 0))
         (tramp-handle-expand-file-name name dir))

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1041,7 +1041,22 @@ and returns a valid path."
     (let ((expanded (expand-file-name "a/../b" dir)))
       (should (string-match-p "/b" expanded))
       (should-not (string-match-p "/a/" expanded))
-      (should (tramp-tramp-file-p expanded)))))
+      (should (tramp-tramp-file-p expanded)))
+
+    ;; Empty localname should expand to home directory, not root.
+    ;; This tests the fix for the inconsistency where "/rpc:host:" would
+    ;; resolve to "/" instead of "~" (GitHub issue #55).
+    (let* ((user-part (if tramp-rpc-test-user
+                          (concat tramp-rpc-test-user "@")
+                        ""))
+           (bare-remote (format "/rpc:%s%s:" user-part tramp-rpc-test-host))
+           (expanded (expand-file-name bare-remote)))
+      (should (tramp-tramp-file-p expanded))
+      ;; The expanded path should NOT be root "/"
+      (should-not (equal (tramp-file-local-name expanded) "/"))
+      ;; It should be the home directory (same as expanding "~")
+      (let ((home-expanded (expand-file-name (concat bare-remote "~"))))
+        (should (equal expanded home-expanded))))))
 
 ;;; ============================================================================
 ;;; Test 12: File Name Completion


### PR DESCRIPTION
## Summary

- Fixes `/rpc:host:` resolving to `/` (root) instead of the user's home directory, matching the behavior of `/ssh:host:` (closes #55)
- Before delegating to the generic `tramp-handle-expand-file-name`, replaces empty localname with `~` so tilde expansion resolves to the home directory
- Adds test to `tramp-rpc-test11-expand-file-name` verifying that `(expand-file-name "/rpc:host:")` equals `(expand-file-name "/rpc:host:~")`