### PR TITLE
fix: handle file-acl and file-selinux-context tests

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1632,7 +1632,7 @@ TYPE is the file type string."
         (set-file-times newname (file-attribute-modification-time
                                  (file-attributes filename))))
       (when preserve-permissions
-        (set-file-extended-attributs newname (file-extended-attributes
+        (set-file-extended-attributes newname (file-extended-attributes
 					      filename))))
      ;; Neither remote - should not reach this handler, but be safe.
      (t


### PR DESCRIPTION
## Summary

Patch from Michael Albinus fixing `tramp-test24-file-acl` and `tramp-test25-file-selinux`.

- Separate `keep-time` and `preserve-permissions` handling in `copy-file`: apply `set-file-extended-attributes` independently when `preserve-permissions` is set, rather than bundling both under a single `(or keep-time preserve-permissions)` check.
- Unquote filenames with `file-name-unquote` in `file-acl`, `set-file-acl`, `file-selinux-context`, and `set-file-selinux-context` handlers so quoted filenames are handled correctly.
- Ensure `file-acl` output includes a trailing newline per convention.

**Note:** The patch contains a typo in the third copy-file branch: `set-file-extended-attributs` (missing trailing 'e'). This is present in the original patch.