### PR TITLE
fix: set INSIDE_EMACS env var for remote child processes

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -46,6 +46,7 @@
 (declare-function tramp-rpc--decode-output "tramp-rpc")
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
+(declare-function tramp-rpc--ensure-inside-emacs-env "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el
@@ -394,8 +395,9 @@ Resolves program path and loads direnv environment from working directory."
     (with-parsed-tramp-file-name default-directory nil
       ;; Unquote localname in case of file-name-quoted paths (e.g. /: prefix).
       (setq localname (file-name-unquote localname))
-      ;; Get direnv environment for this directory
-      (let ((direnv-env (tramp-rpc--get-direnv-environment v localname)))
+      ;; Get direnv environment for this directory, with INSIDE_EMACS
+      (let ((direnv-env (tramp-rpc--ensure-inside-emacs-env
+                         (tramp-rpc--get-direnv-environment v localname))))
         (if use-pty
             ;; PTY mode - start async process with PTY
             (tramp-rpc--make-pty-process v name buffer command coding noquery

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -456,6 +456,15 @@ Otherwise clear all entries."
           (remhash key tramp-rpc--executable-cache)))
     (clrhash tramp-rpc--executable-cache)))
 
+(defun tramp-rpc--ensure-inside-emacs-env (env)
+  "Ensure INSIDE_EMACS is set in environment alist ENV.
+ENV is an alist of (KEY . VALUE) string pairs, or nil.
+If INSIDE_EMACS is not already present, it is added with the value
+from `tramp-inside-emacs'.  Returns the (possibly augmented) alist."
+  (if (assoc "INSIDE_EMACS" env)
+      env
+    (cons (cons "INSIDE_EMACS" (tramp-inside-emacs)) env)))
+
 (defun tramp-rpc--resolve-executable (vec program)
   "Resolve PROGRAM to its full path on VEC.
 Returns the full path if found, otherwise the original PROGRAM.
@@ -2164,19 +2173,19 @@ refresh), git commands are served from the prefetch cache when possible."
             exit-code)
         ;; Cache miss - make actual RPC call
         (let* ((resolved-program (tramp-rpc--resolve-executable v program))
-               (direnv-env (tramp-rpc--get-direnv-environment v localname))
+               (env (tramp-rpc--ensure-inside-emacs-env
+                     (tramp-rpc--get-direnv-environment v localname)))
                (stdin-content (when (and infile (not (eq infile t)))
-                                (with-temp-buffer
-                                  (set-buffer-multibyte nil)
-                                  (insert-file-contents-literally infile)
-                                  (buffer-string))))
+                                 (with-temp-buffer
+                                   (set-buffer-multibyte nil)
+                                   (insert-file-contents-literally infile)
+                                   (buffer-string))))
                (result (condition-case _err
                            (tramp-rpc--call v "process.run"
                                             `((cmd . ,resolved-program)
                                               (args . ,(vconcat args))
                                               (cwd . ,localname)
-                                              ,@(when direnv-env
-                                                  `((env . ,direnv-env)))
+                                              (env . ,env)
                                               ,@(when stdin-content
                                                   `((stdin . ,stdin-content)))))
                          ;; When the binary doesn't exist or can't be


### PR DESCRIPTION
## Summary

- Adds `tramp-rpc--ensure-inside-emacs-env` helper that injects `INSIDE_EMACS` into the environment alist using `tramp-inside-emacs` (e.g. `30.2,tramp:2.7.3.30.2`)
- Applies it to all 4 process-spawning paths: `process-file` (sync), `make-process` pipe mode, direct SSH PTY, and RPC PTY
- Matches behavior of original TRAMP's `tramp-sh.el` which sets `INSIDE_EMACS` via `setenv-internal` in every process path

Fixes #120