### PR TITLE
fix: align CI deploy path with tramp-rpc-deploy-remote-directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,8 +292,8 @@ jobs:
           # Extract version from elisp source (single source of truth)
           VERSION=$(grep -oP 'tramp-rpc-deploy-version "\K[^"]+' lisp/tramp-rpc-deploy.el)
           echo "Deploying version: $VERSION"
-          mkdir -p ~/.cache/tramp-rpc
-          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/tramp-rpc-server-${VERSION}
+          mkdir -p ~/.cache/emacs/tramp-rpc
+          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/emacs/tramp-rpc/tramp-rpc-server-${VERSION}
 
       - name: Install dependencies
         run: |
@@ -368,8 +368,8 @@ jobs:
         run: |
           VERSION=$(grep -oP 'tramp-rpc-deploy-version "\K[^"]+' lisp/tramp-rpc-deploy.el)
           echo "Deploying version: $VERSION"
-          mkdir -p ~/.cache/tramp-rpc
-          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/tramp-rpc/tramp-rpc-server-${VERSION}
+          mkdir -p ~/.cache/emacs/tramp-rpc
+          cp target/x86_64-unknown-linux-musl/release/tramp-rpc-server ~/.cache/emacs/tramp-rpc/tramp-rpc-server-${VERSION}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Commit a652673 changed tramp-rpc-deploy-remote-directory from
~/.cache/tramp-rpc to ~/.cache/emacs/tramp-rpc but the CI workflow
was not updated. This caused the Full Test Suite and Upstream Tramp
Tests to miss the CI-built binary and fall back to downloading the
release binary from GitHub, making server-side changes untestable.