### PR TITLE
perf: use compression when copying files

### DIFF
--- a/benchmark/benchmark.el
+++ b/benchmark/benchmark.el
@@ -107,7 +107,32 @@
         (with-temp-buffer
           (insert (format "Test file %d\n" i))
           (insert (make-string 1000 ?x))
-          (write-region (point-min) (point-max) file))))))
+          (write-region (point-min) (point-max) file))))
+    ;; Create a 10MB fixture for large read benchmark.
+    (let ((file (tramp-rpc-benchmark--make-path method "file-large-10mb.txt")))
+      (with-temp-buffer
+        (let* ((chunk-size 8192)
+               (chunk (make-string chunk-size ?L))
+               (target-size (* 10 1024 1024))
+               (chunk-count (/ target-size chunk-size)))
+          (dotimes (_ chunk-count)
+            (insert chunk)))
+        (write-region (point-min) (point-max) file)))
+    ;; Create a 10MB high-entropy fixture (intentionally hard to compress).
+    ;; Keep it printable ASCII so both sshx and rpc can write it reliably.
+    (let ((file (tramp-rpc-benchmark--make-path method "file-large-10mb-random.bin")))
+      (with-temp-buffer
+        (let* ((chunk-size 8192)
+               (alphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+               (alphabet-len (length alphabet))
+               (chunk (make-string chunk-size ?A))
+               (target-size (* 10 1024 1024))
+               (chunk-count (/ target-size chunk-size)))
+          (dotimes (_ chunk-count)
+            (dotimes (i chunk-size)
+              (aset chunk i (aref alphabet (random alphabet-len))))
+            (insert chunk)))
+        (write-region (point-min) (point-max) file)))))
 
 (defun tramp-rpc-benchmark--teardown (method)
   "Clean up test environment for METHOD."
@@ -145,6 +170,22 @@
      (with-temp-buffer
        (insert-file-contents file)
        (buffer-string)))))
