### PR TITLE
Update AGENTS.md with core instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 /lisp/binaries
 result
+
+# config
+.config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,28 @@
 # TRAMP RPC
 
-This attempts to make a new tramp target that works by RPC rather than piping shell commands over ssh.
-The original tramp code is in ~/src/tramp. Use it as a reference.
-The remote target to test is "x220-nixos" and the location of the server is in .cache/tramp-rpc
+Always read README.org for details about the project
 
+# Building the Rust server
+The script to build the rust server is located at: scripts/build-all.sh
+
+If building for a target other than linux, refer to that script for options.
+
+# Config settings
+
+The settings for this setup are located in .config
+
+always read that file. It will contain:
+
+- remote target
+- remote OS
+- default tramp method
+- tramp source code directory
+- any other relevant instructions or information
+
+# Testing updates
+
+NEVER use emacsclient. That will interfer with the users configuration
+
+Always use `emacs -Q --batch --eval <lisp commands>`
+
+When testing updates to the rust server, always copy it to a temporary location and set `tramp-rpc-deploy-remote-directory` to the temporary path so that testing does not interfere with existing sessions.


### PR DESCRIPTION
The original AGENTS.md file was geared towards your environment and would just confuse the agents when I tried to use it. The setup instead has a `.config` file that can contain all the local paths and hosts and the AGENTS.md can be generic instructions for any user.