### PR TITLE
fix: rewrite rpc hops to ssh in tramp-sh multi-hop chains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,11 @@ jobs:
         with:
           version: '30.1'
 
+      - name: Clone upstream tramp
+        run: |
+          git clone --depth 1 https://github.com/emacsmirror/tramp.git ~/src/tramp
+          echo "Tramp commit: $(git -C ~/src/tramp rev-parse HEAD)"
+
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do
@@ -192,6 +197,8 @@ jobs:
       - name: Run multi-hop tests
         run: |
           emacs -Q --batch \
+            -L lisp \
+            -L ~/src/tramp/lisp \
             --eval "(require 'package)" \
             --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
             --eval "(package-initialize)" \

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -396,7 +396,7 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-add 'process-command :around #'tramp-rpc--process-command-advice)
   (advice-add 'process-tty-name :around #'tramp-rpc--process-tty-name-advice)
   (advice-add 'vc-call-backend :around #'tramp-rpc--vc-call-backend-advice)
-(with-eval-after-load 'eglot
+  (with-eval-after-load 'eglot
     (advice-add 'eglot--cmd :around #'tramp-rpc--eglot-cmd-advice))
   (with-eval-after-load 'vc-dir
     (advice-add 'vc-dir-refresh :around #'tramp-rpc--vc-dir-refresh-advice))
@@ -417,7 +417,7 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'process-command #'tramp-rpc--process-command-advice)
   (advice-remove 'process-tty-name #'tramp-rpc--process-tty-name-advice)
   (advice-remove 'vc-call-backend #'tramp-rpc--vc-call-backend-advice)
