### PR TITLE
Properly handle symlink directories in completions

### DIFF
--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -235,10 +235,19 @@ fn list_dir_sync(
 
         // Get file type - std::fs::DirEntry::file_type() uses d_type on Linux
         // (no extra syscall needed unless d_type is DT_UNKNOWN)
-        let file_type = match entry.file_type() {
+        let mut file_type = match entry.file_type() {
             Ok(ft) => file_type_from_metadata_ft(&ft),
             Err(_) => FileType::Unknown,
         };
+
+        // For completion paths (include_attrs=false), treat symlinks to
+        // directories as directories
+        if !include_attrs
+            && file_type == FileType::Symlink
+            && std::fs::metadata(entry.path()).is_ok_and(|m| m.is_dir())
+        {
+            file_type = FileType::Directory;
+        }
 
         let attrs = if include_attrs {
             // Use lstat (follow_symlinks=false) so symlinks show as symlinks

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1099,6 +1099,19 @@ This matches the upstream `tramp-test28-process-file' test."
       (should (member "file-aab.txt" completions))
       (should-not (member "other.txt" completions)))))
 
+(ert-deftest tramp-rpc-test12b-file-name-completion-symlink-directory ()
+  "Ensure completion marks symlinks to directories with trailing slash."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (tramp-rpc-test--with-temp-dir dir
+    (let ((real-dir (concat dir "/real-dir"))
+          (link-dir (concat dir "/link-dir")))
+      (make-directory real-dir t)
+      (make-symbolic-link "real-dir" link-dir)
+      (let ((completions (file-name-all-completions "" dir)))
+        (should (member "real-dir/" completions))
+        (should (member "link-dir/" completions))))))
+
 ;;; ============================================================================
 ;;; Test 13: File System Info
 ;;; ============================================================================


### PR DESCRIPTION
When using `file-name-all-completions`, symlinks to directories should be treated as directories and not files.