### PR TITLE
fix: retry getpwuid_r/getgrgid_r on ERANGE for LDAP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +89,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -98,6 +116,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fsevent-sys"
@@ -198,6 +222,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +292,12 @@ checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kqueue"
@@ -238,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +341,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -340,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +450,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -368,6 +478,12 @@ checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -409,6 +525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +545,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -455,6 +590,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -501,6 +649,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +701,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_bytes",
+ "tempfile",
  "tokio",
 ]
 
@@ -548,6 +710,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "walkdir"
@@ -564,6 +732,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi-util"
@@ -728,3 +948,97 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,3 +27,6 @@ nix = { version = "0.29", features = ["term", "process", "signal", "fs"] }
 
 # For filesystem watching (inotify on Linux, kqueue on macOS)
 notify = "6.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -332,22 +332,23 @@ mod tests {
         );
     }
 
-    /// An extremely large uid that almost certainly has no passwd entry
-    /// should return None rather than panicking or looping forever.
+    /// A uid that almost certainly has no passwd entry should return
+    /// None rather than panicking or looping forever.
+    /// Note: 0xFFFF_FFFE (-2 signed) is macOS's `nobody`, so we use
+    /// 0x7FFF_FFFE which is unused on both Linux and macOS.
     #[test]
     fn test_get_user_name_unknown_uid() {
-        // 0xFFFF_FFFE is almost guaranteed to have no passwd entry.
-        let name = get_user_name(0xFFFF_FFFE);
+        let name = get_user_name(0x7FFF_FFFE);
         assert!(
             name.is_none(),
             "get_user_name for a non-existent uid should return None"
         );
     }
 
