### PR TITLE
fix: use tramp-shell-quote-argument for paths that may contain tildes

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -891,10 +891,10 @@ This helps troubleshoot deployment issues."
         (let* ((dir tramp-rpc-deploy-remote-directory)
                (ssh-cmd (append
                          (list "ssh" "-o" "BatchMode=yes")
-                         (when user (list "-l" user))
-                         (list host (format "mkdir -p %s && test -w %s && echo 'WRITABLE'"
-                                            (shell-quote-argument dir)
-                                            (shell-quote-argument dir)))))
+                          (when user (list "-l" user))
+                          (list host (format "mkdir -p %s && test -w %s && echo 'WRITABLE'"
+                                             (tramp-shell-quote-argument dir)
+                                             (tramp-shell-quote-argument dir)))))
                (output (with-temp-buffer
                          (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd))
                          (buffer-string))))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -525,7 +525,7 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
                        " "))
          ;; Build the remote command - cd to dir, export env, exec program
          (remote-cmd (format "cd %s && %s exec %s %s"
-                             (shell-quote-argument localname)
+                             (tramp-shell-quote-argument localname)
                              env-exports
                              (shell-quote-argument program)
                              (mapconcat #'shell-quote-argument program-args " ")))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -408,7 +408,7 @@ See `tramp-rpc-direnv-essential-vars' for the list of variables."
       (let* ((result (tramp-rpc--call vec "process.run"
                                        `((cmd . "/bin/sh")
                                          (args . ["-l" "-c"
-                                                  ,(concat "cd " (shell-quote-argument directory)
+                                                  ,(concat "cd " (tramp-shell-quote-argument directory)
                                                            " && direnv export json 2>/dev/null")])
                                          (cwd . "/"))))
              (exit-code (alist-get 'exit_code result))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1009,6 +1009,41 @@ discard it for being unreadable."
     (should (equal recentf-list (list (abbreviate-file-name local-file))))))
 
 ;;; ============================================================================
+;;; Tilde Quoting Tests
+;;; ============================================================================
+
+;; Verify that paths passed to shell commands use `tramp-shell-quote-argument'
+;; (which preserves tilde expansion) rather than raw `shell-quote-argument'
+;; (which escapes the tilde and breaks cd ~/... on the remote).
+
+(ert-deftest tramp-rpc-mock-test-shell-quote-preserves-tilde ()
+  "Test that `tramp-shell-quote-argument' preserves leading tilde."
+  ;; tramp-shell-quote-argument is defined in tramp.el, always available.
+  (should (string-prefix-p "~/" (tramp-shell-quote-argument "~/projects")))
+  (should (equal "~" (tramp-shell-quote-argument "~")))
+  (should (string-prefix-p "~user/" (tramp-shell-quote-argument "~user/dir"))))
+
+(ert-deftest tramp-rpc-mock-test-shell-quote-tilde-vs-raw ()
+  "Demonstrate the bug: raw `shell-quote-argument' escapes tilde."
+  ;; raw shell-quote-argument escapes tilde (the bug this fix addresses)
+  (should (string-prefix-p "\\~" (shell-quote-argument "~/projects")))
+  ;; tramp-shell-quote-argument does not
+  (should-not (string-prefix-p "\\~" (tramp-shell-quote-argument "~/projects"))))
+
+(ert-deftest tramp-rpc-mock-test-shell-quote-absolute-path ()
+  "Test that absolute paths are quoted normally by both functions."
+  (should (equal (shell-quote-argument "/home/user/projects")
+                 (tramp-shell-quote-argument "/home/user/projects"))))
+
+(ert-deftest tramp-rpc-mock-test-shell-quote-path-with-spaces ()
+  "Test that paths with spaces after tilde are properly quoted."
+  (let ((quoted (tramp-shell-quote-argument "~/my projects")))
+    ;; Tilde should be preserved
+    (should (string-prefix-p "~/" quoted))
+    ;; The space should be escaped (backslash-space on Unix)
+    (should (string-match-p "\\\\ " quoted))))
+
+;;; ============================================================================
 ;;; Test Runner
 ;;; ============================================================================
 


### PR DESCRIPTION
## Summary

- Replace `shell-quote-argument` with `tramp-shell-quote-argument` at 3 call sites where paths can contain `~`, fixing broken tilde expansion on the remote shell
- Add ERT tests verifying tilde preservation behavior

## Problem

`shell-quote-argument` escapes `~` to `\~`, which prevents the remote shell from expanding it. This breaks `cd ~/...` commands in:
- Direct SSH PTY process creation (`tramp-rpc-process.el`)
- Direnv environment fetching (`tramp-rpc.el`)
- Deploy diagnostics (`tramp-rpc-deploy.el`, where the default directory is `~/.cache/emacs/tramp-rpc`)

## Fix

Upstream TRAMP already solved this with `tramp-shell-quote-argument` (defined in `tramp.el`), which calls `shell-quote-argument` then strips the leading backslash from `\~`. This is already used in 9 places in `tramp-rpc-deploy.el`. This PR makes the remaining 3 sites consistent.

Supersedes #129 — same bug, simpler fix that reuses existing TRAMP infrastructure instead of inline quoting logic.

Closes #129