-(advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
+  (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -280,19 +280,23 @@ process-file calls are routed through the TRAMP handler."
 ;; ============================================================================
 
 ;; `tramp-file-name-with-sudo' assumes the current TRAMP method can participate
-;; directly in the elevated multi-hop path.  That does not hold for `rpc:'.
-;; Rewrite RPC-backed paths to elevate through an SSH hop instead.
+;; directly in the elevated multi-hop path.  For `rpc:', we build an
+;; /rpc:user@host|sudo:root@host:/path path that the tramp-rpc handler
+;; intercepts.  The RPC server is started via sudo, giving full RPC
+;; performance for privilege-elevated file operations.
 
-(defun tramp-rpc--file-name-with-sudo-via-ssh (filename)
-  "Build an elevated TRAMP file name for RPC-backed FILENAME via SSH."
+(defun tramp-rpc--file-name-with-sudo-via-rpc (filename)
+  "Build an elevated TRAMP file name for RPC-backed FILENAME.
+Produces /rpc:user@host|sudo:root@host:/path which is intercepted
+by the tramp-rpc handler and served via a sudo-launched RPC server."
   (with-parsed-tramp-file-name (expand-file-name filename) nil
     (let* ((sudo-method
             (or (and (boundp 'tramp-file-name-with-method)
                      tramp-file-name-with-method)
                 "sudo"))
-           (ssh-hop
+           (rpc-hop
             (tramp-make-tramp-hop-name
-             (make-tramp-file-name :method "ssh" :user user :host host))))
+             (make-tramp-file-name :method "rpc" :user user :host host))))
       (let ((tramp-show-ad-hoc-proxies t))
         (tramp-make-tramp-file-name
          (make-tramp-file-name
@@ -300,15 +304,15 @@ process-file calls are routed through the TRAMP handler."
           :user (tramp-find-user sudo-method nil host)
           :host (tramp-find-host sudo-method nil host)
           :localname localname
-          :hop ssh-hop))))))
+          :hop rpc-hop))))))
 
 (defun tramp-rpc--file-name-with-sudo-advice (orig-fun filename)
-  "Route RPC-backed sudo elevation through SSH for FILENAME."
+  "Route RPC-backed sudo elevation through RPC for FILENAME."
   (let ((filename (expand-file-name filename)))
     (if (and (tramp-tramp-file-p filename)
              (with-parsed-tramp-file-name filename nil
                (string= method "rpc")))
-        (tramp-rpc--file-name-with-sudo-via-ssh filename)
+        (tramp-rpc--file-name-with-sudo-via-rpc filename)
       (funcall orig-fun filename))))
 
 ;; ============================================================================

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -38,7 +38,6 @@
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
 
 ;; Functions from tramp-cmds.el
-(declare-function tramp-file-name-with-sudo "tramp-cmds")
 
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
@@ -278,44 +277,6 @@ process-file calls are routed through the TRAMP handler."
 ;; ============================================================================
 ;; Privilege elevation integration
 ;; ============================================================================
-
-;; `tramp-file-name-with-sudo' assumes the current TRAMP method can participate
-;; directly in the elevated multi-hop path.  For `rpc:', we build an
-;; /rpc:user@host|sudo:root@host:/path path that the tramp-rpc handler
-;; intercepts.  The RPC server is started via sudo, giving full RPC
-;; performance for privilege-elevated file operations.
-
-(defun tramp-rpc--file-name-with-sudo-via-rpc (filename)
-  "Build an elevated TRAMP file name for RPC-backed FILENAME.
-Produces /rpc:user@host|sudo:root@host:/path which is intercepted
-by the tramp-rpc handler and served via a sudo-launched RPC server."
-  (with-parsed-tramp-file-name (expand-file-name filename) nil
-    (let* ((sudo-method
-            (or (and (boundp 'tramp-file-name-with-method)
-                     tramp-file-name-with-method)
-                "sudo"))
-           (rpc-hop
-            (tramp-make-tramp-hop-name
-             (make-tramp-file-name :method "rpc" :user user :host host))))
-      (let ((tramp-show-ad-hoc-proxies t))
-        (tramp-make-tramp-file-name
-         (make-tramp-file-name
-          :method (tramp-find-method sudo-method nil host)
-          :user (tramp-find-user sudo-method nil host)
-          :host (tramp-find-host sudo-method nil host)
-          :localname localname
-          :hop rpc-hop))))))
-
-(defun tramp-rpc--file-name-with-sudo-advice (orig-fun filename)
-  "Route RPC-backed sudo elevation through RPC for FILENAME."
-  (let ((filename (expand-file-name filename)))
-    (if (and (tramp-tramp-file-p filename)
-             (with-parsed-tramp-file-name filename nil
-               (string= method "rpc")))
-        (tramp-rpc--file-name-with-sudo-via-rpc filename)
-      (funcall orig-fun filename))))
-
-;; ============================================================================
 ;; Eglot integration
 ;; ============================================================================
 
@@ -435,10 +396,7 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-add 'process-command :around #'tramp-rpc--process-command-advice)
   (advice-add 'process-tty-name :around #'tramp-rpc--process-tty-name-advice)
   (advice-add 'vc-call-backend :around #'tramp-rpc--vc-call-backend-advice)
-  (with-eval-after-load 'tramp-cmds
-    (when (fboundp 'tramp-file-name-with-sudo)
-      (advice-add 'tramp-file-name-with-sudo :around #'tramp-rpc--file-name-with-sudo-advice)))
-  (with-eval-after-load 'eglot
+(with-eval-after-load 'eglot
     (advice-add 'eglot--cmd :around #'tramp-rpc--eglot-cmd-advice))
   (with-eval-after-load 'vc-dir
     (advice-add 'vc-dir-refresh :around #'tramp-rpc--vc-dir-refresh-advice))
@@ -459,9 +417,7 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'process-command #'tramp-rpc--process-command-advice)
   (advice-remove 'process-tty-name #'tramp-rpc--process-tty-name-advice)
   (advice-remove 'vc-call-backend #'tramp-rpc--vc-call-backend-advice)
-  (when (fboundp 'tramp-file-name-with-sudo)
-    (advice-remove 'tramp-file-name-with-sudo #'tramp-rpc--file-name-with-sudo-advice))
-  (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
+(advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -102,6 +102,17 @@
     (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename)))
       (string= (tramp-file-name-method vec) tramp-rpc-method)))
 
+  ;; Detect privilege elevation paths with rpc hops, e.g.
+  ;; /rpc:user@host|sudo:root@host:/path.  These are handled by the
+  ;; tramp-rpc handler which starts the RPC server via sudo.
+  (defsubst tramp-rpc--sudo-file-name-p (vec-or-filename)
+    "Check if VEC-OR-FILENAME is a privilege elevation with an rpc hop."
+    (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename))
+                (hop (tramp-file-name-hop vec)))
+      (and (string-match-p "rpc:" hop)
+           (member (tramp-file-name-method vec)
+                   '("sudo" "su" "doas" "sg" "run0" "ksu")))))
+
   ;; Register the foreign handler directly in the alist.  We cannot use
   ;; `tramp-register-foreign-file-name-handler' here because it tries to
   ;; read `tramp-rpc-file-name-handler-alist' (defined in the full file),
@@ -109,6 +120,9 @@
   ;; stub that triggers loading of tramp-rpc.el on first use.
   (add-to-list 'tramp-foreign-file-name-handler-alist
                '(tramp-rpc-file-name-p . tramp-rpc-file-name-handler))
+  ;; sudo+rpc handler must be checked, maps to the same handler.
+  (add-to-list 'tramp-foreign-file-name-handler-alist
+               '(tramp-rpc--sudo-file-name-p . tramp-rpc-file-name-handler))
 
   ;; Configure user and host name completion.
   (tramp-set-completion-function "rpc" tramp-completion-function-alist-ssh)
@@ -118,8 +132,13 @@
   ;; which would cause `tramp-dissect-file-name' to reject filenames like
   ;; /rpc:hop|rpc:target:/path.  We advise it to also accept "rpc".
   (defun tramp-rpc--multi-hop-advice (orig-fun vec)
-    "Allow the rpc method in multi-hop chains."
+    "Allow the rpc method and rpc+sudo paths in multi-hop chains."
     (or (string= (tramp-file-name-method vec) tramp-rpc-method)
+        ;; Also allow privilege elevation methods when the hop contains rpc
+        (when-let* ((hop (tramp-file-name-hop vec)))
+          (and (string-match-p "rpc:" hop)
+               (member (tramp-file-name-method vec)
+                       '("sudo" "su" "doas" "sg" "run0" "ksu"))))
         (funcall orig-fun vec)))
   (advice-add 'tramp-multi-hop-p :around #'tramp-rpc--multi-hop-advice)))
 
@@ -129,8 +148,68 @@
 (require 'tramp-sh)
 (require 'tramp-rpc-protocol)
 
-;; Silence byte-compiler warning for function defined in with-eval-after-load
+;; Give the rpc method all ssh connection parameters so it can serve
+;; as a hop in tramp-sh multi-hop chains (e.g.
+;; /rpc:host|sudo:root@host:/path).  For single-hop rpc, the foreign
+;; handler takes over and these parameters are never used.  This is
+;; future-proof: if ssh's parameters change in future TRAMP versions,
+;; rpc automatically inherits the updates.
+;; Suggested by Michael Albinus.
+(when-let* ((ssh-params (alist-get "ssh" tramp-methods nil nil #'equal))
+            (rpc-entry (assoc tramp-rpc-method tramp-methods)))
+  (setcdr rpc-entry ssh-params))
+
+;; Silence byte-compiler warnings for functions defined in with-eval-after-load
 (declare-function tramp-rpc--multi-hop-advice "tramp-rpc")
+(declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
+
+;; ============================================================================
+;; Sudo-via-RPC: detect privilege elevation from hop chains
+;; ============================================================================
+
+(defun tramp-rpc--detect-sudo-elevation (vec)
+  "Return the SSH user if VEC needs sudo elevation via RPC, or nil.
+Detects when the hop chain has an rpc hop to the same host as the
+target but with a different user, indicating privilege elevation.
+For /rpc:user@host|sudo:root@host:/path, returns \"user\"."
+  (when-let* ((hop (tramp-file-name-hop vec))
+              (target-host (tramp-file-name-host vec)))
+    (let ((hops (split-string hop tramp-postfix-hop-regexp 'omit))
+          result)
+      ;; Walk hops in reverse (closest to target first) looking for
+      ;; an rpc hop to the same host.
+      (dolist (hop-str (reverse hops))
+        (unless result
+          (let* ((hop-name (concat tramp-prefix-format hop-str
+                                   tramp-postfix-host-format))
+                 (hop-vec (tramp-dissect-file-name hop-name 'nodefault)))
+            (when (and (string= (tramp-file-name-method hop-vec) "rpc")
+                       (string= (tramp-file-name-host hop-vec) target-host))
+              (setq result (or (tramp-file-name-user hop-vec)
+                               (user-login-name)))))))
+      result)))
+
+(defun tramp-rpc--proxy-hop-string (vec)
+  "Return VEC's hop string with same-host sudo hops removed.
+For /rpc:gw|rpc:user@host|sudo:root@host:/path, returns \"rpc:gw|\".
+Returns nil if no proxy hops remain."
+  (when-let* ((hop (tramp-file-name-hop vec))
+              (target-host (tramp-file-name-host vec)))
+    (let ((hops (split-string hop tramp-postfix-hop-regexp 'omit))
+          proxy-hops)
+      (dolist (hop-str hops)
+        (let* ((hop-name (concat tramp-prefix-format hop-str
+                                 tramp-postfix-host-format))
+               (hop-vec (tramp-dissect-file-name hop-name 'nodefault)))
+          ;; Keep hops that are genuine proxies (different host)
+          (unless (and (string= (tramp-file-name-method hop-vec) "rpc")
+                       (string= (tramp-file-name-host hop-vec) target-host))
+            (push hop-str proxy-hops))))
+      (when proxy-hops
+        (concat (mapconcat #'identity (nreverse proxy-hops)
+                           tramp-postfix-hop-format)
+                tramp-postfix-hop-format)))))
+
 (require 'tramp-rpc-deploy)
 
 ;; Silence byte-compiler warnings for functions defined elsewhere
@@ -633,29 +712,44 @@ Parses the TRAMP hop field (e.g. \"rpc:user@gateway|\") and converts
 each hop to the SSH ProxyJump format (e.g. \"user@gateway\").
 Returns nil if there are no hops.
 
-Supports mixed methods: both \"rpc:\" and \"ssh:\" hops are accepted
-since ProxyJump only needs host connectivity."
-  (when-let* ((hops (tramp-file-name-hop vec)))
-    (mapconcat
-     (lambda (hop-str)
-       (let* ((hop-name (concat tramp-prefix-format hop-str
-                                tramp-postfix-host-format))
-              (hop-vec (tramp-dissect-file-name hop-name 'nodefault)))
-         (concat
-          (when (tramp-file-name-user hop-vec)
-            (concat (tramp-file-name-user hop-vec) "@"))
-          (tramp-file-name-host hop-vec)
-          (when-let* ((port (tramp-file-name-port hop-vec)))
-            (concat ":" (if (numberp port) (number-to-string port) port))))))
-     (split-string hops tramp-postfix-hop-regexp 'omit)
-     ",")))
+Same-host rpc hops are skipped because they represent sudo elevation,
+not proxy jumps.  Supports mixed methods: both \"rpc:\" and \"ssh:\"
+hops are accepted since ProxyJump only needs host connectivity."
+  (when-let* ((hops (tramp-file-name-hop vec))
+              (target-host (tramp-file-name-host vec)))
+    (let (proxy-parts)
+      (dolist (hop-str (split-string hops tramp-postfix-hop-regexp 'omit))
+        (let* ((hop-name (concat tramp-prefix-format hop-str
+                                 tramp-postfix-host-format))
+               (hop-vec (tramp-dissect-file-name hop-name 'nodefault))
+               (hop-host (tramp-file-name-host hop-vec)))
+          ;; Skip same-host rpc hops (sudo elevation, not proxy)
+          (unless (and (string= (tramp-file-name-method hop-vec) "rpc")
+                       (string= hop-host target-host))
+            (push (concat
+                   (when (tramp-file-name-user hop-vec)
+                     (concat (tramp-file-name-user hop-vec) "@"))
+                   hop-host
+                   (when-let* ((port (tramp-file-name-port hop-vec)))
+                     (concat ":" (if (numberp port)
+                                     (number-to-string port) port))))
+                  proxy-parts))))
+      (when proxy-parts
+        (mapconcat #'identity (nreverse proxy-parts) ",")))))
 
 (defun tramp-rpc--controlmaster-socket-path (vec)
   "Return the ControlMaster socket path for VEC.
-Expands SSH escape sequences in `tramp-rpc-controlmaster-path'."
-  (let* ((host (tramp-file-name-host vec))
-         (user (or (tramp-file-name-user vec) (user-login-name)))
+Expands SSH escape sequences in `tramp-rpc-controlmaster-path'.
+For sudo-via-RPC paths, uses the SSH user and excludes the sudo
+hop so the socket is shared with the normal rpc connection."
+  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         (host (tramp-file-name-host vec))
+         (user (or sudo-ssh-user (tramp-file-name-user vec) (user-login-name)))
          (port (or (tramp-file-name-port vec) 22))
+         ;; For sudo, use only proxy hops (exclude the same-host sudo hop)
+         (hop (if sudo-ssh-user
+                  (tramp-rpc--proxy-hop-string vec)
+                (tramp-file-name-hop vec)))
          (path tramp-rpc-controlmaster-path))
     ;; Expand common SSH escape sequences
     ;; %h = host, %r = remote user, %p = port
@@ -668,17 +762,18 @@ Expands SSH escape sequences in `tramp-rpc-controlmaster-path'."
     (setq path (replace-regexp-in-string
                 "%C"
                 (md5 (format "%s%s%s%s%s" (system-name) host port user
-                             (or (tramp-file-name-hop vec) "")))
+                             (or hop "")))
                 path t t))
     (expand-file-name path)))
 
 (defun tramp-rpc--controlmaster-active-p (vec)
   "Return non-nil if a ControlMaster connection is active for VEC."
-  (let ((socket-path (tramp-rpc--controlmaster-socket-path vec))
-        (host (tramp-file-name-host vec))
-        (user (tramp-file-name-user vec))
-        (port (tramp-file-name-port vec))
-        (proxyjump (tramp-rpc--hops-to-proxyjump vec)))
+  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         (socket-path (tramp-rpc--controlmaster-socket-path vec))
+         (host (tramp-file-name-host vec))
+         (user (or sudo-ssh-user (tramp-file-name-user vec)))
+         (port (tramp-file-name-port vec))
+         (proxyjump (tramp-rpc--hops-to-proxyjump vec)))
     (and (file-exists-p socket-path)
          ;; Check if the socket is actually usable via ssh -O check
          (zerop (apply #'call-process "ssh" nil nil nil
@@ -701,8 +796,9 @@ Returns non-nil on success."
     (tramp-rpc--debug "ControlMaster already active for %s" (tramp-file-name-host vec))
     (cl-return-from tramp-rpc--establish-controlmaster t))
   (tramp-rpc--ensure-controlmaster-directory)
-  (let* ((host (tramp-file-name-host vec))
-         (user (tramp-file-name-user vec))
+  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         (host (tramp-file-name-host vec))
+         (user (or sudo-ssh-user (tramp-file-name-user vec)))
          (port (tramp-file-name-port vec))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          (socket-path (tramp-rpc--controlmaster-socket-path vec))
@@ -765,12 +861,78 @@ Returns non-nil on success."
 	 (list (format
 		"Failed to establish SSH connection to %s: %s" host output)))))))
 
+(defun tramp-rpc--sudo-authenticate (vec ssh-user)
+  "Pre-authenticate sudo on the remote host for VEC.
+Uses the ControlMaster to run `sudo -v' interactively, caching
+credentials so the server can be started with sudo via pipes.
+SSH-USER is the user for the SSH connection (from the rpc hop)."
+  (let* ((host (tramp-file-name-host vec))
+         (port (tramp-file-name-port vec))
+         (proxyjump (tramp-rpc--hops-to-proxyjump vec))
+         (socket-path (tramp-rpc--controlmaster-socket-path vec))
+         (process-name (format "*tramp-rpc-sudo %s*" host))
+         (buffer (get-buffer-create (format " *tramp-rpc-sudo %s*" host)))
+         (ssh-args (append
+                    (list "ssh")
+                    tramp-rpc-ssh-args
+                    (when ssh-user (list "-l" ssh-user))
+                    (when port (list "-p" (number-to-string port)))
+                    ;; Multi-hop via ProxyJump
+                    (when proxyjump (list "-J" proxyjump))
+                    ;; Reuse ControlMaster for the SSH layer
+                    (when (and tramp-rpc-use-controlmaster
+                               (file-exists-p socket-path))
+                      (list "-o" "ControlMaster=auto"
+                            "-o" (format "ControlPath=%s" socket-path)))
+                    (list "-o" "StrictHostKeyChecking=accept-new")
+                    ;; Run sudo -v to cache credentials, then exit
+                    (list host "sudo" "-v")))
+         process)
+    (with-current-buffer buffer (erase-buffer))
+    ;; Use PTY for the sudo password prompt
+    (let ((process-connection-type t))
+      (setq process (apply #'start-process process-name buffer ssh-args)))
+    (set-process-query-on-exit-flag process nil)
+    ;; Handle sudo password prompt
+    (let ((start-time (current-time))
+          (timeout 60)
+          timed-out)
+      (while (and (process-live-p process)
+                  (< (float-time (time-subtract (current-time) start-time))
+                     timeout))
+        (with-tramp-suspended-timers
+          (accept-process-output process 0.1))
+        (with-current-buffer buffer
+          (goto-char (point-min))
+          (when (re-search-forward tramp-rpc--password-prompt-regexp nil t)
+            (let ((password (read-passwd
+                             (format "Sudo password for %s@%s: "
+                                     ssh-user host))))
+              (process-send-string process (concat password "\n"))
+              ;; Clear the buffer to avoid re-matching
+              (erase-buffer)))))
+      ;; Detect timeout: process still alive after loop exit
+      (when (process-live-p process)
+        (setq timed-out t)
+        (delete-process process))
+      ;; Check result
+      (when (or timed-out
+                (not (zerop (process-exit-status process))))
+        (let ((output (with-current-buffer buffer (buffer-string))))
+          (signal
+           'remote-file-error
+           (list (format "sudo authentication %s on %s: %s"
+                         (if timed-out "timed out" "failed")
+                         host output))))))))
+
 (defun tramp-rpc--start-server-process (vec binary-path)
   "Start the RPC server on VEC at BINARY-PATH and verify it responds.
 BINARY-PATH is the remote localname of the server binary (may contain ~).
+For sudo-via-RPC paths, the server is started via sudo.
 Returns the connection plist.  Signals `remote-file-error' on failure."
-  (let* ((host (tramp-file-name-host vec))
-         (user (tramp-file-name-user vec))
+  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         (host (tramp-file-name-host vec))
+         (user (or sudo-ssh-user (tramp-file-name-user vec)))
          (port (tramp-file-name-port vec))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          ;; Build SSH command to run the RPC server
@@ -796,7 +958,12 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
                                          (tramp-rpc--controlmaster-socket-path vec))
                             "-o" (format "ControlPersist=%s"
                                          tramp-rpc-controlmaster-persist)))
-                    (list host binary-path)))
+                    ;; For sudo elevation, wrap the binary in sudo
+                    (if sudo-ssh-user
+                        (list host "sudo" "-n"
+                              "-u" (tramp-file-name-user vec)
+                              binary-path)
+                      (list host binary-path))))
          ;; Use TRAMP's standard naming so tramp-get-connection-process works
          (process-name (tramp-get-connection-name vec))
          (buffer-name (tramp-buffer-name vec))
@@ -885,6 +1052,10 @@ accidentally routing file operations through tramp-sh."
   ;; - Password: prompts user, then subsequent connections reuse it
   (when tramp-rpc-use-controlmaster
     (tramp-rpc--establish-controlmaster vec))
+  ;; For sudo-via-RPC, pre-authenticate sudo so the server can be
+  ;; started with `sudo -n' (non-interactive) via pipes.
+  (when-let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec)))
+    (tramp-rpc--sudo-authenticate vec sudo-ssh-user))
   (if tramp-rpc-deploy-never-deploy
       ;; Never-deploy mode: use the configured path directly, no fallback.
       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
@@ -2725,7 +2896,7 @@ VEC-OR-FILENAME can be either a tramp-file-name struct or a filename string."
 
 (defun tramp-rpc--multi-hop-advice-remove ()
   "Remove multi-hop advice."
-  (advice-remove 'process-send-string #'tramp-rpc--multi-hop-advice))
+  (advice-remove 'tramp-multi-hop-p #'tramp-rpc--multi-hop-advice))
 
 ;; ============================================================================
 ;; Recentf integration
@@ -2862,7 +3033,12 @@ Removes advice and cleanup hooks.  Deletes `tramp-rpc-method' from
   ;; Clean up `tramp-methods' and `tramp-foreign-file-name-handler-alist'.
   (setq tramp-methods (delete (assoc tramp-rpc-method tramp-methods) tramp-methods))
   (setq tramp-foreign-file-name-handler-alist
-	(delete (assoc 'tramp-rpc-file-name-p tramp-foreign-file-name-handler-alist)
+	(delete (assoc 'tramp-rpc--sudo-file-name-p
+			tramp-foreign-file-name-handler-alist)
+		tramp-foreign-file-name-handler-alist))
+  (setq tramp-foreign-file-name-handler-alist
+	(delete (assoc 'tramp-rpc-file-name-p
+			tramp-foreign-file-name-handler-alist)
 		tramp-foreign-file-name-handler-alist))
   ;; Return nil to allow normal unload to proceed
   nil)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -697,10 +697,54 @@ Creates the directory from `tramp-rpc-controlmaster-path' if needed."
         ;; Set restrictive permissions for security
         (set-file-modes dir #o700)))))
 
-(defvar tramp-rpc--password-prompt-regexp
-  (rx (or "password:" "Password:" "Password for" "passphrase"
-          (seq "Enter passphrase for")))
-  "Regexp matching SSH password/passphrase prompts.")
+;;; ============================================================================
+;;; Authentication via tramp-process-actions
+;;; ============================================================================
+
+;; Reuse upstream TRAMP's `tramp-process-actions' state machine for all
+;; interactive authentication (SSH passwords, sudo, host-key prompts,
+;; OTP, security keys).  This gives us auth-source integration, password
+;; caching, wrong-password detection, and locale-aware prompt matching
+;; for free, instead of reimplementing with a custom regexp + loop.
+
+(defvar tramp-rpc--controlmaster-socket-path nil
+  "Dynamically bound socket path during ControlMaster establishment.
+Used by `tramp-rpc--action-controlmaster-established'.")
+
+(defun tramp-rpc--action-controlmaster-established (proc _vec)
+  "Succeed when the ControlMaster socket file appears, fail on process death.
+The target socket path is read from the dynamic variable
+`tramp-rpc--controlmaster-socket-path'."
+  (cond
+   ((file-exists-p tramp-rpc--controlmaster-socket-path)
+    (throw 'tramp-action 'ok))
+   ((not (process-live-p proc))
+    (while (tramp-accept-process-output proc))
+    (throw 'tramp-action 'process-died))))
+
+(defconst tramp-rpc--controlmaster-actions
+  '((tramp-password-prompt-regexp tramp-action-password)
+    (tramp-wrong-passwd-regexp tramp-action-permission-denied)
+    (tramp-yesno-prompt-regexp tramp-action-yesno)
+    (tramp-yn-prompt-regexp tramp-action-yn)
+    (tramp-process-alive-regexp tramp-rpc--action-controlmaster-established))
+  "Actions for SSH ControlMaster establishment.
+Handles password prompts, host-key verification, and detects the
+ControlMaster socket file appearing as the success condition.")
+
+(defun tramp-rpc--action-sudo-complete (proc _vec)
+  "Succeed when `sudo -v' exits with code 0, fail otherwise."
+  (unless (process-live-p proc)
+    (while (tramp-accept-process-output proc))
+    (throw 'tramp-action
+           (if (zerop (process-exit-status proc)) 'ok 'permission-denied))))
+
+(defconst tramp-rpc--sudo-actions
+  '((tramp-password-prompt-regexp tramp-action-password)
+    (tramp-wrong-passwd-regexp tramp-action-permission-denied)
+    (tramp-process-alive-regexp tramp-rpc--action-sudo-complete))
+  "Actions for `sudo -v' pre-authentication.
+Handles password prompts and detects sudo exit as success.")
 
 ;;; ============================================================================
 ;;; Multi-hop support
@@ -827,45 +871,32 @@ Returns non-nil on success."
     (let ((process-connection-type t))  ; Use PTY for password prompts
       (setq process (apply #'start-process process-name buffer ssh-args)))
     (set-process-query-on-exit-flag process nil)
-    ;; Handle password prompts and wait for connection
-    (let ((start-time (current-time))
-          (timeout 60))  ; 60 second timeout for authentication
-      (while (and (process-live-p process)
-                  (not (file-exists-p socket-path))
-                  (< (float-time (time-subtract (current-time) start-time)) timeout))
-        (with-tramp-suspended-timers
-          (accept-process-output process 0.1))
-        (with-current-buffer buffer
-          (goto-char (point-min))
-          (when (re-search-forward tramp-rpc--password-prompt-regexp nil t)
-            ;; Password prompt detected - ask user
-            (let ((password (read-passwd
-                             (format "Password for %s@%s: "
-                                     (or user (user-login-name)) host))))
-              (when password
-                (process-send-string process (concat password "\n"))
-                ;; Clear the buffer to avoid re-matching the same prompt
-                (erase-buffer)))))))
-    ;; Check if authentication succeeded (socket was created)
-    (if (file-exists-p socket-path)
-        (progn
-          ;; Give it a moment to stabilize
-          (sleep-for 0.1)
-          t)
-      ;; Authentication failed
-      (when (process-live-p process)
-        (delete-process process))
-      (let ((output (with-current-buffer buffer (buffer-string))))
-        (signal
-	 'remote-file-error
-	 (list (format
-		"Failed to establish SSH connection to %s: %s" host output)))))))
+    (set-process-sentinel process #'ignore)
+    ;; Set up process properties for tramp-process-actions / tramp-read-passwd.
+    ;; pw-vector tells auth-source where to look up credentials.
+    (process-put process 'tramp-vector vec)
+    (tramp-set-connection-property process "hop-vector" vec)
+    (tramp-set-connection-property
+     process "pw-vector"
+     (make-tramp-file-name :method "ssh" :user user :host host))
+    ;; Use upstream tramp-process-actions for password/host-key handling.
+    ;; The custom action checks for the ControlMaster socket appearing.
+    (let ((tramp-rpc--controlmaster-socket-path socket-path))
+      (tramp-process-actions process vec nil
+                             tramp-rpc--controlmaster-actions 60))
+    ;; tramp-process-actions throws on failure; reaching here means success.
+    (sleep-for 0.1)
+    t))
 
 (defun tramp-rpc--sudo-authenticate (vec ssh-user)
   "Pre-authenticate sudo on the remote host for VEC.
 Uses the ControlMaster to run `sudo -v' interactively, caching
 credentials so the server can be started with sudo via pipes.
-SSH-USER is the user for the SSH connection (from the rpc hop)."
+SSH-USER is the user for the SSH connection (from the rpc hop).
+
+Uses `tramp-process-actions' with `tramp-rpc--sudo-actions' for
+password handling, giving auth-source integration and password
+caching for free."
   (let* ((host (tramp-file-name-host vec))
          (port (tramp-file-name-port vec))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
@@ -893,37 +924,20 @@ SSH-USER is the user for the SSH connection (from the rpc hop)."
     (let ((process-connection-type t))
       (setq process (apply #'start-process process-name buffer ssh-args)))
     (set-process-query-on-exit-flag process nil)
-    ;; Handle sudo password prompt
-    (let ((start-time (current-time))
-          (timeout 60)
-          timed-out)
-      (while (and (process-live-p process)
-                  (< (float-time (time-subtract (current-time) start-time))
-                     timeout))
-        (with-tramp-suspended-timers
-          (accept-process-output process 0.1))
-        (with-current-buffer buffer
-          (goto-char (point-min))
-          (when (re-search-forward tramp-rpc--password-prompt-regexp nil t)
-            (let ((password (read-passwd
-                             (format "Sudo password for %s@%s: "
-                                     ssh-user host))))
-              (process-send-string process (concat password "\n"))
-              ;; Clear the buffer to avoid re-matching
-              (erase-buffer)))))
-      ;; Detect timeout: process still alive after loop exit
-      (when (process-live-p process)
-        (setq timed-out t)
-        (delete-process process))
-      ;; Check result
-      (when (or timed-out
-                (not (zerop (process-exit-status process))))
-        (let ((output (with-current-buffer buffer (buffer-string))))
-          (signal
-           'remote-file-error
-           (list (format "sudo authentication %s on %s: %s"
-                         (if timed-out "timed out" "failed")
-                         host output))))))))
+    (set-process-sentinel process #'ignore)
+    ;; Set up process properties for tramp-process-actions / tramp-read-passwd.
+    ;; pw-vector points to the sudo user so auth-source can look up
+    ;; credentials via e.g. "machine host login user port sudo".
+    (process-put process 'tramp-vector vec)
+    (tramp-set-connection-property process "hop-vector" vec)
+    (tramp-set-connection-property
+     process "pw-vector"
+     (make-tramp-file-name :method "sudo" :user ssh-user :host host))
+    ;; Use upstream tramp-process-actions for password handling.
+    ;; tramp-rpc--action-sudo-complete throws 'ok on exit 0,
+    ;; 'permission-denied otherwise.  tramp-process-actions handles
+    ;; timeout, wrong-password cleanup, and error signaling.
+    (tramp-process-actions process vec nil tramp-rpc--sudo-actions 60)))
 
 (defun tramp-rpc--start-server-process (vec binary-path)
   "Start the RPC server on VEC at BINARY-PATH and verify it responds.

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -780,8 +780,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (string-match-p "ssh:" hop))
       (should-not (string-match-p "rpc:" hop)))))
 
-(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-rpc-via-ssh ()
-  "Test that RPC sudo elevation is rewritten through an SSH hop."
+(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-rpc-via-rpc ()
+  "Test that RPC sudo elevation produces an rpc+sudo path."
   :tags '(:multi-hop)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
@@ -791,10 +791,13 @@ This matches the behavior expected by `tramp-test28-process-file'."
          (hop (tramp-file-name-hop vec)))
     (should (tramp-tramp-file-p filename))
     (should (equal (tramp-file-name-localname vec) "/etc/hosts"))
+    ;; The hop should be an rpc hop (not ssh)
     (should hop)
-    (should (string-match-p (rx bos "ssh:") hop))
-    (should-not (string-match-p "rpc:" hop))
-    (should-not (string-match-p (rx bos "/rpc:") filename))))
+    (should (string-match-p "rpc:" hop))
+    ;; The final method should be sudo
+    (should (string= (tramp-file-name-method vec) "sudo"))
+    ;; The host should be preserved
+    (should (string= (tramp-file-name-host vec) "target"))))
 
 (ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-non-rpc-passthrough ()
   "Test that non-RPC sudo elevation still calls the original function."
@@ -826,11 +829,8 @@ hop with \"Host name does not match\"."
 
 (ert-deftest tramp-rpc-mock-test-compute-multi-hops-rpc-sudo-chain ()
   "Test that `tramp-compute-multi-hops' accepts rpc as a proxy for sudo.
-Regression test for GitHub issue #123: `sudo-edit' on an rpc-backed
-file produced /rpc:server|sudo:root@server:/path, which then caused
-  user-error: Host name `server' does not match `localhost-regexp'
-because rpc had no tramp-login-args and the host-check in
-`tramp-compute-multi-hops' rejected it."
+The rpc method inherits all ssh connection parameters, so
+`tramp-maybe-open-connection' can process rpc hops using SSH."
   :tags '(:multi-hop)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   ;; Manually install the proxy entry that tramp-add-hops would create
@@ -842,14 +842,112 @@ because rpc had no tramp-login-args and the host-check in
                                          :host "server"
                                          :localname "/var/log/kern.log"))
          result)
-    ;; Before the fix, tramp-compute-multi-hops would signal:
-    ;;   user-error: Host name `server' does not match `localhost-regexp'
-    ;; because the rpc item in target-alist had no %h in tramp-login-args.
     (should (setq result (tramp-compute-multi-hops sudo-vec)))
     ;; The chain should contain 2 elements: rpc proxy hop + sudo destination.
     (should (= (length result) 2))
-    ;; The first element (gateway hop) should be the rpc method.
-    (should (string= (tramp-file-name-method (car result)) "rpc"))))
+    ;; The rpc hop keeps its method name; it works because the rpc
+    ;; method entry has ssh's tramp-login-program and tramp-login-args.
+    (should (string= (tramp-file-name-method (car result)) "rpc"))
+    (should (string= (tramp-file-name-host (car result)) "server"))))
+
+(ert-deftest tramp-rpc-mock-test-rpc-method-has-ssh-login-program ()
+  "Test that the rpc method inherits ssh's tramp-login-program.
+This is needed for `tramp-maybe-open-connection' to process rpc
+as a hop in multi-hop chains."
+  :tags '(:multi-hop)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "target")))
+    (should (string= (tramp-get-method-parameter vec 'tramp-login-program) "ssh"))
+    (should (tramp-get-method-parameter vec 'tramp-remote-shell))))
+
+;;; ============================================================================
+;;; Sudo-via-RPC tests (No server or SSH required)
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-detect-sudo-elevation-basic ()
+  "Test sudo elevation detection for /rpc:user@host|sudo:root@host:/path."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@server|sudo:root@server:/etc/shadow")))
+    (should (equal (tramp-rpc--detect-sudo-elevation vec) "alice"))))
+
+(ert-deftest tramp-rpc-mock-test-detect-sudo-elevation-no-hop ()
+  "Test that normal rpc paths return nil for sudo detection."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :user "root"
+                                   :host "server" :localname "/root")))
+    (should-not (tramp-rpc--detect-sudo-elevation vec))))
+
+(ert-deftest tramp-rpc-mock-test-detect-sudo-elevation-different-host ()
+  "Test that proxy hops to different hosts don't trigger sudo detection."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:user@gateway|sudo:root@server:/root")))
+    ;; gateway != server, so no sudo elevation
+    (should-not (tramp-rpc--detect-sudo-elevation vec))))
+
+(ert-deftest tramp-rpc-mock-test-sudo-file-name-predicate ()
+  "Test the sudo+rpc handler predicate."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; rpc+sudo should match
+  (should (tramp-rpc--sudo-file-name-p
+           (tramp-dissect-file-name
+            "/rpc:user@server|sudo:root@server:/root")))
+  ;; plain rpc should not match
+  (should-not (tramp-rpc--sudo-file-name-p
+               (tramp-dissect-file-name "/rpc:user@server:/home")))
+  ;; ssh+sudo should not match (no rpc in hop)
+  (should-not (tramp-rpc--sudo-file-name-p
+               (tramp-dissect-file-name
+                "/ssh:user@server|sudo:root@server:/root"))))
+
+(ert-deftest tramp-rpc-mock-test-proxy-hop-string-sudo ()
+  "Test that same-host sudo hops are excluded from proxy hop string."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; Simple sudo: /rpc:user@host|sudo:root@host:/path -> no proxy hops
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:user@server|sudo:root@server:/root")))
+    (should-not (tramp-rpc--proxy-hop-string vec)))
+  ;; With gateway: /rpc:gw|rpc:user@host|sudo:root@host:/path -> "rpc:gw|"
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:gw|rpc:user@server|sudo:root@server:/root")))
+    (should (string-match-p "rpc:gw" (tramp-rpc--proxy-hop-string vec)))
+    ;; The same-host hop should be excluded
+    (should-not (string-match-p "rpc:user@server"
+                                (tramp-rpc--proxy-hop-string vec)))))
+
+(ert-deftest tramp-rpc-mock-test-hops-to-proxyjump-skips-sudo ()
+  "Test that hops-to-proxyjump skips same-host sudo hops."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; Simple sudo: no proxy jumps needed
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:user@server|sudo:root@server:/root")))
+    (should-not (tramp-rpc--hops-to-proxyjump vec)))
+  ;; With gateway: only gateway in proxyjump
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:gw|rpc:user@server|sudo:root@server:/root")))
+    (let ((pj (tramp-rpc--hops-to-proxyjump vec)))
+      (should pj)
+      (should (string-match-p "gw" pj))
+      (should-not (string-match-p "server" pj)))))
+
+(ert-deftest tramp-rpc-mock-test-controlmaster-socket-shared ()
+  "Test that sudo and normal connections share the ControlMaster socket."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((normal-vec (make-tramp-file-name :method "rpc" :user "alice"
+                                          :host "server" :localname "/home"))
+        (sudo-vec (tramp-dissect-file-name
+                   "/rpc:alice@server|sudo:root@server:/root")))
+    ;; Both should produce the same ControlMaster socket path
+    (should (equal (tramp-rpc--controlmaster-socket-path normal-vec)
+                   (tramp-rpc--controlmaster-socket-path sudo-vec)))))
 
 ;;; ============================================================================
 ;;; Dir-locals advice tests (No server or SSH required)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -780,40 +780,31 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (string-match-p "ssh:" hop))
       (should-not (string-match-p "rpc:" hop)))))
 
-(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-rpc-via-rpc ()
-  "Test that RPC sudo elevation produces an rpc+sudo path."
+;; With latest tramp, tramp-file-name-with-sudo natively produces
+;; /rpc:user@host|sudo:root@host:/path for rpc paths since the rpc
+;; method is now multi-hop capable (inherits ssh connection params).
+(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-native ()
+  "Test that tramp-file-name-with-sudo natively produces rpc+sudo path."
   :tags '(:multi-hop)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
   (let* ((tramp-file-name-with-method "sudo")
          (filename (tramp-file-name-with-sudo "/rpc:user@target:/etc/hosts"))
-         (vec (tramp-dissect-file-name filename))
-         (hop (tramp-file-name-hop vec)))
+         (vec (tramp-dissect-file-name filename)))
     (should (tramp-tramp-file-p filename))
     (should (equal (tramp-file-name-localname vec) "/etc/hosts"))
-    ;; The hop should be an rpc hop (not ssh)
-    (should hop)
-    (should (string-match-p "rpc:" hop))
-    ;; The final method should be sudo
     (should (string= (tramp-file-name-method vec) "sudo"))
-    ;; The host should be preserved
+    (should (string= (tramp-file-name-host vec) "target"))
+    ;; The hop should preserve the rpc method
+    (when (tramp-file-name-hop vec)
+      (should (string-match-p "rpc:" (tramp-file-name-hop vec)))))
+  ;; Also verify non-rpc paths still work
+  (let* ((tramp-file-name-with-method "sudo")
+         (filename (tramp-file-name-with-sudo "/ssh:user@target:/etc/hosts"))
+         (vec (tramp-dissect-file-name filename)))
+    (should (tramp-tramp-file-p filename))
+    (should (string= (tramp-file-name-method vec) "sudo"))
     (should (string= (tramp-file-name-host vec) "target"))))
-
-(ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-non-rpc-passthrough ()
-  "Test that non-RPC sudo elevation still calls the original function."
-  :tags '(:multi-hop)
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
-  (let ((called-with nil)
-        (filename "/ssh:user@target:/etc/hosts"))
-    (should
-     (eq (tramp-rpc--file-name-with-sudo-advice
-          (lambda (arg)
-            (setq called-with arg)
-            'passthrough)
-          filename)
-         'passthrough))
-    (should (equal called-with (expand-file-name filename)))))
 
 (ert-deftest tramp-rpc-mock-test-rpc-method-advertises-host-arg ()
   "Test that the rpc method declares %%h in tramp-login-args.


### PR DESCRIPTION
## Summary

- Advise `tramp-compute-multi-hops` to rewrite `rpc` hops to `ssh` when the final target is a tramp-sh method (like sudo/su), so `tramp-maybe-open-connection` can process the hop chain
- Fix bug in `tramp-rpc--multi-hop-advice-remove` which removed advice from `process-send-string` instead of `tramp-multi-hop-p`
- Add 3 new tests for the rewrite behavior (mixed chains, non-rpc passthrough, single-hop no-rewrite)

## Problem

Opening `/rpc:host|sudo:root@host:/path` fails because the final method is `sudo` (tramp-sh), so `tramp-maybe-open-connection` processes the hop chain. It iterates each hop looking up `tramp-login-program` to build a shell command. The `rpc` method has no `tramp-login-program` — commit 14fb974 only added `tramp-login-args (("%h"))` to pass validation, but the hop loop still cannot execute the rpc hop.

## Approach

Since rpc uses SSH under the hood and file operations go through tramp-sh anyway (the final method is sudo), the advice rewrites `rpc` hops to `ssh` in `tramp-compute-multi-hops` results. This gives the hop loop the ssh method parameters it needs (`tramp-login-program "ssh"`, `tramp-login-args`, `tramp-remote-shell`, etc.).

The rewrite only triggers when:
1. The chain has multiple hops (single-hop rpc is unaffected)
2. The final target is a tramp-sh method (rpc-to-rpc chains use their own ProxyJump mechanism)

**Note**: This path uses tramp-sh for all file operations, so it does not get RPC performance benefits. For RPC-accelerated sudo, the existing `tramp-file-name-with-sudo` advice (used by sudo-edit) remains the recommended approach.