### PR TITLE
fix: forward caller's process-environment to remote process-file

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -47,6 +47,7 @@
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
 (declare-function tramp-rpc--ensure-inside-emacs-env "tramp-rpc")
+(declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el
@@ -149,8 +150,32 @@ This prevents race conditions where later messages arrive before earlier ones."
                                             tramp-rpc--process-write-queues))
                                  (tramp-rpc--process-write-queue queue-key))))))))
 
+(defun tramp-rpc--drain-write-queue (pid)
+  "Wait for all pending writes to PID to complete.
+Spins the event loop so that async RPC write callbacks fire and the
+queue drains.  Returns once no writes are pending or in-flight, or
+after a safety timeout of 5 seconds."
+  (let ((deadline (+ (float-time) 5.0)))
+    (while (let ((queue (gethash pid tramp-rpc--process-write-queues)))
+             (and queue
+                  (or (plist-get queue :writing)
+                      (plist-get queue :pending))
+                  (< (float-time) deadline)))
+      ;; Let the event loop process async RPC responses (write callbacks)
+      (accept-process-output nil 0.01))))
+
 (defun tramp-rpc--close-remote-stdin (vec pid)
-  "Close stdin of remote process PID on VEC."
+  "Close stdin of remote process PID on VEC.
+Drains the write queue first so that all pending data reaches the
+remote process before the pipe is closed.  Without this, the
+server may process close_stdin before process.write when they
+arrive as concurrent RPC requests."
+  ;; Ensure all queued writes have been acknowledged by the server
+  ;; before we send close_stdin.  Both requests are dispatched as
+  ;; separate concurrent tokio tasks on the server; without draining,
+  ;; close_stdin can win the process-map lock race and drop the stdin
+  ;; handle before the write task delivers the data.
+  (tramp-rpc--drain-write-queue pid)
   (tramp-rpc--call vec "process.close_stdin" `((pid . ,pid))))
 
 (defun tramp-rpc--kill-remote-process (vec pid &optional signal)
@@ -395,9 +420,11 @@ Resolves program path and loads direnv environment from working directory."
     (with-parsed-tramp-file-name default-directory nil
       ;; Unquote localname in case of file-name-quoted paths (e.g. /: prefix).
       (setq localname (file-name-unquote localname))
-      ;; Get direnv environment for this directory, with INSIDE_EMACS
+      ;; Get direnv environment for this directory, with INSIDE_EMACS,
+      ;; plus any caller-set env vars (e.g. GIT_INDEX_FILE from magit).
       (let ((direnv-env (tramp-rpc--ensure-inside-emacs-env
-                         (tramp-rpc--get-direnv-environment v localname))))
+                         (append (tramp-rpc--get-direnv-environment v localname)
+                                 (tramp-rpc--caller-environment)))))
         (if use-pty
             ;; PTY mode - start async process with PTY
             (tramp-rpc--make-pty-process v name buffer command coding noquery

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -507,6 +507,26 @@ from `tramp-inside-emacs'.  Returns the (possibly augmented) alist."
       env
     (cons (cons "INSIDE_EMACS" (tramp-inside-emacs)) env)))
 
+(defun tramp-rpc--caller-environment ()
+  "Extract environment variable overrides from `process-environment'.
+Emacs packages dynamically bind env vars via `with-environment-variables'
+or `setenv' (e.g. magit sets GIT_INDEX_FILE for temp-index operations).
+These additions/changes land in `process-environment' but are not forwarded
+by `tramp-rpc-handle-process-file' unless we explicitly extract them.
+
+Compares the current `process-environment' against the toplevel default.
+Entries that are only present in the current dynamic scope (e.g. added
+by `with-environment-variables') are returned as an alist of
+\(NAME . VALUE) pairs."
+  (let ((toplevel (default-toplevel-value 'process-environment))
+        (env nil))
+    (dolist (elt process-environment)
+      (when (and (stringp elt)
+                 (not (member elt toplevel))
+                 (string-match "\\`\\([^=]+\\)=\\(.*\\)\\'" elt))
+        (push (cons (match-string 1 elt) (match-string 2 elt)) env)))
+    (nreverse env)))
+
 (defun tramp-rpc--resolve-executable (vec program)
   "Resolve PROGRAM to its full path on VEC.
 Returns the full path if found, otherwise the original PROGRAM.
@@ -2221,7 +2241,12 @@ refresh), git commands are served from the prefetch cache when possible."
         ;; Cache miss - make actual RPC call
         (let* ((resolved-program (tramp-rpc--resolve-executable v program))
                (env (tramp-rpc--ensure-inside-emacs-env
-                     (tramp-rpc--get-direnv-environment v localname)))
+                     ;; Merge: direnv base + caller overrides (e.g. GIT_INDEX_FILE).
+                     ;; Caller overrides take priority -- append last so
+                     ;; duplicate keys resolve to the caller's value when
+                     ;; the server iterates the map.
+                     (append (tramp-rpc--get-direnv-environment v localname)
+                             (tramp-rpc--caller-environment))))
                (stdin-content (when (and infile (not (eq infile t)))
                                  (with-temp-buffer
                                    (set-buffer-multibyte nil)

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -324,8 +324,14 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
         .get_mut(&params.pid)
         .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
 
-    // Drop stdin to close it
-    managed.child.stdin.take();
+    // Flush any buffered data before closing stdin, then drop to close the pipe.
+    // This is a defensive measure: the client should drain its write queue before
+    // calling close_stdin, but flushing here guards against data loss if a
+    // concurrent process.write task wrote data that hasn't been flushed yet.
+    if let Some(mut stdin) = managed.child.stdin.take() {
+        let _ = stdin.flush().await;
+        // stdin is dropped here, closing the pipe
+    }
 
     Ok(Value::Boolean(true))
 }


### PR DESCRIPTION
## Summary

- **Forward dynamically-bound environment variables** (e.g. `GIT_INDEX_FILE`) from `process-environment` to the RPC `process.run` and `process.start` calls. This fixes magit staging/unstaging being silently undone on every refresh.
- **Drain the async write queue** before sending `close_stdin` to prevent a server-side race condition where `close_stdin` could win the tokio process-map lock and drop the stdin pipe before the `process.write` task delivers data.

## Root Cause

Magit's WIP (work-in-progress) save runs `git update-index --add --remove -- <file>` during every refresh inside `magit-with-temp-index`, which sets `GIT_INDEX_FILE` via `with-environment-variables` to point at a temporary index file. Standard `tramp-sh` forwards `process-environment` to the remote shell, but `tramp-rpc` was only sending the direnv environment and `INSIDE_EMACS` — completely ignoring `process-environment`.

This caused the `update-index` to operate on the **main** `.git/index` instead of the temp index, silently re-staging whatever the user had just unstaged. Every `magit-refresh` would undo the user's unstage operation.

## Changes

### `lisp/tramp-rpc.el`
- Add `tramp-rpc--caller-environment`: uses `default-toplevel-value` to diff the current dynamic `process-environment` against the global default, capturing vars added by `with-environment-variables`
- Merge caller env overrides into the `env` parameter of `tramp-rpc-handle-process-file`

### `lisp/tramp-rpc-process.el`
- Merge caller env overrides into `tramp-rpc-handle-make-process`
- Add `tramp-rpc--drain-write-queue` to ensure all async `process.write` RPCs complete before `close_stdin` is sent

### `server/src/handlers/process.rs`
- Flush stdin before dropping in `close_stdin` as a defensive measure against the write/close race