+
+(defun tramp-rpc-benchmark--file-read-10mb (method)
+  "Benchmark reading a 10MB file for METHOD."
+  (let ((file (tramp-rpc-benchmark--make-path method "file-large-10mb.txt")))
+    (tramp-rpc-benchmark--time
+     (with-temp-buffer
+       (insert-file-contents file)
+       (buffer-size)))))
+
+(defun tramp-rpc-benchmark--file-read-10mb-random (method)
+  "Benchmark reading a high-entropy 10MB file for METHOD."
+  (let ((file (tramp-rpc-benchmark--make-path method "file-large-10mb-random.bin")))
+    (tramp-rpc-benchmark--time
+     (with-temp-buffer
+       (insert-file-contents file)
+       (buffer-size)))))
 
 (defun tramp-rpc-benchmark--file-write (method)
   "Benchmark writing a file for METHOD."
@@ -267,6 +308,8 @@ Same operations as batch-mixed-ops but done one at a time."
     ("file-exists"        . tramp-rpc-benchmark--file-exists)
     ("file-attributes"    . tramp-rpc-benchmark--file-attributes)
     ("file-read"          . tramp-rpc-benchmark--file-read)
+    ("file-read-10mb"     . tramp-rpc-benchmark--file-read-10mb)
+    ("file-read-10mb-random" . tramp-rpc-benchmark--file-read-10mb-random)
     ("file-write"         . tramp-rpc-benchmark--file-write)
     ("directory-files"    . tramp-rpc-benchmark--directory-files)
     ("dir-files-attrs"    . tramp-rpc-benchmark--directory-files-and-attributes)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -231,6 +231,11 @@ Set to t to enable debugging for hang diagnosis."
   :type 'boolean
   :group 'tramp-rpc)
 
+(defcustom tramp-rpc-compress-file-read (fboundp 'zlib-decompress-region)
+  "When non-nil, use compression for file reads to enable faster transfers."
+  :type 'boolean
+  :group 'tramp-rpc)
+
 (defun tramp-rpc--debug (format-string &rest args)
   "Log a debug message to *tramp-rpc-debug* buffer if debugging is enabled.
 FORMAT-STRING and ARGS are passed to `format'."
@@ -240,6 +245,44 @@ FORMAT-STRING and ARGS are passed to `format'."
       (insert (format-time-string "[%Y-%m-%d %H:%M:%S.%3N] ")
               (apply #'format format-string args)
               "\n"))))
+
+(defun tramp-rpc--extract-file-read-content (rpc-result)
+  "Extract and optionally decompress content from FILE.READ RPC-RESULT.
+Signals `remote-file-error' on compressed payload decode failures."
+  (let ((content (if (stringp rpc-result)
+                     rpc-result
+                   (alist-get 'content rpc-result))))
+    (if (and (not (stringp rpc-result))
+             (alist-get 'compressed rpc-result))
+        (let ((compression (or (alist-get 'compression rpc-result) "zlib")))
+          (cond
+           ((and (string= compression "zlib")
+                 (fboundp 'zlib-decompress-region))
+            (condition-case err
+                (with-temp-buffer
+                  (set-buffer-multibyte nil)
+                  (insert content)
+                  (zlib-decompress-region (point-min) (point-max))
+                  (buffer-string))
+              (error
+               (signal 'remote-file-error
+                       (list "RPC"
+                             (format "zlib decompression failed: %s" err))))))
+           (t
+            (signal 'remote-file-error
+                    (list "RPC"
+                          (format "Unsupported file.read compression: %s" compression))))))
+      content)))
+
+(defun tramp-rpc--file-read-params (localname &optional force-uncompressed)
+  "Build params for `file.read' on LOCALNAME.
+When `tramp-rpc-compress-file-read' is non-nil, request compression unless
+FORCE-UNCOMPRESSED is non-nil."
+  (let ((params (tramp-rpc--encode-path localname)))
+    (when (and tramp-rpc-compress-file-read
+               (not force-uncompressed))
+      (push '(compress . t) params))
+    params))
 
 ;; ============================================================================
 ;; Connection management
@@ -2211,9 +2254,9 @@ Caches the PATH portion per connection."
 (defun tramp-rpc-handle-file-local-copy (filename)
   "Create a local copy of remote FILENAME using RPC."
   (tramp-skeleton-file-local-copy filename
-    (let* ((result (tramp-rpc--call v "file.read" (tramp-rpc--encode-path localname)))
-           ;; With MessagePack, content is already raw bytes
-           (content (alist-get 'content result)))
+    (let* ((params (tramp-rpc--file-read-params localname))
+           (result (tramp-rpc--call v "file.read" params))
+           (content (tramp-rpc--extract-file-read-content result)))
       (with-temp-file tmpfile
         (set-buffer-multibyte nil)
         (insert content)))))

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ rmpv.workspace = true
 serde_bytes.workspace = true
 tokio.workspace = true
 futures.workspace = true
+flate2 = "1.0"
 
 # For file operations
 libc = "0.2"

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -2,9 +2,11 @@
 
 use crate::msgpack_map;
 use crate::protocol::{from_value, RpcError};
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
 use rmpv::Value;
 use serde::Deserialize;
-use std::io::SeekFrom;
+use std::io::{SeekFrom, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tokio::fs::{self, File, OpenOptions};
@@ -27,6 +29,9 @@ pub async fn read(params: Value) -> HandlerResult {
         /// Maximum number of bytes to read (default: entire file)
         #[serde(default)]
         length: Option<usize>,
+        /// When true, zlib-compress payload bytes before sending.
+        #[serde(default)]
+        compress: bool,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -47,27 +52,52 @@ pub async fn read(params: Value) -> HandlerResult {
 
     // Read the content
     let content = if let Some(length) = params.length {
-        let mut buf = vec![0u8; length];
-        let bytes_read = file
-            .read(&mut buf)
+        // Read up to LENGTH bytes in a single pass. `take` keeps reads bounded.
+        let mut buf = Vec::with_capacity(length);
+        let mut reader = file.take(length as u64);
+        reader
+            .read_to_end(&mut buf)
             .await
             .map_err(|e| map_io_error(e, &path_str))?;
-        buf.truncate(bytes_read);
         buf
     } else {
+        // Pre-size from metadata to avoid repeated reallocations on large reads.
         let mut buf = Vec::new();
+        if let Ok(metadata) = file.metadata().await {
+            let mut expected_len = metadata.len() as usize;
+            if let Some(offset) = params.offset {
+                expected_len = expected_len.saturating_sub(offset as usize);
+            }
+            buf.reserve(expected_len);
+        }
         file.read_to_end(&mut buf)
             .await
             .map_err(|e| map_io_error(e, &path_str))?;
         buf
     };
 
-    // Return binary content directly (no base64!)
+    // Return binary content directly (no base64!). Compression is opt-in.
     let size = content.len();
-    Ok(msgpack_map! {
-        "content" => Value::Binary(content),
-        "size" => size
-    })
+    if params.compress {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::fast());
+        encoder
+            .write_all(&content)
+            .map_err(|e| RpcError::internal_error(format!("zlib write failed: {e}")))?;
+        let compressed = encoder
+            .finish()
+            .map_err(|e| RpcError::internal_error(format!("zlib finish failed: {e}")))?;
+        Ok(msgpack_map! {
+            "content" => Value::Binary(compressed),
+            "size" => size,
+            "compressed" => true,
+            "compression" => "zlib"
+        })
+    } else {
+        Ok(msgpack_map! {
+            "content" => Value::Binary(content),
+            "size" => size
+        })
+    }
 }
 
 /// Write file contents


### PR DESCRIPTION
closes #101 

This greatly speeds up reading files by enabling compression and avoiding reallocation on the server. It went from being much slower to much faster compared to ssh.

## Benchmarks

### `file-read-10mb` - easy to compress (5 iterations):
- sshx: 165.86ms
- rpc with compression: 111.57ms (vs sshx: 1.49x faster)
- rpc without compression: 1092.25ms (vs sshx: 0.15x, much slower)

### `file-read-10mb-random` - hard to compress (5 iterations):
- sshx: 1953.97ms
- rpc with compression: 944.72ms (vs sshx: 2.07x faster)
- rpc without compression: 1067.54ms (vs sshx: 1.83 faster)
