### PR TITLE
fix: add tramp-barf-if-file-missing to set-file-{modes,times,uid-gid}

### DIFF
--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -120,8 +120,10 @@
 
 ;; tramp-rpc supports external processes via process.run and process.start
 (setf (symbol-function #'tramp--test-supports-processes-p) #'always)
-;; tramp-rpc supports set-file-modes via file.chmod RPC
+;; tramp-rpc supports set-file-modes via file.set_modes RPC
 (setf (symbol-function #'tramp--test-supports-set-file-modes-p) #'always)
+;; tramp-rpc supports set-file-modes via file.set_times RPC
+(setf (symbol-function #'tramp--test-supports-set-file-times-p) #'always)
 
 (provide 'run-tramp-tests)
 ;;; run-tramp-tests.el ends here


### PR DESCRIPTION
Wrap tramp-rpc-handle-set-file-modes, tramp-rpc-handle-set-file-times,
and tramp-rpc-handle-set-file-uid-gid with tramp-barf-if-file-missing
so they properly signal when the target file does not exist, fixing
tramp-test22-file-times.

Also enable tramp--test-supports-set-file-times-p in the test runner
and fix the comment for set-file-modes (file.set_modes, not file.chmod).

This is a continuation.

Patch from Michael Albinus.