### PR TITLE
fix: allow rpc method as proxy hop in sudo/su multi-hop chains

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -63,6 +63,16 @@
   ;; Register the method
   (add-to-list 'tramp-methods
                `(,tramp-rpc-method
+                 ;; Declare that the rpc method uses the host name.
+                 ;; tramp-compute-multi-hops validates that methods without
+                 ;; "%h" in tramp-login-args use a host matching the previous
+                 ;; hop.  Since rpc IS host-directed (it SSH-connects to the
+                 ;; specified host), advertising "%h" here lets rpc appear
+                 ;; as a proxy hop in chains like /rpc:server|sudo:root@server:/path
+                 ;; without triggering the "host does not match" error.
+                 ;; The actual tramp-login-args value is never used for login
+                 ;; because rpc is a foreign (non-tramp-sh) file handler.
+                 (tramp-login-args (("%h")))
                  ;; Direct async process support: tramp-rpc uses direct SSH
                  ;; PTY connections for async processes, which means stderr
                  ;; is mixed with stdout (normal PTY behavior).  Setting

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -806,6 +806,45 @@ This matches the behavior expected by `tramp-test28-process-file'."
          'passthrough))
     (should (equal called-with (expand-file-name filename)))))
 
+(ert-deftest tramp-rpc-mock-test-rpc-method-advertises-host-arg ()
+  "Test that the rpc method declares %%h in tramp-login-args.
+This is required so `tramp-compute-multi-hops' allows rpc to appear
+as a proxy hop alongside shell methods like sudo/su.  Without %%h,
+the host-check in `tramp-compute-multi-hops' would reject the rpc
+hop with \"Host name does not match\"."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "target"))
+         (login-args (tramp-get-method-parameter vec 'tramp-login-args)))
+    (should (member "%h" (flatten-tree login-args)))))
+
+(ert-deftest tramp-rpc-mock-test-compute-multi-hops-rpc-sudo-chain ()
+  "Test that `tramp-compute-multi-hops' accepts rpc as a proxy for sudo.
+Regression test for GitHub issue #123: `sudo-edit' on an rpc-backed
+file produced /rpc:server|sudo:root@server:/path, which then caused
+  user-error: Host name `server' does not match `localhost-regexp'
+because rpc had no tramp-login-args and the host-check in
+`tramp-compute-multi-hops' rejected it."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; Manually install the proxy entry that tramp-add-hops would create
+  ;; when processing /rpc:server|sudo:root@server:/path.
+  (let* ((tramp-default-proxies-alist
+          (list (list "^server$" "^root$"
+                      (propertize "/rpc:server:" 'tramp-ad-hoc t))))
+         (sudo-vec (make-tramp-file-name :method "sudo" :user "root"
+                                         :host "server"
+                                         :localname "/var/log/kern.log"))
+         result)
+    ;; Before the fix, tramp-compute-multi-hops would signal:
+    ;;   user-error: Host name `server' does not match `localhost-regexp'
+    ;; because the rpc item in target-alist had no %h in tramp-login-args.
+    (should (setq result (tramp-compute-multi-hops sudo-vec)))
+    ;; The chain should contain 2 elements: rpc proxy hop + sudo destination.
+    (should (= (length result) 2))
+    ;; The first element (gateway hop) should be the rpc method.
+    (should (string= (tramp-file-name-method (car result)) "rpc"))))
+
 ;;; ============================================================================
 ;;; Dir-locals advice tests (No server or SSH required)
 ;;; ============================================================================


### PR DESCRIPTION
tramp-compute-multi-hops validates that methods without %h in
tramp-login-args (e.g. sudo) must use a host matching the previous hop.
When rpc appeared in the proxy chain (e.g. /rpc:server|sudo:root@server:/path),
the check failed because rpc had no tramp-login-args at all, so the %h
member-check was false and 'server' did not match tramp-local-host-regexp.

Declare (tramp-login-args (("%h"))) on the rpc method to signal that it
connects to the specified host.  Since rpc is a foreign (non-tramp-sh)
handler these args are never used for actual login; they only satisfy the
host-check in tramp-compute-multi-hops.

Fixes: #123 (sudo-edit not working with tramp-rpc)