-    /// An extremely large gid should return None.
+    /// A gid that almost certainly has no group entry should return None.
     #[test]
     fn test_get_group_name_unknown_gid() {
-        let name = get_group_name(0xFFFF_FFFE);
+        let name = get_group_name(0x7FFF_FFFE);
         assert!(
             name.is_none(),
             "get_group_name for a non-existent gid should return None"

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -365,10 +365,7 @@ mod tests {
     #[test]
     fn test_get_group_name_root() {
         let name = get_group_name(0);
-        assert!(
-            name.is_some(),
-            "gid 0 should always have a group entry"
-        );
+        assert!(name.is_some(), "gid 0 should always have a group entry");
     }
 
     /// Repeated lookups should hit the cache and return the same value.

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -126,15 +126,45 @@ fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
 static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, String>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Get user name from uid using thread-safe getpwuid_r
-pub fn get_user_name(uid: u32) -> Option<String> {
-    let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-
-    if let Some(result) = cache.get(&uid) {
-        Some(result.clone())
+/// Initial buffer size hint from sysconf, or a reasonable default.
+fn sysconf_bufsize(name: libc::c_int, fallback: usize) -> usize {
+    let ret = unsafe { libc::sysconf(name) };
+    if ret > 0 {
+        ret as usize
     } else {
-        // Use getpwuid_r (reentrant) instead of getpwuid for thread safety
-        let mut buf = vec![0u8; 1024];
+        fallback
+    }
+}
+
+/// Maximum buffer size we will attempt before giving up (1 MiB).
+/// Used for both getpwuid_r and getgrgid_r retry loops.
+const MAX_NSS_BUFSIZE: usize = 1024 * 1024;
+
+/// Get user name from uid using thread-safe getpwuid_r.
+///
+/// Uses `sysconf(_SC_GETPW_R_SIZE_MAX)` for the initial buffer size and
+/// retries with a doubled buffer on `ERANGE`, which can happen when user
+/// records are served by LDAP or other NSS backends that return large
+/// entries.
+///
+/// The mutex is only held for cache lookups/inserts, not during the
+/// (potentially slow) NSS syscall, to avoid blocking other threads
+/// when the directory backend is slow.
+pub fn get_user_name(uid: u32) -> Option<String> {
+    // Fast path: check cache under lock, release immediately.
+    {
+        let cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(result) = cache.get(&uid) {
+            return Some(result.clone());
+        }
+    }
+
+    // Slow path: perform the syscall without holding the lock.
+    let init_size = sysconf_bufsize(libc::_SC_GETPW_R_SIZE_MAX, 1024);
+    let mut bufsize = init_size;
+
+    let name = loop {
+        let mut buf = vec![0u8; bufsize];
         let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
         let mut result_ptr: *mut libc::passwd = std::ptr::null_mut();
 
@@ -148,31 +178,55 @@ pub fn get_user_name(uid: u32) -> Option<String> {
             )
         };
 
+        if ret == libc::ERANGE && bufsize < MAX_NSS_BUFSIZE {
+            bufsize = bufsize.saturating_mul(2).min(MAX_NSS_BUFSIZE);
+            continue;
+        }
+
         if ret != 0 || result_ptr.is_null() {
             return None;
         }
 
-        let name = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
-        name.to_str().ok().map(|s| {
-            let result = s.to_string();
-            cache.insert(uid, result.clone());
-            result
-        })
+        let cname = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
+        break cname.to_str().ok().map(|s| s.to_string());
+    };
+
+    // Re-acquire lock to insert into cache.
+    if let Some(ref n) = name {
+        let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+        cache.insert(uid, n.clone());
     }
+
+    name
 }
 
 static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, String>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Get group name from gid using thread-safe getgrgid_r
+/// Get group name from gid using thread-safe getgrgid_r.
+///
+/// Uses `sysconf(_SC_GETGR_R_SIZE_MAX)` for the initial buffer size and
+/// retries with a doubled buffer on `ERANGE`, which can happen when group
+/// records are served by LDAP or other NSS backends that return large
+/// entries (e.g. groups with many members).
+///
+/// The mutex is only held for cache lookups/inserts, not during the
+/// (potentially slow) NSS syscall.
 pub fn get_group_name(gid: u32) -> Option<String> {
-    let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+    // Fast path: check cache under lock, release immediately.
+    {
+        let cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(result) = cache.get(&gid) {
+            return Some(result.clone());
+        }
+    }
 
-    if let Some(result) = cache.get(&gid) {
-        Some(result.clone())
-    } else {
-        // Use getgrgid_r (reentrant) instead of getgrgid for thread safety
-        let mut buf = vec![0u8; 1024];
+    // Slow path: perform the syscall without holding the lock.
+    let init_size = sysconf_bufsize(libc::_SC_GETGR_R_SIZE_MAX, 1024);
+    let mut bufsize = init_size;
+
+    let name = loop {
+        let mut buf = vec![0u8; bufsize];
         let mut grp: libc::group = unsafe { std::mem::zeroed() };
         let mut result_ptr: *mut libc::group = std::ptr::null_mut();
 
@@ -186,17 +240,26 @@ pub fn get_group_name(gid: u32) -> Option<String> {
             )
         };
 
+        if ret == libc::ERANGE && bufsize < MAX_NSS_BUFSIZE {
+            bufsize = bufsize.saturating_mul(2).min(MAX_NSS_BUFSIZE);
+            continue;
+        }
+
         if ret != 0 || result_ptr.is_null() {
             return None;
         }
 
-        let name = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };
-        name.to_str().ok().map(|s| {
-            let result = s.to_string();
-            cache.insert(gid, result.clone());
-            result
-        })
+        let cname = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };
+        break cname.to_str().ok().map(|s| s.to_string());
+    };
+
+    // Re-acquire lock to insert into cache.
+    if let Some(ref n) = name {
+        let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+        cache.insert(gid, n.clone());
     }
+
+    name
 }
 
 pub fn map_io_error(err: std::io::Error, path: &str) -> RpcError {
@@ -232,3 +295,152 @@ fn expand_tilde_path(path: &Path) -> PathBuf {
 }
 
 use crate::protocol::path_or_bytes;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify get_user_name resolves the current process uid.
+    /// This must succeed on any system -- the running user always has
+    /// a passwd entry (local or NSS/LDAP).
+    #[test]
+    fn test_get_user_name_current_uid() {
+        let uid = unsafe { libc::getuid() };
+        let name = get_user_name(uid);
+        assert!(
+            name.is_some(),
+            "get_user_name({uid}) should resolve the current user"
+        );
+        assert!(
+            !name.as_ref().unwrap().is_empty(),
+            "resolved name should be non-empty"
+        );
+    }
+
+    /// Verify get_group_name resolves the current process gid.
+    #[test]
+    fn test_get_group_name_current_gid() {
+        let gid = unsafe { libc::getgid() };
+        let name = get_group_name(gid);
+        assert!(
+            name.is_some(),
+            "get_group_name({gid}) should resolve the current group"
+        );
+        assert!(
+            !name.as_ref().unwrap().is_empty(),
+            "resolved name should be non-empty"
+        );
+    }
+
+    /// An extremely large uid that almost certainly has no passwd entry
+    /// should return None rather than panicking or looping forever.
+    #[test]
+    fn test_get_user_name_unknown_uid() {
+        // 0xFFFF_FFFE is almost guaranteed to have no passwd entry.
+        let name = get_user_name(0xFFFF_FFFE);
+        assert!(
+            name.is_none(),
+            "get_user_name for a non-existent uid should return None"
+        );
+    }
+
+    /// An extremely large gid should return None.
+    #[test]
+    fn test_get_group_name_unknown_gid() {
+        let name = get_group_name(0xFFFF_FFFE);
+        assert!(
+            name.is_none(),
+            "get_group_name for a non-existent gid should return None"
+        );
+    }
+
+    /// Verify root (uid 0) resolves to "root".
+    #[test]
+    fn test_get_user_name_root() {
+        let name = get_user_name(0);
+        assert_eq!(name.as_deref(), Some("root"));
+    }
+
+    /// Verify gid 0 resolves (usually "root" or "wheel").
+    #[test]
+    fn test_get_group_name_root() {
+        let name = get_group_name(0);
+        assert!(
+            name.is_some(),
+            "gid 0 should always have a group entry"
+        );
+    }
+
+    /// Repeated lookups should hit the cache and return the same value.
+    #[test]
+    fn test_user_name_caching() {
+        let uid = unsafe { libc::getuid() };
+        let first = get_user_name(uid);
+        let second = get_user_name(uid);
+        assert_eq!(first, second, "cached lookup should match initial lookup");
+    }
+
+    /// Repeated group lookups should hit the cache.
+    #[test]
+    fn test_group_name_caching() {
+        let gid = unsafe { libc::getgid() };
+        let first = get_group_name(gid);
+        let second = get_group_name(gid);
+        assert_eq!(first, second, "cached lookup should match initial lookup");
+    }
+
+    /// sysconf_bufsize should return a positive value for _SC_GETPW_R_SIZE_MAX.
+    #[test]
+    fn test_sysconf_bufsize_pw() {
+        let size = sysconf_bufsize(libc::_SC_GETPW_R_SIZE_MAX, 1024);
+        assert!(size > 0, "sysconf should return a positive buffer size");
+    }
+
+    /// sysconf_bufsize should return a positive value for _SC_GETGR_R_SIZE_MAX.
+    #[test]
+    fn test_sysconf_bufsize_gr() {
+        let size = sysconf_bufsize(libc::_SC_GETGR_R_SIZE_MAX, 1024);
+        assert!(size > 0, "sysconf should return a positive buffer size");
+    }
+
+    /// sysconf_bufsize should return the fallback for an invalid argument.
+    #[test]
+    fn test_sysconf_bufsize_fallback() {
+        // -1 is not a valid sysconf name, so it should return the fallback.
+        let size = sysconf_bufsize(-1, 4096);
+        assert_eq!(size, 4096, "invalid sysconf should return fallback");
+    }
+
+    /// Verify that file.stat via the RPC handler returns uname/gname for
+    /// a file owned by the current user (e.g. /tmp which is world-writable,
+    /// so we create a temp file to be certain of ownership).
+    #[tokio::test]
+    async fn test_stat_returns_user_group_names() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        write!(tmp, "test").unwrap();
+
+        let path = tmp.path();
+        let attrs = get_file_attributes(path, false)
+            .await
+            .expect("stat should succeed");
+
+        assert!(
+            attrs.uname.is_some(),
+            "stat should resolve user name, got uid={}",
+            attrs.uid
+        );
+        assert!(
+            attrs.gname.is_some(),
+            "stat should resolve group name, got gid={}",
+            attrs.gid
+        );
+
+        let expected_uid = unsafe { libc::getuid() };
+        assert_eq!(attrs.uid, expected_uid);
+        assert_eq!(
+            attrs.uname.as_deref(),
+            get_user_name(expected_uid).as_deref()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Use `sysconf(_SC_GETPW_R_SIZE_MAX)` / `_SC_GETGR_R_SIZE_MAX` for the initial buffer size instead of a hardcoded 1024 bytes, and retry with a doubled buffer on `ERANGE` (up to 1 MiB cap). This fixes user/group name resolution on LDAP-backed systems where NSS entries can exceed 1024 bytes.
- Restructure mutex usage so the lock is only held during cache check/insert, not during the potentially slow NSS syscall, preventing thread contention on slow directory backends.
- Add 11 unit tests covering name resolution, unknown IDs, caching, sysconf helper, and end-to-end `file.stat` integration.

Closes #130