### PR TITLE
fix: route rpc sudo elevation through ssh

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -36,6 +36,9 @@
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process")
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
 
+;; Functions from tramp-cmds.el
+(declare-function tramp-file-name-with-sudo "tramp-cmds")
+
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")
@@ -272,6 +275,42 @@ process-file calls are routed through the TRAMP handler."
       (apply orig-fun backend function-name args))))
 
 ;; ============================================================================
+;; Privilege elevation integration
+;; ============================================================================
+
+;; `tramp-file-name-with-sudo' assumes the current TRAMP method can participate
+;; directly in the elevated multi-hop path.  That does not hold for `rpc:'.
+;; Rewrite RPC-backed paths to elevate through an SSH hop instead.
+
+(defun tramp-rpc--file-name-with-sudo-via-ssh (filename)
+  "Build an elevated TRAMP file name for RPC-backed FILENAME via SSH."
+  (with-parsed-tramp-file-name (expand-file-name filename) nil
+    (let* ((sudo-method
+            (or (and (boundp 'tramp-file-name-with-method)
+                     tramp-file-name-with-method)
+                "sudo"))
+           (ssh-hop
+            (tramp-make-tramp-hop-name
+             (make-tramp-file-name :method "ssh" :user user :host host))))
+      (let ((tramp-show-ad-hoc-proxies t))
+        (tramp-make-tramp-file-name
+         (make-tramp-file-name
+          :method (tramp-find-method sudo-method nil host)
+          :user (tramp-find-user sudo-method nil host)
+          :host (tramp-find-host sudo-method nil host)
+          :localname localname
+          :hop ssh-hop))))))
+
+(defun tramp-rpc--file-name-with-sudo-advice (orig-fun filename)
+  "Route RPC-backed sudo elevation through SSH for FILENAME."
+  (let ((filename (expand-file-name filename)))
+    (if (and (tramp-tramp-file-p filename)
+             (with-parsed-tramp-file-name filename nil
+               (string= method "rpc")))
+        (tramp-rpc--file-name-with-sudo-via-ssh filename)
+      (funcall orig-fun filename))))
+
+;; ============================================================================
 ;; Eglot integration
 ;; ============================================================================
 
@@ -334,6 +373,9 @@ exited (remote side finished), delete it so the refresh can proceed."
   (advice-add 'process-command :around #'tramp-rpc--process-command-advice)
   (advice-add 'process-tty-name :around #'tramp-rpc--process-tty-name-advice)
   (advice-add 'vc-call-backend :around #'tramp-rpc--vc-call-backend-advice)
+  (with-eval-after-load 'tramp-cmds
+    (when (fboundp 'tramp-file-name-with-sudo)
+      (advice-add 'tramp-file-name-with-sudo :around #'tramp-rpc--file-name-with-sudo-advice)))
   (with-eval-after-load 'eglot
     (advice-add 'eglot--cmd :around #'tramp-rpc--eglot-cmd-advice))
   (with-eval-after-load 'vc-dir
@@ -350,6 +392,8 @@ exited (remote side finished), delete it so the refresh can proceed."
   (advice-remove 'process-command #'tramp-rpc--process-command-advice)
   (advice-remove 'process-tty-name #'tramp-rpc--process-tty-name-advice)
   (advice-remove 'vc-call-backend #'tramp-rpc--vc-call-backend-advice)
+  (when (fboundp 'tramp-file-name-with-sudo)
+    (advice-remove 'tramp-file-name-with-sudo #'tramp-rpc--file-name-with-sudo-advice))
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice))
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -498,6 +498,11 @@ Returns the result or signals an error."
      nil))
   "Non-nil if tramp-rpc.el loaded successfully.")
 
+(defun tramp-rpc-mock-test--sudo-helper-available-p ()
+  "Return non-nil when the sudo path helpers needed by this test are available."
+  (and (require 'tramp-cmds nil t)
+       (fboundp 'tramp-file-name-with-sudo)))
+
 (ert-deftest tramp-rpc-mock-test-multi-hop-advice ()
   "Test that tramp-multi-hop-p returns t for the rpc method."
   :tags '(:multi-hop)
@@ -694,6 +699,38 @@ Returns the result or signals an error."
       (should hop)
       (should (string-match-p "ssh:" hop))
       (should-not (string-match-p "rpc:" hop)))))
+
+(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-rpc-via-ssh ()
+  "Test that RPC sudo elevation is rewritten through an SSH hop."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let* ((tramp-file-name-with-method "sudo")
+         (filename (tramp-file-name-with-sudo "/rpc:user@target:/etc/hosts"))
+         (vec (tramp-dissect-file-name filename))
+         (hop (tramp-file-name-hop vec)))
+    (should (tramp-tramp-file-p filename))
+    (should (equal (tramp-file-name-localname vec) "/etc/hosts"))
+    (should hop)
+    (should (string-match-p (rx bos "ssh:") hop))
+    (should-not (string-match-p "rpc:" hop))
+    (should-not (string-match-p (rx bos "/rpc:") filename))))
+
+(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-non-rpc-passthrough ()
+  "Test that non-RPC sudo elevation still calls the original function."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let ((called-with nil)
+        (filename "/ssh:user@target:/etc/hosts"))
+    (should
+     (eq (tramp-rpc--file-name-with-sudo-advice
+          (lambda (arg)
+            (setq called-with arg)
+            'passthrough)
+          filename)
+         'passthrough))
+    (should (equal called-with (expand-file-name filename)))))
 
 ;;; ============================================================================
 ;;; Test Runner


### PR DESCRIPTION
## Summary

Fix privilege elevation for `rpc:` buffers by handling `tramp-file-name-with-sudo` in `tramp-rpc` instead of relying on
user-side config workarounds.

This rewrites RPC-backed elevation through an `ssh` hop, so paths like:

```
/rpc:user@host:/etc/hosts
```

elevate via the equivalent of:

```
/ssh:user@host|sudo:root@host:/etc/hosts
```

instead of constructing a broken rpc|sudo path.

Refs ArthurHeymans/emacs-tramp-rpc#104.

## Changes

- add tramp-file-name-with-sudo advice in tramp-rpc-advice.el
- rewrite rpc: privilege elevation through ssh
- keep non-rpc paths on the original code path
- add mock regression tests for:
    - rpc: sudo elevation
    - non-rpc passthrough behavior

## Why this belongs in tramp-rpc

tramp-rpc already adapts several generic TRAMP behaviors to RPC-specific semantics, including multi-hop support and hop
normalization for bootstrap/deploy paths.

This fix is the same class of integration work: tramp-cmds assumes the current backend method can participate directly in
the elevated hop chain, which does not hold for rpc:.

## Testing

emacs -Q --batch \
  -L /home/lucius/.emacs.d/straight/repos/msgpack.el \
  -L /home/lucius/emacs-tramp-rpc/lisp \
  -l /home/lucius/emacs-tramp-rpc/test/tramp-rpc-mock-tests.el \
  --eval "(ert-run-tests-batch-and-exit '(tag :multi-hop))"

Result: 23 tests passed, 0 unexpected.