### PR TITLE
fix: force pipe mode for magit hunk staging over tramp-rpc

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -347,6 +347,10 @@ and handles binary data correctly."
 ;; correctly.  This advice forces pipe mode only for tramp-rpc connections
 ;; when input will be piped, leaving other TRAMP methods untouched.
 
+;; Declared special so the dynamic let-binding in the advice below
+;; is not flagged as an unused lexical variable by the byte-compiler.
+(defvar magit-tramp-pipe-stty-settings)
+
 (defun tramp-rpc--magit-start-process-advice (orig-fun program &optional input &rest args)
   "Force pipe mode for tramp-rpc when INPUT will be piped to the process.
 PTY mode breaks stdin piping because `process-send-eof' sends Ctrl-D


### PR DESCRIPTION
When magit-tramp-pipe-stty-settings is 'pty, magit forces PTY mode for all remote processes including git apply which reads a patch from stdin. On a PTY, process-send-eof sends Ctrl-D instead of closing the pipe. Ctrl-D only signals EOF when the terminal line buffer is empty, so git waits for more input forever — hanging Emacs.

Add advice on magit-start-process that let-binds
magit-tramp-pipe-stty-settings to "" when input will be piped and the connection uses the rpc method. Other TRAMP methods are unaffected.