### PR TITLE
Implement locate-dominating-file and dir-locals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # TRAMP RPC
 
-Always read README.org for details about the project
+for details about the project see @README.org
 
 # Building the Rust server
 The script to build the rust server is located at: scripts/build-all.sh
@@ -9,14 +9,17 @@ If building for a target other than linux, refer to that script for options.
 
 # Config settings
 
-The settings for this setup are located in .config
+The settings for this setup are located in `.config`
 
-always read that file. It will contain:
+@.config
+
+This can include:
 
 - remote target
 - remote OS
 - default tramp method
 - tramp source code directory
+- msgpack package path
 - any other relevant instructions or information
 
 # Testing updates
@@ -26,3 +29,27 @@ NEVER use emacsclient. That will interfer with the users configuration
 Always use `emacs -Q --batch --eval <lisp commands>`
 
 When testing updates to the rust server, always copy it to a temporary location and set `tramp-rpc-deploy-remote-directory` to the temporary path so that testing does not interfere with existing sessions.
+
+## Test Example
+
+running all tests that start with `tramp-rpc-test` in tramp-rpc-tests.el
+```sh
+  emacs -Q --batch -l test/tramp-rpc-tests.el \
+    --eval '(add-to-list (quote load-path) "/path/to/msgpack")' \
+    --eval '(setq tramp-rpc-test-source "/path/to/tramp/source")' \
+    --eval '(setq tramp-rpc-test-host "remote-host")' \
+    --eval '(ert-run-tests-batch-and-exit "^tramp-rpc-test")'
+```
+
+## Benchmark Example
+
+running "file-exists" and "file-read" benchmarks with rpc
+```sh
+  emacs -Q --batch -l benchmark/benchmark.el \
+    --eval '(add-to-list (quote load-path) "/path/to/msgpack")' \
+    --eval '(add-to-list (quote load-path) (expand-file-name "lisp" default-directory))' \
+    --eval '(require (quote tramp-rpc))' \
+    --eval '(setq tramp-rpc-benchmark-host "remote-host")' \
+    --eval '(tramp-rpc-benchmark-run-subset (quote ("file-exists" "file-read")) (quote ("rpc")))'
+```
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/benchmark/benchmark.el
+++ b/benchmark/benchmark.el
@@ -39,6 +39,14 @@
 (defvar tramp-rpc-benchmark-test-dir "/tmp/tramp-benchmark"
   "Remote directory to use for tests (will be created/cleaned).")
 
+(defconst tramp-rpc-benchmark--deep-relative-file
+  (concat "project/"
+          (mapconcat (lambda (i) (format "d%02d" i))
+                     (number-sequence 1 12)
+                     "/")
+          "/deep.txt")
+  "Relative path for deep traversal benchmarks (12 directories deep).")
+
 ;;; Results storage
 
 (defvar tramp-rpc-benchmark-results nil
@@ -132,7 +140,23 @@
             (dotimes (i chunk-size)
               (aset chunk i (aref alphabet (random alphabet-len))))
             (insert chunk)))
-        (write-region (point-min) (point-max) file)))))
+        (write-region (point-min) (point-max) file)))
+    ;; Create nested fixture used by high-level parent traversal benchmarks.
+    (let* ((project-root (tramp-rpc-benchmark--make-path method "project"))
+           (git-marker (tramp-rpc-benchmark--make-path method "project/.git"))
+           (nested-file (tramp-rpc-benchmark--make-path method
+                                                        tramp-rpc-benchmark--deep-relative-file))
+           (nested-dir (file-name-directory nested-file))
+           (dir-locals-file (tramp-rpc-benchmark--make-path method "project/.dir-locals.el")))
+      (make-directory project-root t)
+      (make-directory git-marker t)
+      (make-directory nested-dir t)
+      (with-temp-buffer
+        (insert "deep fixture\n")
+        (write-region (point-min) (point-max) nested-file))
+      (with-temp-buffer
+        (insert "((nil . ((fill-column . 80))))\n")
+        (write-region (point-min) (point-max) dir-locals-file)))))
 
 (defun tramp-rpc-benchmark--teardown (method)
   "Clean up test environment for METHOD."
@@ -301,6 +325,22 @@ Same operations as batch-mixed-ops but done one at a time."
     (tramp-rpc-benchmark--time
      (ignore (file-exists-p file)))))
 
+(defun tramp-rpc-benchmark--locate-dominating-file (method)
+  "Benchmark `locate-dominating-file' for METHOD."
+  (let ((file (tramp-rpc-benchmark--make-path method tramp-rpc-benchmark--deep-relative-file)))
+    (tramp-rpc-benchmark--flush-cache file)
+    (tramp-rpc-benchmark--time
+     (locate-dominating-file file ".git"))))
+
+(defun tramp-rpc-benchmark--dir-locals-find-file (method)
+  "Benchmark `dir-locals-find-file' for METHOD."
+  (let ((file (tramp-rpc-benchmark--make-path method tramp-rpc-benchmark--deep-relative-file)))
+    (tramp-rpc-benchmark--flush-cache file)
+    (tramp-rpc-benchmark--time
+     ;; Measure resolution path, not the global dir-locals cache hit path.
+     (let ((dir-locals-directory-cache nil))
+       (dir-locals-find-file file)))))
+
 ;;; Main benchmark runner
 
 (defconst tramp-rpc-benchmark--tests
@@ -317,6 +357,8 @@ Same operations as batch-mixed-ops but done one at a time."
     ("process-file-cat"   . tramp-rpc-benchmark--process-file-cat)
     ("copy-file"          . tramp-rpc-benchmark--copy-file)
     ("multi-stat"         . tramp-rpc-benchmark--multiple-stats)
+    ("locate-dominating-file" . tramp-rpc-benchmark--locate-dominating-file)
+    ("dir-locals-find-file" . tramp-rpc-benchmark--dir-locals-find-file)
     ("seq-mixed-ops"      . tramp-rpc-benchmark--sequential-mixed-ops))
   "Alist of benchmark tests (name . function).")
 

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -45,9 +45,6 @@
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc--call-async "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
-(declare-function tramp-rpc-handle-locate-dominating-file "tramp-rpc")
-(declare-function tramp-rpc-handle-dir-locals-find-file "tramp-rpc")
-(declare-function tramp-rpc-handle-dir-locals--all-files "tramp-rpc")
 
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
 (defvar tramp-rpc--delivering-output)
@@ -400,68 +397,17 @@ exited (remote side finished), delete it so the refresh can proceed."
 ;; Dir-locals advice
 ;; ============================================================================
 
-;; Emacs's `enable-remote-dir-locals' defaults to nil because looking
-;; for .dir-locals.el on remote hosts can be slow for traditional TRAMP
-;; methods that pipe shell commands over SSH.  TRAMP-RPC uses an
-;; efficient binary protocol with caching, so this concern does not
-;; apply.  Rather than setting the variable globally (which would affect
-;; all TRAMP methods), we advise `hack-dir-local-variables' to enable
-;; it only for buffers visiting files via the RPC method.
-
+;; Emacs's `enable-remote-dir-locals' defaults to nil because looking for
+;; .dir-locals.el on remote hosts can be slow for traditional TRAMP methods.
+;; TRAMP-RPC uses a fast binary protocol and dedicated high-level operations,
+;; so enable this only for buffers using the rpc method.
 (defun tramp-rpc--hack-dir-local-variables-advice (orig-fun)
-  "Enable dir-locals for buffers visiting TRAMP-RPC remote files.
-Let-binds `enable-remote-dir-locals' to t when the current buffer
-is visiting a file (or has `default-directory') on an RPC remote,
-so that .dir-locals.el files are detected and loaded normally."
+  "Enable remote dir-locals in `hack-dir-local-variables' for RPC files."
   (let ((enable-remote-dir-locals
          (or enable-remote-dir-locals
              (when-let* ((file (or (buffer-file-name) default-directory)))
                (tramp-rpc-file-name-p file)))))
     (funcall orig-fun)))
-
-;; Compatibility fallback for Tramp versions lacking
-;; `tramp-add-external-operation'.
-(defun tramp-rpc--locate-dominating-file-advice (orig-fun file name)
-  "Use RPC fast-path for remote `locate-dominating-file'."
-  (if (and (not (functionp name))
-           (stringp file)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p file)
-                file
-              (file-name-concat default-directory file))))
-      (tramp-rpc-handle-locate-dominating-file file name)
-    (funcall orig-fun file name)))
-
-(defun tramp-rpc--dir-locals--all-files-advice (orig-fun directory &optional base-el-only)
-  "Use RPC fast-path for remote `dir-locals--all-files'."
-  (if (and (stringp directory)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p directory)
-                directory
-              (file-name-concat default-directory directory))))
-      (tramp-rpc-handle-dir-locals--all-files directory base-el-only)
-    ;; Emacs versions differ in accepted arity for `dir-locals--all-files'.
-    ;; Try the 2-arg form first and fall back for older 1-arg variants.
-    (condition-case nil
-        (funcall orig-fun directory base-el-only)
-      (wrong-number-of-arguments
-       (funcall orig-fun directory)))))
-
-(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
-  "Use RPC fast-path for remote `dir-locals-find-file'."
-  (if (and (stringp file)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p file)
-                file
-              (file-name-concat default-directory file))))
-      ;; The dedicated RPC fast-path can miss edge cases in upstream
-      ;; `tramp-test34' when `find-file-hook' is intentionally modified.
-      ;; In that case, defer to upstream behavior.
-      (if (memq #'tramp-set-connection-local-variables-for-buffer find-file-hook)
-          (or (tramp-rpc-handle-dir-locals-find-file file)
-              (funcall orig-fun file))
-        (funcall orig-fun file))
-    (funcall orig-fun file)))
 
 ;; ============================================================================
 ;; Install and uninstall advice
@@ -488,15 +434,6 @@ so that .dir-locals.el files are detected and loaded normally."
   (with-eval-after-load 'magit-process
     (advice-add 'magit-start-process :around
                 #'tramp-rpc--magit-start-process-advice))
-  ;; Always use explicit advice for these operations.  Using
-  ;; `tramp-add-external-operation' here can recurse while the
-  ;; `tramp-rpc' feature is still loading.
-  (advice-add 'locate-dominating-file :around
-              #'tramp-rpc--locate-dominating-file-advice)
-  (advice-add 'dir-locals-find-file :around
-              #'tramp-rpc--dir-locals-find-file-advice)
-  (advice-add 'dir-locals--all-files :around
-              #'tramp-rpc--dir-locals--all-files-advice)
   (advice-add 'hack-dir-local-variables :around
               #'tramp-rpc--hack-dir-local-variables-advice))
 
@@ -516,9 +453,6 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
-  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
-  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
-  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
 
 (defcustom tramp-rpc-install-advice-on-load t

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -270,7 +270,7 @@ process-file calls are routed through the TRAMP handler."
                               (stringp file)
                               (tramp-tramp-file-p file)
                               ;; Operations that take a file and may call process-file
-                              (memq function-name '(state state-heuristic dir-status-files
+                              (memq function-name '(registered state state-heuristic dir-status-files
                                                     working-revision previous-revision next-revision
                                                     responsible-p)))))
     (if should-set-dir
@@ -450,7 +450,12 @@ so that .dir-locals.el files are detected and loaded normally."
                 directory
               (file-name-concat default-directory directory))))
       (tramp-rpc-handle-dir-locals--all-files directory base-el-only)
-    (funcall orig-fun directory base-el-only)))
+    ;; Emacs versions differ in accepted arity for `dir-locals--all-files'.
+    ;; Try the 2-arg form first and fall back for older 1-arg variants.
+    (condition-case nil
+        (funcall orig-fun directory base-el-only)
+      (wrong-number-of-arguments
+       (funcall orig-fun directory)))))
 
 ;; ============================================================================
 ;; Install and uninstall advice

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -419,28 +419,18 @@ so that .dir-locals.el files are detected and loaded normally."
                (tramp-rpc-file-name-p file)))))
     (funcall orig-fun)))
 
-;; `locate-dominating-file', `dir-locals-find-file', and
-;; `dir-locals--all-files' are advised for TRAMP versions without external
-;; operation registration APIs.
+;; Compatibility fallback for Tramp versions lacking
+;; `tramp-add-external-operation'.
 (defun tramp-rpc--locate-dominating-file-advice (orig-fun file name)
   "Use RPC fast-path for remote `locate-dominating-file'."
-  (if (and (stringp file)
+  (if (and (not (functionp name))
+           (stringp file)
            (tramp-rpc-file-name-p
             (if (file-name-absolute-p file)
                 file
               (file-name-concat default-directory file))))
       (tramp-rpc-handle-locate-dominating-file file name)
     (funcall orig-fun file name)))
-
-(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
-  "Use RPC fast-path for remote `dir-locals-find-file'."
-  (if (and (stringp file)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p file)
-                file
-              (file-name-concat default-directory file))))
-      (tramp-rpc-handle-dir-locals-find-file file)
-    (funcall orig-fun file)))
 
 (defun tramp-rpc--dir-locals--all-files-advice (orig-fun directory &optional base-el-only)
   "Use RPC fast-path for remote `dir-locals--all-files'."
@@ -456,6 +446,22 @@ so that .dir-locals.el files are detected and loaded normally."
         (funcall orig-fun directory base-el-only)
       (wrong-number-of-arguments
        (funcall orig-fun directory)))))
+
+(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
+  "Use RPC fast-path for remote `dir-locals-find-file'."
+  (if (and (stringp file)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p file)
+                file
+              (file-name-concat default-directory file))))
+      ;; The dedicated RPC fast-path can miss edge cases in upstream
+      ;; `tramp-test34' when `find-file-hook' is intentionally modified.
+      ;; In that case, defer to upstream behavior.
+      (if (memq #'tramp-set-connection-local-variables-for-buffer find-file-hook)
+          (or (tramp-rpc-handle-dir-locals-find-file file)
+              (funcall orig-fun file))
+        (funcall orig-fun file))
+    (funcall orig-fun file)))
 
 ;; ============================================================================
 ;; Install and uninstall advice
@@ -482,12 +488,20 @@ so that .dir-locals.el files are detected and loaded normally."
   (with-eval-after-load 'magit-process
     (advice-add 'magit-start-process :around
                 #'tramp-rpc--magit-start-process-advice))
-  (advice-add 'locate-dominating-file :around
-              #'tramp-rpc--locate-dominating-file-advice)
-  (advice-add 'dir-locals-find-file :around
-              #'tramp-rpc--dir-locals-find-file-advice)
-  (advice-add 'dir-locals--all-files :around
-              #'tramp-rpc--dir-locals--all-files-advice)
+  ;; Prefer Tramp's external-operation API when available.  On older
+  ;; Tramp versions, fall back to explicit advice for these operations.
+  (if (fboundp 'tramp-add-external-operation)
+      (progn
+        (tramp-add-external-operation
+         'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
+        (tramp-add-external-operation
+         'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc))
+    (advice-add 'locate-dominating-file :around
+                #'tramp-rpc--locate-dominating-file-advice)
+    (advice-add 'dir-locals-find-file :around
+                #'tramp-rpc--dir-locals-find-file-advice)
+    (advice-add 'dir-locals--all-files :around
+                #'tramp-rpc--dir-locals--all-files-advice))
   (advice-add 'hack-dir-local-variables :around
               #'tramp-rpc--hack-dir-local-variables-advice))
 
@@ -507,9 +521,13 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
-  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
-  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
-  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
+  (if (fboundp 'tramp-remove-external-operation)
+      (progn
+        (tramp-remove-external-operation 'locate-dominating-file 'tramp-rpc)
+        (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc))
+    (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
+    (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
+    (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice))
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
 
 (defcustom tramp-rpc-install-advice-on-load t

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -45,6 +45,9 @@
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc--call-async "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc-handle-locate-dominating-file "tramp-rpc")
+(declare-function tramp-rpc-handle-dir-locals-find-file "tramp-rpc")
+(declare-function tramp-rpc-handle-dir-locals--all-files "tramp-rpc")
 
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
 (defvar tramp-rpc--delivering-output)
@@ -416,6 +419,39 @@ so that .dir-locals.el files are detected and loaded normally."
                (tramp-rpc-file-name-p file)))))
     (funcall orig-fun)))
 
+;; `locate-dominating-file', `dir-locals-find-file', and
+;; `dir-locals--all-files' are advised for TRAMP versions without external
+;; operation registration APIs.
+(defun tramp-rpc--locate-dominating-file-advice (orig-fun file name)
+  "Use RPC fast-path for remote `locate-dominating-file'."
+  (if (and (stringp file)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p file)
+                file
+              (file-name-concat default-directory file))))
+      (tramp-rpc-handle-locate-dominating-file file name)
+    (funcall orig-fun file name)))
+
+(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
+  "Use RPC fast-path for remote `dir-locals-find-file'."
+  (if (and (stringp file)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p file)
+                file
+              (file-name-concat default-directory file))))
+      (tramp-rpc-handle-dir-locals-find-file file)
+    (funcall orig-fun file)))
+
+(defun tramp-rpc--dir-locals--all-files-advice (orig-fun directory &optional base-el-only)
+  "Use RPC fast-path for remote `dir-locals--all-files'."
+  (if (and (stringp directory)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p directory)
+                directory
+              (file-name-concat default-directory directory))))
+      (tramp-rpc-handle-dir-locals--all-files directory base-el-only)
+    (funcall orig-fun directory base-el-only)))
+
 ;; ============================================================================
 ;; Install and uninstall advice
 ;; ============================================================================
@@ -441,6 +477,12 @@ so that .dir-locals.el files are detected and loaded normally."
   (with-eval-after-load 'magit-process
     (advice-add 'magit-start-process :around
                 #'tramp-rpc--magit-start-process-advice))
+  (advice-add 'locate-dominating-file :around
+              #'tramp-rpc--locate-dominating-file-advice)
+  (advice-add 'dir-locals-find-file :around
+              #'tramp-rpc--dir-locals-find-file-advice)
+  (advice-add 'dir-locals--all-files :around
+              #'tramp-rpc--dir-locals--all-files-advice)
   (advice-add 'hack-dir-local-variables :around
               #'tramp-rpc--hack-dir-local-variables-advice))
 
@@ -460,6 +502,9 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
+  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
+  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
+  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
 
 (defcustom tramp-rpc-install-advice-on-load t

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -488,20 +488,15 @@ so that .dir-locals.el files are detected and loaded normally."
   (with-eval-after-load 'magit-process
     (advice-add 'magit-start-process :around
                 #'tramp-rpc--magit-start-process-advice))
-  ;; Prefer Tramp's external-operation API when available.  On older
-  ;; Tramp versions, fall back to explicit advice for these operations.
-  (if (fboundp 'tramp-add-external-operation)
-      (progn
-        (tramp-add-external-operation
-         'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
-        (tramp-add-external-operation
-         'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc))
-    (advice-add 'locate-dominating-file :around
-                #'tramp-rpc--locate-dominating-file-advice)
-    (advice-add 'dir-locals-find-file :around
-                #'tramp-rpc--dir-locals-find-file-advice)
-    (advice-add 'dir-locals--all-files :around
-                #'tramp-rpc--dir-locals--all-files-advice))
+  ;; Always use explicit advice for these operations.  Using
+  ;; `tramp-add-external-operation' here can recurse while the
+  ;; `tramp-rpc' feature is still loading.
+  (advice-add 'locate-dominating-file :around
+              #'tramp-rpc--locate-dominating-file-advice)
+  (advice-add 'dir-locals-find-file :around
+              #'tramp-rpc--dir-locals-find-file-advice)
+  (advice-add 'dir-locals--all-files :around
+              #'tramp-rpc--dir-locals--all-files-advice)
   (advice-add 'hack-dir-local-variables :around
               #'tramp-rpc--hack-dir-local-variables-advice))
 
@@ -521,13 +516,9 @@ so that .dir-locals.el files are detected and loaded normally."
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
-  (if (fboundp 'tramp-remove-external-operation)
-      (progn
-        (tramp-remove-external-operation 'locate-dominating-file 'tramp-rpc)
-        (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc))
-    (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
-    (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
-    (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice))
+  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
+  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
+  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
 
 (defcustom tramp-rpc-install-advice-on-load t

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -782,6 +782,39 @@ is missing, signals an error."
     (delete-directory tramp-rpc-deploy-local-cache-directory t)
     (message "Cleared tramp-rpc binary cache")))
 
+(defun tramp-rpc-deploy-show-binary-paths (vec)
+  "Show resolved deployment paths for remote VEC.
+Reports remote architecture and the paths used for local cache, bundled
+binary lookup, and remote installation target."
+  (interactive
+   (list (tramp-dissect-file-name
+          (read-file-name "Remote host: " "/rpc:"))))
+  (let* ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
+         (arch (tramp-rpc-deploy--detect-remote-arch bootstrap-vec))
+         (cache (tramp-rpc-deploy--local-cache-path arch))
+         (bundled (tramp-rpc-deploy--bundled-binary-path arch))
+         (remote (tramp-rpc-deploy--remote-binary-path bootstrap-vec))
+         (buf (get-buffer-create "*tramp-rpc-deploy-paths*")))
+    (with-current-buffer buf
+      (erase-buffer)
+      (insert "TRAMP-RPC Binary Path Resolution\n")
+      (insert "===============================\n\n")
+      (insert (format "Host:    %s\n" (tramp-file-name-host bootstrap-vec)))
+      (insert (format "User:    %s\n" (or (tramp-file-name-user bootstrap-vec) "<default>")))
+      (insert (format "Method:  %s (bootstrap)\n" (tramp-file-name-method bootstrap-vec)))
+      (insert (format "Arch:    %s\n\n" arch))
+      (insert (format "Cache:   %s\n" cache))
+      (insert (format "Bundled: %s\n"
+                      (or bundled "<none>")))
+      (insert (format "Remote:  %s\n" (tramp-file-local-name remote))))
+    (display-buffer buf)
+    (message "Resolved binary paths for %s (arch=%s)"
+             (tramp-file-name-host bootstrap-vec) arch)
+    `((arch . ,arch)
+      (cache . ,cache)
+      (bundled . ,bundled)
+      (remote . ,(tramp-file-local-name remote)))))
+
 (defun tramp-rpc-deploy-status ()
   "Show the status of tramp-rpc-server binaries."
   (interactive)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1820,7 +1820,8 @@ If ORIGINAL-LOCALNAME is file-name-quoted, quote NEW-LOCALNAME too."
 
 (defun tramp-rpc--locate-dominating-before-stop-p (search-path dominating-dir)
   "Return non-nil when DOMINATING-DIR is reachable without crossing stop regexp.
-SEARCH-PATH is the lexical path used to start dominating-directory traversal."
+SEARCH-PATH and DOMINATING-DIR must use the same pathname form (remote/local)
+that `locate-dominating-stop-dir-regexp' is expected to match."
   (let ((stop locate-dominating-stop-dir-regexp))
     (if (or (null stop) (equal stop ""))
         t
@@ -1879,13 +1880,18 @@ to the built-in implementation."
                         (names . ,(vconcat names))))))
         (when-let* ((marker (car result))
                     (marker-path (tramp-rpc--decode-string marker)))
-          (let ((dominating-dir (file-name-directory marker-path)))
-            (when (tramp-rpc--locate-dominating-before-stop-p localname dominating-dir)
-              (tramp-make-tramp-file-name
-               v
-               (tramp-rpc--quote-localname
-                quoted-localname
-                dominating-dir)))))))))
+          (let* ((dominating-dir (file-name-directory marker-path))
+                 (search-remote
+                  (tramp-make-tramp-file-name
+                   v
+                   (tramp-rpc--quote-localname quoted-localname localname)))
+                 (dominating-remote
+                  (tramp-make-tramp-file-name
+                   v
+                   (tramp-rpc--quote-localname quoted-localname dominating-dir))))
+            (when (tramp-rpc--locate-dominating-before-stop-p
+                   search-remote dominating-remote)
+              dominating-remote)))))))
 
 (defun tramp-rpc--dir-locals-cache-update (file cache)
   "Call RPC helper for `dir-locals-find-file' update using FILE and CACHE."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1782,6 +1782,40 @@ If ORIGINAL-LOCALNAME is file-name-quoted, quote NEW-LOCALNAME too."
       (file-name-quote new-localname)
     new-localname))
 
+(defun tramp-rpc--parent-directory (directory)
+  "Return parent directory for DIRECTORY, or nil at filesystem root."
+  (let* ((current (directory-file-name directory))
+         (parent (file-name-directory current)))
+    (when parent
+      (let ((parent (directory-file-name parent)))
+        (unless (equal parent current)
+          parent)))))
+
+(defun tramp-rpc--locate-search-directory (path)
+  "Return lexical search directory for locate-dominating PATH."
+  (if (string-suffix-p "/" path)
+      (directory-file-name path)
+    (let ((normalized (directory-file-name path)))
+      (or (and (file-name-directory normalized)
+               (directory-file-name (file-name-directory normalized)))
+          normalized))))
+
+(defun tramp-rpc--locate-dominating-before-stop-p (search-path dominating-dir)
+  "Return non-nil when DOMINATING-DIR is reachable without crossing stop regexp.
+SEARCH-PATH is the lexical path used to start dominating-directory traversal."
+  (let ((stop locate-dominating-stop-dir-regexp))
+    (if (or (null stop) (equal stop ""))
+        t
+      (let ((current (tramp-rpc--locate-search-directory search-path))
+            (target (directory-file-name dominating-dir))
+            (blocked nil))
+        (while (and current (not blocked) (not (equal current target)))
+          (when (string-match-p stop (file-name-as-directory current))
+            (setq blocked t))
+          (setq current (tramp-rpc--parent-directory current)))
+        (and (not blocked)
+             (equal current target))))))
+
 (defun tramp-rpc-handle-dir-locals--all-files (directory &optional base-el-only)
   "Like `dir-locals--all-files' for TRAMP-RPC files.
 Return readable dir-locals files in DIRECTORY in increasing priority order."
@@ -1810,7 +1844,6 @@ Return readable dir-locals files in DIRECTORY in increasing priority order."
   "Like `locate-dominating-file' for TRAMP-RPC files.
 For string/list NAME, uses a high-level RPC call.  Predicate NAME falls back
 to the built-in implementation."
-  ;; This intentionally ignores `locate-dominating-stop-dir-regexp'.
   (if (functionp name)
       (tramp-run-real-handler #'locate-dominating-file (list file name))
     (with-parsed-tramp-file-name
@@ -1828,11 +1861,13 @@ to the built-in implementation."
                         (names . ,(vconcat names))))))
         (when-let* ((marker (car result))
                     (marker-path (tramp-rpc--decode-string marker)))
-          (tramp-make-tramp-file-name
-           v
-           (tramp-rpc--quote-localname
-            quoted-localname
-            (file-name-directory marker-path))))))))
+          (let ((dominating-dir (file-name-directory marker-path)))
+            (when (tramp-rpc--locate-dominating-before-stop-p localname dominating-dir)
+              (tramp-make-tramp-file-name
+               v
+               (tramp-rpc--quote-localname
+                quoted-localname
+                dominating-dir)))))))))
 
 (defun tramp-rpc--dir-locals-cache-update (file cache)
   "Call RPC helper for `dir-locals-find-file' update using FILE and CACHE."
@@ -1866,6 +1901,13 @@ to the built-in implementation."
         (when (time-less-p latest f-time)
           (setq latest f-time))))))
 
+(defun tramp-rpc--dir-locals-cache-covers-p (locals-dir cache-dir)
+  "Return non-nil when CACHE-DIR is at or below LOCALS-DIR."
+  (let ((locals (directory-file-name locals-dir))
+        (cache (directory-file-name cache-dir)))
+    (or (equal locals cache)
+        (file-in-directory-p cache locals))))
+
 (defun tramp-rpc-handle-dir-locals-find-file (file)
   "Like `dir-locals-find-file' for TRAMP-RPC files."
   (let* ((file (if (file-name-absolute-p file)
@@ -1890,7 +1932,7 @@ to the built-in implementation."
                               dir-locals-directory-cache))))
     (if (and dir-elt
              (or (null locals-dir)
-                 (<= (length locals-dir) (length (car dir-elt)))))
+                 (tramp-rpc--dir-locals-cache-covers-p locals-dir (car dir-elt))))
         ;; Potential cache hit, verify mtimes.
         (if (or (null (nth 2 dir-elt))
                 (let ((cached-files (alist-get 'files cache-dir-update)))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -133,6 +133,9 @@
 (declare-function tramp-rpc--multi-hop-advice "tramp-rpc")
 ;; From tramp-rpc-advice.el (loaded at runtime)
 (declare-function tramp-rpc-advice-remove "tramp-rpc-advice")
+;; Tramp 2.8+ APIs used for external operation registration.
+(declare-function tramp-add-external-operation "tramp")
+(declare-function tramp-remove-external-operation "tramp")
 (require 'tramp-rpc-deploy)
 
 ;; Silence byte-compiler warnings for functions defined elsewhere
@@ -2785,7 +2788,9 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
+    (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
     (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
+    (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
     (vc-registered . tramp-rpc-handle-vc-registered)
 
     ;; =========================================================================
@@ -2842,6 +2847,13 @@ Also controls process exit detection latency."
     (unhandled-file-name-directory . ignore) ; Should return nil for TRAMP
     )
   "Alist of handler functions for TRAMP-RPC method.")
+
+;; Defer registration until tramp-rpc is fully loaded so
+;; `tramp-add-external-operation' can safely `(require 'tramp-rpc)'.
+(with-eval-after-load 'tramp-rpc
+  (tramp-add-external-operation 'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
+  (tramp-add-external-operation 'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc)
+  (tramp-add-external-operation 'dir-locals-find-file 'tramp-rpc-handle-dir-locals-find-file 'tramp-rpc))
 
 ;;;###autoload
 (defun tramp-rpc-file-name-handler (operation &rest args)
@@ -2981,6 +2993,10 @@ cleanup of all connections has run."
 (defun tramp-rpc-unload-function ()
   "Unload function for tramp-rpc.
 Removes advice and cleans up async processes."
+  ;; Remove high-level external operations from tramp-rpc core.
+  (tramp-remove-external-operation 'locate-dominating-file 'tramp-rpc)
+  (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc)
+  (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
   ;; Remove all advice (from tramp-rpc-advice module)
   (tramp-rpc-advice-remove)
   ;; Remove legacy multi-hop advice and cleanup hooks.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2487,36 +2487,6 @@ Returns \"/bin/sh\" if the lookup fails."
           "/bin/sh"))
     (error "/bin/sh")))
 
-(defun tramp-rpc--locate-dominating-file-advice (orig-fun file name)
-  "Use RPC fast-path for remote `locate-dominating-file'."
-  (if (and (stringp file)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p file)
-                file
-              (file-name-concat default-directory file))))
-      (tramp-rpc-handle-locate-dominating-file file name)
-    (funcall orig-fun file name)))
-
-(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
-  "Use RPC fast-path for remote `dir-locals-find-file'."
-  (if (and (stringp file)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p file)
-                file
-              (file-name-concat default-directory file))))
-      (tramp-rpc-handle-dir-locals-find-file file)
-    (funcall orig-fun file)))
-
-(defun tramp-rpc--dir-locals--all-files-advice (orig-fun directory &optional base-el-only)
-  "Use RPC fast-path for remote `dir-locals--all-files'."
-  (if (and (stringp directory)
-           (tramp-rpc-file-name-p
-            (if (file-name-absolute-p directory)
-                directory
-              (file-name-concat default-directory directory))))
-      (tramp-rpc-handle-dir-locals--all-files directory base-el-only)
-    (funcall orig-fun directory base-el-only)))
-
 (defun tramp-rpc--fetch-remote-exec-path (vec)
   "Fetch the remote PATH from VEC using the user's login shell.
 Invokes the login shell with `-l' to source shell configuration
@@ -2683,12 +2653,6 @@ Also controls process exit detection latency."
 (require 'tramp-rpc-process)
 (require 'tramp-rpc-advice)
 (require 'tramp-rpc-magit)
-
-;; Use normal advice for high-level parent/dir-locals operations so this works
-;; on TRAMP versions that do not provide external operation registration APIs.
-(advice-add 'locate-dominating-file :around #'tramp-rpc--locate-dominating-file-advice)
-(advice-add 'dir-locals-find-file :around #'tramp-rpc--dir-locals-find-file-advice)
-(advice-add 'dir-locals--all-files :around #'tramp-rpc--dir-locals--all-files-advice)
 
 ;; ============================================================================
 ;; File name handler registration
@@ -2998,10 +2962,7 @@ Removes advice and cleans up async processes."
   ;; Remove all advice (from tramp-rpc-advice module)
   (tramp-rpc-advice-remove)
   ;; Remove legacy multi-hop advice and cleanup hooks.
-  (tramp-rpc--multi-hop-advice-remove)
-  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
-  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
-  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
+  (advice-remove 'tramp-multi-hop-p #'tramp-rpc--multi-hop-advice)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
   (remove-hook 'tramp-cleanup-all-connections-hook #'tramp-rpc-cleanup-all-connections)
   ;; Clean up all async processes (from tramp-rpc-process module)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1580,6 +1580,13 @@ When BASE-EL-ONLY is non-nil, return only `dir-locals-file'."
         (list file-1)
       (delq nil (list file-1 file-2)))))
 
+(defun tramp-rpc--quote-localname (original-localname new-localname)
+  "Return NEW-LOCALNAME with ORIGINAL-LOCALNAME quoting style.
+If ORIGINAL-LOCALNAME is file-name-quoted, quote NEW-LOCALNAME too."
+  (if (file-name-quoted-p original-localname)
+      (file-name-quote new-localname)
+    new-localname))
+
 (defun tramp-rpc-handle-dir-locals--all-files (directory &optional base-el-only)
   "Like `dir-locals--all-files' for TRAMP-RPC files.
 Return readable dir-locals files in DIRECTORY in increasing priority order."
@@ -1588,14 +1595,20 @@ Return readable dir-locals files in DIRECTORY in increasing priority order."
           directory
         (file-name-concat default-directory directory))
       nil
-    (let* ((localdir (directory-file-name localname))
+    ;; Unquote file names (e.g. /: prefix) before sending to server.
+    (let* ((quoted-localname localname)
+           (localdir (directory-file-name (file-name-unquote localname)))
            (names (tramp-rpc--dir-locals-candidate-files base-el-only))
            (result (tramp-rpc--call
                     v "highlevel.test_files_in_dir"
                     `((directory . ,(tramp-rpc--path-to-bytes localdir))
                       (names . ,(vconcat names))))))
       (mapcar (lambda (path)
-                (tramp-make-tramp-file-name v (tramp-rpc--decode-string path)))
+                (tramp-make-tramp-file-name
+                 v
+                 (tramp-rpc--quote-localname
+                  quoted-localname
+                  (tramp-rpc--decode-string path))))
               result))))
 
 (defun tramp-rpc-handle-locate-dominating-file (file name)
@@ -1610,14 +1623,21 @@ to the built-in implementation."
             file
           (file-name-concat default-directory file))
         nil
-      (let* ((names (ensure-list name))
+      ;; Unquote file names (e.g. /: prefix) before sending to server.
+      (let* ((quoted-localname localname)
+             (localname (file-name-unquote localname))
+             (names (ensure-list name))
              (result (tramp-rpc--call
                       v "highlevel.locate_dominating_file_multi"
                       `((file . ,(tramp-rpc--path-to-bytes localname))
                         (names . ,(vconcat names))))))
         (when-let* ((marker (car result))
                     (marker-path (tramp-rpc--decode-string marker)))
-          (tramp-make-tramp-file-name v (file-name-directory marker-path)))))))
+          (tramp-make-tramp-file-name
+           v
+           (tramp-rpc--quote-localname
+            quoted-localname
+            (file-name-directory marker-path))))))))
 
 (defun tramp-rpc--dir-locals-cache-update (file cache)
   "Call RPC helper for `dir-locals-find-file' update using FILE and CACHE."
@@ -1626,7 +1646,9 @@ to the built-in implementation."
           file
         (file-name-concat default-directory file))
       nil
-    (let* ((file-connection (file-remote-p file))
+    ;; Unquote file names (e.g. /: prefix) before sending to server.
+    (let* ((localname (file-name-unquote localname))
+           (file-connection (file-remote-p file))
            (names (tramp-rpc--dir-locals-candidate-files nil))
            (cache-dirs
             (seq-uniq
@@ -1634,12 +1656,20 @@ to the built-in implementation."
               for cache-entry in cache
               for cache-dir = (car cache-entry)
               when (string= file-connection (file-remote-p cache-dir))
-              collect (file-local-name cache-dir)))))
+              collect (file-name-unquote (file-local-name cache-dir))))))
       (tramp-rpc--call
        v "highlevel.dir_locals_find_file_cache_update"
        `((file . ,(tramp-rpc--path-to-bytes localname))
          (names . ,(vconcat names))
          (cache_dirs . ,(vconcat cache-dirs)))))))
+
+(defun tramp-rpc--dir-locals-latest-mtime (files)
+  "Return latest mtime from FILES alist data as a Lisp time value."
+  (let ((latest 0))
+    (dolist (f files latest)
+      (let ((f-time (seconds-to-time (alist-get 'mtime f))))
+        (when (time-less-p latest f-time)
+          (setq latest f-time))))))
 
 (defun tramp-rpc-handle-dir-locals-find-file (file)
   "Like `dir-locals-find-file' for TRAMP-RPC files."
@@ -1670,11 +1700,7 @@ to the built-in implementation."
                   (and cached-files
                        (time-equal-p
                         (nth 2 dir-elt)
-                        (let ((latest 0))
-                          (dolist (f cached-files latest)
-                            (let ((f-time (seconds-to-time (alist-get 'mtime f))))
-                              (when (time-less-p latest f-time)
-                                (setq latest f-time))))))))
+                        (tramp-rpc--dir-locals-latest-mtime cached-files)))))
             dir-elt
           (progn
             ;; Cache entry invalid, clear and return discovered locals dir.
@@ -1682,7 +1708,7 @@ to the built-in implementation."
                   (delq dir-elt dir-locals-directory-cache))
             locals-dir))
       ;; No cache entry.
-      locals-dir))))
+      locals-dir)))
 
 ;; ============================================================================
 ;; Directory operations
@@ -2753,8 +2779,6 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
-    (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
-    (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
     (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
     (vc-registered . tramp-rpc-handle-vc-registered)
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -131,6 +131,8 @@
 
 ;; Silence byte-compiler warning for function defined in with-eval-after-load
 (declare-function tramp-rpc--multi-hop-advice "tramp-rpc")
+;; From tramp-rpc-advice.el (loaded at runtime)
+(declare-function tramp-rpc-advice-remove "tramp-rpc-advice")
 (require 'tramp-rpc-deploy)
 
 ;; Silence byte-compiler warnings for functions defined elsewhere
@@ -2693,7 +2695,11 @@ Also controls process exit detection latency."
 ;; Process support, advice functions, and magit integration are now in
 ;; separate modules for better organization and maintainability.
 (require 'tramp-rpc-process)
-(require 'tramp-rpc-advice)
+;; Loading tramp-rpc-advice while this file is being byte-compiled can
+;; recurse on some Emacs/TRAMP combinations.  Advice is still loaded at
+;; runtime when `tramp-rpc' is required normally.
+(unless (bound-and-true-p byte-compile-current-file)
+  (require 'tramp-rpc-advice))
 (require 'tramp-rpc-magit)
 
 ;; ============================================================================

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1685,14 +1685,16 @@ to the built-in implementation."
          (cache-update (tramp-rpc--dir-locals-cache-update file dir-locals-directory-cache))
          (locals-dir-update (alist-get 'locals cache-update))
          (locals-dir (when locals-dir-update
-                       (concat file-connection
-                               (tramp-rpc--decode-string
-                                (alist-get 'dir locals-dir-update)))))
+                       (file-name-as-directory
+                        (concat file-connection
+                                (tramp-rpc--decode-string
+                                 (alist-get 'dir locals-dir-update))))))
          (cache-dir-update (alist-get 'cache cache-update))
          (cache-dir (when cache-dir-update
-                      (concat file-connection
-                              (tramp-rpc--decode-string
-                               (alist-get 'dir cache-dir-update)))))
+                      (file-name-as-directory
+                       (concat file-connection
+                               (tramp-rpc--decode-string
+                                (alist-get 'dir cache-dir-update))))))
          (dir-elt (when cache-dir
                     (seq-find (lambda (elt) (string= (car elt) cache-dir))
                               dir-locals-directory-cache))))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1558,6 +1558,124 @@ TYPE is the file type string."
 
 
 ;; ============================================================================
+;; High-level operations
+;; ============================================================================
+
+(defun tramp-rpc--dir-locals-candidate-files (&optional base-el-only)
+  "Return dir-locals candidate file names.
+When BASE-EL-ONLY is non-nil, return only `dir-locals-file'."
+  (let ((file-1 dir-locals-file)
+        (file-2 (and (string-match "\\.el\\'" dir-locals-file)
+                     (replace-match "-2.el" t nil dir-locals-file))))
+    (if base-el-only
+        (list file-1)
+      (delq nil (list file-1 file-2)))))
+
+(defun tramp-rpc-handle-dir-locals--all-files (directory &optional base-el-only)
+  "Like `dir-locals--all-files' for TRAMP-RPC files.
+Return readable dir-locals files in DIRECTORY in increasing priority order."
+  (with-parsed-tramp-file-name
+      (if (file-name-absolute-p directory)
+          directory
+        (file-name-concat default-directory directory))
+      nil
+    (let* ((localdir (directory-file-name localname))
+           (names (tramp-rpc--dir-locals-candidate-files base-el-only))
+           (result (tramp-rpc--call
+                    v "highlevel.test_files_in_dir"
+                    `((directory . ,(tramp-rpc--path-to-bytes localdir))
+                      (names . ,(vconcat names))))))
+      (mapcar (lambda (path)
+                (tramp-make-tramp-file-name v (tramp-rpc--decode-string path)))
+              result))))
+
+(defun tramp-rpc-handle-locate-dominating-file (file name)
+  "Like `locate-dominating-file' for TRAMP-RPC files.
+For string/list NAME, uses a high-level RPC call.  Predicate NAME falls back
+to the built-in implementation."
+  ;; This intentionally ignores `locate-dominating-stop-dir-regexp'.
+  (if (functionp name)
+      (tramp-run-real-handler #'locate-dominating-file (list file name))
+    (with-parsed-tramp-file-name
+        (if (file-name-absolute-p file)
+            file
+          (file-name-concat default-directory file))
+        nil
+      (let* ((names (ensure-list name))
+             (result (tramp-rpc--call
+                      v "highlevel.locate_dominating_file_multi"
+                      `((file . ,(tramp-rpc--path-to-bytes localname))
+                        (names . ,(vconcat names))))))
+        (when-let* ((marker (car result))
+                    (marker-path (tramp-rpc--decode-string marker)))
+          (tramp-make-tramp-file-name v (file-name-directory marker-path)))))))
+
+(defun tramp-rpc--dir-locals-cache-update (file cache)
+  "Call RPC helper for `dir-locals-find-file' update using FILE and CACHE."
+  (with-parsed-tramp-file-name
+      (if (file-name-absolute-p file)
+          file
+        (file-name-concat default-directory file))
+      nil
+    (let* ((file-connection (file-remote-p file))
+           (names (tramp-rpc--dir-locals-candidate-files nil))
+           (cache-dirs
+            (seq-uniq
+             (cl-loop
+              for cache-entry in cache
+              for cache-dir = (car cache-entry)
+              when (string= file-connection (file-remote-p cache-dir))
+              collect (file-local-name cache-dir)))))
+      (tramp-rpc--call
+       v "highlevel.dir_locals_find_file_cache_update"
+       `((file . ,(tramp-rpc--path-to-bytes localname))
+         (names . ,(vconcat names))
+         (cache_dirs . ,(vconcat cache-dirs)))))))
+
+(defun tramp-rpc-handle-dir-locals-find-file (file)
+  "Like `dir-locals-find-file' for TRAMP-RPC files."
+  (let* ((file (if (file-name-absolute-p file)
+                   file
+                 (file-name-concat default-directory file)))
+         (file-connection (file-remote-p file))
+         (cache-update (tramp-rpc--dir-locals-cache-update file dir-locals-directory-cache))
+         (locals-dir-update (alist-get 'locals cache-update))
+         (locals-dir (when locals-dir-update
+                       (concat file-connection
+                               (tramp-rpc--decode-string
+                                (alist-get 'dir locals-dir-update)))))
+         (cache-dir-update (alist-get 'cache cache-update))
+         (cache-dir (when cache-dir-update
+                      (concat file-connection
+                              (tramp-rpc--decode-string
+                               (alist-get 'dir cache-dir-update)))))
+         (dir-elt (when cache-dir
+                    (seq-find (lambda (elt) (string= (car elt) cache-dir))
+                              dir-locals-directory-cache))))
+    (if (and dir-elt
+             (or (null locals-dir)
+                 (<= (length locals-dir) (length (car dir-elt)))))
+        ;; Potential cache hit, verify mtimes.
+        (if (or (null (nth 2 dir-elt))
+                (let ((cached-files (alist-get 'files cache-dir-update)))
+                  (and cached-files
+                       (time-equal-p
+                        (nth 2 dir-elt)
+                        (let ((latest 0))
+                          (dolist (f cached-files latest)
+                            (let ((f-time (seconds-to-time (alist-get 'mtime f))))
+                              (when (time-less-p latest f-time)
+                                (setq latest f-time))))))))
+            dir-elt
+          (progn
+            ;; Cache entry invalid, clear and return discovered locals dir.
+            (setq dir-locals-directory-cache
+                  (delq dir-elt dir-locals-directory-cache))
+            locals-dir))
+      ;; No cache entry.
+      locals-dir))))
+
+;; ============================================================================
 ;; Directory operations
 ;; ============================================================================
 
@@ -2369,6 +2487,36 @@ Returns \"/bin/sh\" if the lookup fails."
           "/bin/sh"))
     (error "/bin/sh")))
 
+(defun tramp-rpc--locate-dominating-file-advice (orig-fun file name)
+  "Use RPC fast-path for remote `locate-dominating-file'."
+  (if (and (stringp file)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p file)
+                file
+              (file-name-concat default-directory file))))
+      (tramp-rpc-handle-locate-dominating-file file name)
+    (funcall orig-fun file name)))
+
+(defun tramp-rpc--dir-locals-find-file-advice (orig-fun file)
+  "Use RPC fast-path for remote `dir-locals-find-file'."
+  (if (and (stringp file)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p file)
+                file
+              (file-name-concat default-directory file))))
+      (tramp-rpc-handle-dir-locals-find-file file)
+    (funcall orig-fun file)))
+
+(defun tramp-rpc--dir-locals--all-files-advice (orig-fun directory &optional base-el-only)
+  "Use RPC fast-path for remote `dir-locals--all-files'."
+  (if (and (stringp directory)
+           (tramp-rpc-file-name-p
+            (if (file-name-absolute-p directory)
+                directory
+              (file-name-concat default-directory directory))))
+      (tramp-rpc-handle-dir-locals--all-files directory base-el-only)
+    (funcall orig-fun directory base-el-only)))
+
 (defun tramp-rpc--fetch-remote-exec-path (vec)
   "Fetch the remote PATH from VEC using the user's login shell.
 Invokes the login shell with `-l' to source shell configuration
@@ -2536,6 +2684,12 @@ Also controls process exit detection latency."
 (require 'tramp-rpc-advice)
 (require 'tramp-rpc-magit)
 
+;; Use normal advice for high-level parent/dir-locals operations so this works
+;; on TRAMP versions that do not provide external operation registration APIs.
+(advice-add 'locate-dominating-file :around #'tramp-rpc--locate-dominating-file-advice)
+(advice-add 'dir-locals-find-file :around #'tramp-rpc--dir-locals-find-file-advice)
+(advice-add 'dir-locals--all-files :around #'tramp-rpc--dir-locals--all-files-advice)
+
 ;; ============================================================================
 ;; File name handler registration
 ;; ============================================================================
@@ -2619,6 +2773,9 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
+    (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
+    (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
+    (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
     (vc-registered . tramp-rpc-handle-vc-registered)
 
     ;; =========================================================================
@@ -2712,10 +2869,6 @@ VEC-OR-FILENAME can be either a tramp-file-name struct or a filename string."
 ;; byte-compiled defun version is used.)
 (tramp-register-foreign-file-name-handler
  #'tramp-rpc-file-name-p #'tramp-rpc-file-name-handler)
-
-(defun tramp-rpc--multi-hop-advice-remove ()
-  "Remove multi-hop advice."
-  (advice-remove 'process-send-string #'tramp-rpc--multi-hop-advice))
 
 ;; ============================================================================
 ;; Recentf integration
@@ -2841,15 +2994,21 @@ cleanup of all connections has run."
 
 (defun tramp-rpc-unload-function ()
   "Unload function for tramp-rpc.
-Removes advice and cleanup hooks.  Deletes `tramp-rpc-method' from
-`tramp-methods', and `tramp-rpc-file-name-p' from
-`tramp-foreign-file-name-handler-alist'."
-  ;; Remove advice.
+Removes advice and cleans up async processes."
+  ;; Remove all advice (from tramp-rpc-advice module)
+  (tramp-rpc-advice-remove)
+  ;; Remove legacy multi-hop advice and cleanup hooks.
   (tramp-rpc--multi-hop-advice-remove)
-  ;; Remove cleanup hooks.
+  (advice-remove 'locate-dominating-file #'tramp-rpc--locate-dominating-file-advice)
+  (advice-remove 'dir-locals-find-file #'tramp-rpc--dir-locals-find-file-advice)
+  (advice-remove 'dir-locals--all-files #'tramp-rpc--dir-locals--all-files-advice)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
   (remove-hook 'tramp-cleanup-all-connections-hook #'tramp-rpc-cleanup-all-connections)
-  ;; Clean up `tramp-methods' and `tramp-foreign-file-name-handler-alist'.
+  ;; Clean up all async processes (from tramp-rpc-process module)
+  (tramp-rpc--cleanup-async-processes)
+  ;; Clean up PTY processes (from tramp-rpc-process module)
+  (tramp-rpc--cleanup-pty-processes)
+  ;; Remove method registrations.
   (setq tramp-methods (delete (assoc tramp-rpc-method tramp-methods) tramp-methods))
   (setq tramp-foreign-file-name-handler-alist
 	(delete (assoc 'tramp-rpc-file-name-p tramp-foreign-file-name-handler-alist)

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -9,9 +9,11 @@ use crate::protocol::{from_value, IntoValue, RpcError};
 use rmpv::Value;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::Path;
+use std::fs::File;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
+use std::time::UNIX_EPOCH;
 
 use super::HandlerResult;
 
@@ -109,10 +111,7 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
             // Recover from thread panics instead of unwinding
             handles
                 .into_iter()
-                .filter_map(|h| match h.join() {
-                    Ok(result) => Some(result),
-                    Err(_) => None, // thread panicked; skip this result
-                })
+                .filter_map(|h| h.join().ok()) // thread panicked; skip this result
                 .collect()
         });
 
@@ -199,6 +198,239 @@ pub async fn ancestors_scan(params: Value) -> HandlerResult {
             .collect();
 
         Ok(Value::Map(pairs))
+    })
+    .await
+    .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn find_existing_start(path: &Path) -> Option<&Path> {
+    if path.exists() {
+        return Some(path);
+    }
+
+    let mut current = path;
+    while !current.exists() {
+        current = current.parent()?;
+    }
+    Some(current)
+}
+
+fn as_search_dir(path: &Path) -> Option<PathBuf> {
+    if path.is_dir() {
+        Some(path.to_path_buf())
+    } else {
+        path.parent().map(|p| p.to_path_buf())
+    }
+}
+
+fn find_dominating_dir(start_dir: &Path, names: &[String]) -> Option<(PathBuf, Vec<String>)> {
+    let mut current = start_dir.to_path_buf();
+    loop {
+        let found: Vec<String> = names
+            .iter()
+            .filter(|name| current.join(name.as_str()).exists())
+            .cloned()
+            .collect();
+
+        if !found.is_empty() {
+            return Some((current, found));
+        }
+
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+}
+
+fn mtime_seconds(path: &Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let duration = modified.duration_since(UNIX_EPOCH).ok()?;
+    Some(duration.as_secs() as i64)
+}
+
+/// Return readable regular files from a directory for a list of names.
+pub async fn highlevel_test_files_in_dir(params: &Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        directory: String,
+        names: Vec<String>,
+    }
+
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        let dir = canonical_or_original(Path::new(&params.directory));
+        if !dir.is_dir() {
+            return Ok(Value::Array(vec![]));
+        }
+
+        let mut found = Vec::new();
+        for name in &params.names {
+            let candidate = dir.join(name);
+            if candidate.is_file() && File::open(&candidate).is_ok() {
+                found.push(candidate.to_string_lossy().to_string().into_value());
+            }
+        }
+        Ok(Value::Array(found))
+    })
+    .await
+    .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?
+}
+
+/// Locate marker files in ancestor directories.
+///
+/// Returns marker paths from the first ancestor that contains any markers.
+pub async fn highlevel_locate_dominating_file_multi(params: &Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        file: String,
+        names: Vec<String>,
+    }
+
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        let path = PathBuf::from(&params.file);
+        // Preserve lexical path shape instead of canonicalizing symlinks.
+        // TRAMP clients rely on this to compute repo-relative paths correctly.
+        let Some(existing_start) = find_existing_start(&path) else {
+            return Ok(Value::Array(vec![]));
+        };
+        let Some(start_dir) = as_search_dir(existing_start) else {
+            return Ok(Value::Array(vec![]));
+        };
+
+        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names) else {
+            return Ok(Value::Array(vec![]));
+        };
+
+        let marker_paths: Vec<Value> = found_names
+            .into_iter()
+            .map(|name| dir.join(name).to_string_lossy().to_string().into_value())
+            .collect();
+        Ok(Value::Array(marker_paths))
+    })
+    .await
+    .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?
+}
+
+/// Prepare dir-locals data in one RPC call.
+pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        file: String,
+        names: Vec<String>,
+        #[serde(default)]
+        cache_dirs: Vec<String>,
+    }
+
+    let params: Params =
+        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        let file_path = PathBuf::from(&params.file);
+        let resolved_file = if file_path.exists() {
+            canonical_or_original(&file_path)
+        } else {
+            file_path.clone()
+        };
+
+        let file_value = resolved_file.to_string_lossy().to_string().into_value();
+
+        let Some(existing_start) = find_existing_start(&file_path) else {
+            return Ok(msgpack_map! {
+                "file" => file_value,
+                "locals" => Value::Nil,
+                "cache" => Value::Nil
+            });
+        };
+        let Some(start_dir) = as_search_dir(&canonical_or_original(existing_start)) else {
+            return Ok(msgpack_map! {
+                "file" => file_value,
+                "locals" => Value::Nil,
+                "cache" => Value::Nil
+            });
+        };
+
+        let locals_value =
+            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names) {
+                let local_files: Vec<Value> = params
+                    .names
+                    .iter()
+                    .filter_map(|name| {
+                        let p = locals_dir.join(name);
+                        if p.is_file() {
+                            mtime_seconds(&p).map(|mtime| {
+                                msgpack_map! {
+                                    "name" => name.clone(),
+                                    "mtime" => mtime
+                                }
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                msgpack_map! {
+                    "dir" => locals_dir.to_string_lossy().to_string(),
+                    "files" => Value::Array(local_files)
+                }
+            } else {
+                Value::Nil
+            };
+
+        let mut best_cache: Option<PathBuf> = None;
+        for cache_dir in &params.cache_dirs {
+            let p = PathBuf::from(cache_dir);
+            if p.is_dir()
+                && resolved_file.starts_with(&p)
+                && best_cache
+                    .as_ref()
+                    .map(|best| p.components().count() > best.components().count())
+                    .unwrap_or(true)
+            {
+                best_cache = Some(p);
+            }
+        }
+
+        let cache_value = if let Some(cache_dir) = best_cache {
+            let cache_files: Vec<Value> = params
+                .names
+                .iter()
+                .filter_map(|name| {
+                    let p = cache_dir.join(name);
+                    if p.is_file() {
+                        mtime_seconds(&p).map(|mtime| {
+                            msgpack_map! {
+                                "name" => name.clone(),
+                                "mtime" => mtime
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            msgpack_map! {
+                "dir" => cache_dir.to_string_lossy().to_string(),
+                "files" => Value::Array(cache_files)
+            }
+        } else {
+            Value::Nil
+        };
+
+        Ok(msgpack_map! {
+            "file" => file_value,
+            "locals" => locals_value,
+            "cache" => cache_value
+        })
     })
     .await
     .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -247,6 +247,20 @@ fn find_dominating_dir(start_dir: &Path, names: &[String]) -> Option<(PathBuf, V
     }
 }
 
+fn remap_to_lexical_ancestor(start_dir: &Path, found_dir: &Path) -> PathBuf {
+    let canonical_found = canonical_or_original(found_dir);
+    let mut current = start_dir.to_path_buf();
+    loop {
+        if canonical_or_original(&current) == canonical_found {
+            return current;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => return found_dir.to_path_buf(),
+        }
+    }
+}
+
 fn mtime_seconds(path: &Path) -> Option<i64> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
     let duration = modified.duration_since(UNIX_EPOCH).ok()?;
@@ -254,15 +268,14 @@ fn mtime_seconds(path: &Path) -> Option<i64> {
 }
 
 /// Return readable regular files from a directory for a list of names.
-pub async fn highlevel_test_files_in_dir(params: &Value) -> HandlerResult {
+pub async fn highlevel_test_files_in_dir(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         directory: String,
         names: Vec<String>,
     }
 
-    let params: Params =
-        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
         let dir = canonical_or_original(Path::new(&params.directory));
@@ -286,15 +299,14 @@ pub async fn highlevel_test_files_in_dir(params: &Value) -> HandlerResult {
 /// Locate marker files in ancestor directories.
 ///
 /// Returns marker paths from the first ancestor that contains any markers.
-pub async fn highlevel_locate_dominating_file_multi(params: &Value) -> HandlerResult {
+pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         file: String,
         names: Vec<String>,
     }
 
-    let params: Params =
-        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
         let path = PathBuf::from(&params.file);
@@ -322,7 +334,7 @@ pub async fn highlevel_locate_dominating_file_multi(params: &Value) -> HandlerRe
 }
 
 /// Prepare dir-locals data in one RPC call.
-pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> HandlerResult {
+pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         file: String,
@@ -331,18 +343,13 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> Hand
         cache_dirs: Vec<String>,
     }
 
-    let params: Params =
-        from_value(params.clone()).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
         let file_path = PathBuf::from(&params.file);
-        let resolved_file = if file_path.exists() {
-            canonical_or_original(&file_path)
-        } else {
-            file_path.clone()
-        };
-
-        let file_value = resolved_file.to_string_lossy().to_string().into_value();
+        // Keep lexical (non-canonical) path shape to match locate-dominating behavior.
+        let lexical_file = file_path.clone();
+        let file_value = lexical_file.to_string_lossy().to_string().into_value();
 
         let Some(existing_start) = find_existing_start(&file_path) else {
             return Ok(msgpack_map! {
@@ -351,7 +358,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> Hand
                 "cache" => Value::Nil
             });
         };
-        let Some(start_dir) = as_search_dir(&canonical_or_original(existing_start)) else {
+        let Some(start_dir) = as_search_dir(existing_start) else {
             return Ok(msgpack_map! {
                 "file" => file_value,
                 "locals" => Value::Nil,
@@ -361,6 +368,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> Hand
 
         let locals_value =
             if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names) {
+                let locals_dir = remap_to_lexical_ancestor(&start_dir, &locals_dir);
                 let local_files: Vec<Value> = params
                     .names
                     .iter()
@@ -390,7 +398,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: &Value) -> Hand
         for cache_dir in &params.cache_dirs {
             let p = PathBuf::from(cache_dir);
             if p.is_dir()
-                && resolved_file.starts_with(&p)
+                && lexical_file.starts_with(&p)
                 && best_cache
                     .as_ref()
                     .map(|best| p.components().count() > best.components().count())

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -227,8 +227,14 @@ fn as_search_dir(path: &Path) -> Option<PathBuf> {
     }
 }
 
-fn find_dominating_dir(start_dir: &Path, names: &[String]) -> Option<(PathBuf, Vec<String>)> {
+const MAX_DOMINATING_DEPTH: usize = 100;
+
+fn find_dominating_dir(
+    start_dir: &Path,
+    names: &[String],
+) -> Result<Option<(PathBuf, Vec<String>)>, RpcError> {
     let mut current = start_dir.to_path_buf();
+    let mut depth = 0usize;
     loop {
         let found: Vec<String> = names
             .iter()
@@ -237,12 +243,21 @@ fn find_dominating_dir(start_dir: &Path, names: &[String]) -> Option<(PathBuf, V
             .collect();
 
         if !found.is_empty() {
-            return Some((current, found));
+            return Ok(Some((current, found)));
         }
 
         match current.parent() {
-            Some(parent) if parent != current => current = parent.to_path_buf(),
-            _ => return None,
+            Some(parent) if parent != current => {
+                if depth >= MAX_DOMINATING_DEPTH {
+                    return Err(RpcError::invalid_params(format!(
+                        "Maximum ancestor traversal depth ({}) exceeded",
+                        MAX_DOMINATING_DEPTH
+                    )));
+                }
+                current = parent.to_path_buf();
+                depth += 1;
+            }
+            _ => return Ok(None),
         }
     }
 }
@@ -319,7 +334,7 @@ pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerRes
             return Ok(Value::Array(vec![]));
         };
 
-        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names) else {
+        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names)? else {
             return Ok(Value::Array(vec![]));
         };
 
@@ -367,7 +382,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
         };
 
         let locals_value =
-            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names) {
+            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names)? {
                 let locals_dir = remap_to_lexical_ancestor(&start_dir, &locals_dir);
                 let local_files: Vec<Value> = params
                     .names

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -312,6 +312,15 @@ async fn dispatch_inner(request: Request) -> Response {
         // Parallel command execution and ancestor scanning
         "commands.run_parallel" => commands::run_parallel(params).await,
         "ancestors.scan" => commands::ancestors_scan(params).await,
+        "highlevel.test_files_in_dir" => {
+            commands::highlevel_test_files_in_dir(&params).await
+        }
+        "highlevel.locate_dominating_file_multi" => {
+            commands::highlevel_locate_dominating_file_multi(&params).await
+        }
+        "highlevel.dir_locals_find_file_cache_update" => {
+            commands::highlevel_dir_locals_find_file_cache_update(&params).await
+        }
 
         // Filesystem watch operations (for cache invalidation)
         "watch.add" => crate::watcher::handle_add(params),

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -312,9 +312,7 @@ async fn dispatch_inner(request: Request) -> Response {
         // Parallel command execution and ancestor scanning
         "commands.run_parallel" => commands::run_parallel(params).await,
         "ancestors.scan" => commands::ancestors_scan(params).await,
-        "highlevel.test_files_in_dir" => {
-            commands::highlevel_test_files_in_dir(&params).await
-        }
+        "highlevel.test_files_in_dir" => commands::highlevel_test_files_in_dir(&params).await,
         "highlevel.locate_dominating_file_multi" => {
             commands::highlevel_locate_dominating_file_multi(&params).await
         }

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -312,12 +312,12 @@ async fn dispatch_inner(request: Request) -> Response {
         // Parallel command execution and ancestor scanning
         "commands.run_parallel" => commands::run_parallel(params).await,
         "ancestors.scan" => commands::ancestors_scan(params).await,
-        "highlevel.test_files_in_dir" => commands::highlevel_test_files_in_dir(&params).await,
+        "highlevel.test_files_in_dir" => commands::highlevel_test_files_in_dir(params).await,
         "highlevel.locate_dominating_file_multi" => {
-            commands::highlevel_locate_dominating_file_multi(&params).await
+            commands::highlevel_locate_dominating_file_multi(params).await
         }
         "highlevel.dir_locals_find_file_cache_update" => {
-            commands::highlevel_dir_locals_find_file_cache_update(&params).await
+            commands::highlevel_dir_locals_find_file_cache_update(params).await
         }
 
         // Filesystem watch operations (for cache invalidation)

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -280,7 +280,7 @@ pub async fn read(params: Value) -> HandlerResult {
         "stdout" => stdout_val,
         "stderr" => stderr_val,
         "exited" => exit_status.is_some(),
-        "exit_code" => exit_status.map(|s| crate::protocol::exit_code_from_status(s)).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        "exit_code" => exit_status.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
     })
 }
 
@@ -394,7 +394,7 @@ pub async fn list(_params: Value) -> HandlerResult {
                 "os_pid" => managed.child.id().map(|id| Value::Integer((id as i64).into())).unwrap_or(Value::Nil),
                 "cmd" => managed.cmd.clone(),
                 "exited" => exited.is_some(),
-                "exit_code" => exited.map(|s| crate::protocol::exit_code_from_status(s)).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+                "exit_code" => exited.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
             }
         })
         .collect();

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -199,12 +199,10 @@ async fn debounce_loop(mut rx: mpsc::Receiver<Event>, writer: WriterHandle) {
         }
 
         // Phase 3: Send notification with all collected paths
-        if !pending_paths.is_empty() {
-            if send_notification(&writer, &pending_paths).await.is_err() {
-                // Stdout is broken (Emacs disconnected), stop the loop.
-                // Cannot use eprintln! as SSH merges stderr with stdout.
-                break;
-            }
+        if !pending_paths.is_empty() && send_notification(&writer, &pending_paths).await.is_err() {
+            // Stdout is broken (Emacs disconnected), stop the loop.
+            // Cannot use eprintln! as SSH merges stderr with stdout.
+            break;
         }
     }
 }

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1033,6 +1033,42 @@ because rpc had no tramp-login-args and the host-check in
        (lambda () (setq orig-called t)))
       (should orig-called))))
 
+(ert-deftest tramp-rpc-mock-test-locate-dominating-file-unquotes-and-requotes-paths ()
+  "Ensure locate-dominating handler unquotes RPC paths for transport.
+Quoted RPC localnames (/: prefix) must be unquoted for server filesystem
+operations and re-quoted on the way back."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let (captured-file)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (string= method "highlevel.locate_dominating_file_multi"))
+                 (setq captured-file
+                       (decode-coding-string (alist-get 'file params) 'utf-8 t))
+                 (list (encode-coding-string "/tmp/tramp-rpc-root/.git" 'utf-8 t)))))
+      (let* ((default-directory "/rpc:host:/:/tmp/tramp-rpc-root/subdir/")
+             (result (tramp-rpc-handle-locate-dominating-file "foo" ".git")))
+        (should (equal captured-file "/tmp/tramp-rpc-root/subdir/foo"))
+        (should (equal result "/rpc:host:/:/tmp/tramp-rpc-root/"))))))
+
+(ert-deftest tramp-rpc-mock-test-dir-locals-all-files-unquotes-and-requotes-paths ()
+  "Ensure dir-locals-all-files handler preserves quoted RPC localnames."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let (captured-directory)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (string= method "highlevel.test_files_in_dir"))
+                 (setq captured-directory
+                       (decode-coding-string (alist-get 'directory params) 'utf-8 t))
+                 (list (encode-coding-string "/tmp/tramp-rpc-root/.dir-locals.el"
+                                             'utf-8 t)))))
+      (let ((result (tramp-rpc-handle-dir-locals--all-files
+                     "/rpc:host:/:/tmp/tramp-rpc-root/" nil)))
+        (should (equal captured-directory "/tmp/tramp-rpc-root"))
+        (should (equal result
+                       '("/rpc:host:/:/tmp/tramp-rpc-root/.dir-locals.el")))))))
+
 (ert-deftest tramp-rpc-mock-test-dir-locals-advice-installed ()
   "Test that the dir-locals advice is installed and removed correctly."
   :tags '(:dir-locals)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1069,22 +1069,6 @@ operations and re-quoted on the way back."
         (should (equal result
                        '("/rpc:host:/:/tmp/tramp-rpc-root/.dir-locals.el")))))))
 
-(ert-deftest tramp-rpc-mock-test-dir-locals-advice-installed ()
-  "Test that the dir-locals advice is installed and removed correctly."
-  :tags '(:dir-locals)
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  ;; After loading tramp-rpc-advice, the advice should be active.
-  (should (advice-member-p #'tramp-rpc--hack-dir-local-variables-advice
-                           'hack-dir-local-variables))
-  ;; After removing, it should be gone.
-  (unwind-protect
-      (progn
-        (tramp-rpc-advice-remove)
-        (should-not (advice-member-p #'tramp-rpc--hack-dir-local-variables-advice
-                                     'hack-dir-local-variables)))
-    ;; Restore advice for remaining tests.
-    (tramp-rpc-advice-install)))
-
 ;;; ============================================================================
 ;;; Non-essential / recentf Tests (No server or SSH required)
 ;;; ============================================================================

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -550,6 +550,32 @@ Returns the result or signals an error."
             (should (string-match-p "/\\.git\\'" first)))))
     (tramp-rpc-mock-test--stop-server)))
 
+(ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-depth-limit ()
+  "Ensure dominating-file helper errors after 100 ancestor levels."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((root (expand-file-name "highlevel-depth-limit" tramp-rpc-mock-test-temp-dir))
+               (deep-rel (mapconcat (lambda (n) (format "d%03d" n))
+                                    (number-sequence 1 110) "/"))
+               (deep (expand-file-name deep-rel root))
+               (file (expand-file-name "file.txt" deep)))
+          (make-directory deep t)
+          (make-directory (expand-file-name ".git" root) t)
+          (with-temp-file file (insert "x"))
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "highlevel.locate_dominating_file_multi"
+                         `((file . ,(encode-coding-string file 'utf-8))
+                           (names . [".git"])))))
+            (should (stringp (plist-get result :error)))
+            (should (string-match-p
+                     "Maximum ancestor traversal depth (100) exceeded"
+                     (plist-get result :error))))))
+    (tramp-rpc-mock-test--stop-server)))
+
 (ert-deftest tramp-rpc-mock-test-server-highlevel-test-files-in-dir ()
   "Test high-level dir-locals file listing RPC helper."
   :tags '(:server)
@@ -626,6 +652,32 @@ Returns the result or signals an error."
             (should (string-match-p "/highlevel-cache-link\\'" (alist-get 'dir locals)))
             (should cache)
             (should (string-match-p "/highlevel-cache-link\\'" (alist-get 'dir cache))))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-highlevel-dir-locals-cache-update-depth-limit ()
+  "Ensure dir-locals cache helper errors after 100 ancestor levels."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((root (expand-file-name "highlevel-cache-depth-limit" tramp-rpc-mock-test-temp-dir))
+               (deep-rel (mapconcat (lambda (n) (format "d%03d" n))
+                                    (number-sequence 1 110) "/"))
+               (deep (expand-file-name deep-rel root))
+               (file (expand-file-name "new-file.txt" deep)))
+          (make-directory deep t)
+          (with-temp-file (expand-file-name ".dir-locals.el" root) (insert "((nil . nil))"))
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "highlevel.dir_locals_find_file_cache_update"
+                         `((file . ,(encode-coding-string file 'utf-8))
+                           (names . [".dir-locals.el"])
+                           (cache_dirs . [])))))
+            (should (stringp (plist-get result :error)))
+            (should (string-match-p
+                     "Maximum ancestor traversal depth (100) exceeded"
+                     (plist-get result :error))))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-process-run ()

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -596,6 +596,38 @@ Returns the result or signals an error."
             (should (alist-get 'files locals)))))
     (tramp-rpc-mock-test--stop-server)))
 
+(ert-deftest tramp-rpc-mock-test-server-highlevel-dir-locals-cache-update-preserves-symlink-path ()
+  "Ensure dir-locals cache update keeps lexical symlink paths."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (skip-unless (not (memq system-type '(windows-nt ms-dos))))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((real-root (expand-file-name "highlevel-cache-real" tramp-rpc-mock-test-temp-dir))
+               (link-root (expand-file-name "highlevel-cache-link" tramp-rpc-mock-test-temp-dir))
+               (deep (expand-file-name "a/b/c" link-root))
+               (file (expand-file-name "new-file.txt" deep)))
+          (make-directory (expand-file-name "a/b/c" real-root) t)
+          (with-temp-file (expand-file-name ".dir-locals.el" real-root) (insert "((nil . nil))"))
+          (ignore-errors (delete-file link-root))
+          (make-symbolic-link real-root link-root)
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "highlevel.dir_locals_find_file_cache_update"
+                          `((file . ,(encode-coding-string file 'utf-8))
+                            (names . [".dir-locals.el"])
+                            (cache_dirs . [,(encode-coding-string link-root 'utf-8)]))))
+                 (locals (alist-get 'locals result))
+                 (cache (alist-get 'cache result)))
+            (should (alist-get 'file result))
+            (should (string-match-p "/highlevel-cache-link/" (alist-get 'file result)))
+            (should locals)
+            (should (string-match-p "/highlevel-cache-link\\'" (alist-get 'dir locals)))
+            (should cache)
+            (should (string-match-p "/highlevel-cache-link\\'" (alist-get 'dir cache))))))
+    (tramp-rpc-mock-test--stop-server)))
+
 (ert-deftest tramp-rpc-mock-test-server-process-run ()
   "Test process.run RPC call."
   :tags '(:server :process)
@@ -1122,6 +1154,15 @@ as a hop in multi-hop chains."
        (lambda () (setq orig-called t)))
       (should orig-called))))
 
+(ert-deftest tramp-rpc-mock-test-dir-locals-cache-covers-uses-containment ()
+  "Ensure cache coverage check uses containment, not string length."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((locals "/tmp/a/very-long-dirname/")
+        (cache "/tmp/a/b/c/d/"))
+    ;; String length can disagree with depth here; containment should win.
+    (should (tramp-rpc--dir-locals-cache-covers-p locals cache))))
+
 (ert-deftest tramp-rpc-mock-test-locate-dominating-file-unquotes-and-requotes-paths ()
   "Ensure locate-dominating handler unquotes RPC paths for transport.
 Quoted RPC localnames (/: prefix) must be unquoted for server filesystem
@@ -1139,6 +1180,19 @@ operations and re-quoted on the way back."
              (result (tramp-rpc-handle-locate-dominating-file "foo" ".git")))
         (should (equal captured-file "/tmp/tramp-rpc-root/subdir/foo"))
         (should (equal result "/rpc:host:/:/tmp/tramp-rpc-root/"))))))
+
+(ert-deftest tramp-rpc-mock-test-locate-dominating-file-respects-stop-regexp ()
+  "Ensure locate-dominating handler filters results above stop regexp."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (cl-letf (((symbol-function 'tramp-rpc--call)
+             (lambda (_vec method _params)
+               (should (string= method "highlevel.locate_dominating_file_multi"))
+               (list (encode-coding-string "/tmp/tramp-rpc-root/.git" 'utf-8 t)))))
+    (let* ((default-directory "/rpc:host:/tmp/tramp-rpc-root/a/b/c/")
+           (locate-dominating-stop-dir-regexp
+            (regexp-quote "/tmp/tramp-rpc-root/a/b/")))
+      (should-not (tramp-rpc-handle-locate-dominating-file "foo" ".git")))))
 
 (ert-deftest tramp-rpc-mock-test-dir-locals-all-files-unquotes-and-requotes-paths ()
   "Ensure dir-locals-all-files handler preserves quoted RPC localnames."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -500,6 +500,103 @@ Returns the result or signals an error."
             (should (not result)))))
     (tramp-rpc-mock-test--stop-server)))
 
+(ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file ()
+  "Test high-level locate-dominating-file RPC helper."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((root (expand-file-name "highlevel-root" tramp-rpc-mock-test-temp-dir))
+               (deep (expand-file-name "a/b/c/d" root))
+               (file (expand-file-name "file.txt" deep)))
+          (make-directory deep t)
+          (make-directory (expand-file-name ".git" root) t)
+          (with-temp-file file (insert "x"))
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "highlevel.locate_dominating_file_multi"
+                          `((file . ,(encode-coding-string file 'utf-8))
+                            (names . [".git" ".dir-locals.el"]))))
+                 (first (car result)))
+            (should (stringp first))
+            (should (string-match-p "/highlevel-root/\\.git\\'" first)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-preserves-symlink-path ()
+  "Test locate-dominating-file keeps lexical symlink path."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (skip-unless (not (memq system-type '(windows-nt ms-dos))))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((real-root (expand-file-name "highlevel-real-root" tramp-rpc-mock-test-temp-dir))
+               (link-root (expand-file-name "highlevel-link-root" tramp-rpc-mock-test-temp-dir))
+               (deep (expand-file-name "a/b/c/d" link-root))
+               (file (expand-file-name "file.txt" deep)))
+          (make-directory (expand-file-name "a/b/c/d" real-root) t)
+          (make-directory (expand-file-name ".git" real-root) t)
+          (ignore-errors (delete-file link-root))
+          (make-symbolic-link real-root link-root)
+          (with-temp-file file (insert "x"))
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "highlevel.locate_dominating_file_multi"
+                          `((file . ,(encode-coding-string file 'utf-8))
+                            (names . [".git"]))))
+                 (first (car result)))
+            (should (stringp first))
+            (should (string-prefix-p link-root first))
+            (should (string-match-p "/\\.git\\'" first)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-highlevel-test-files-in-dir ()
+  "Test high-level dir-locals file listing RPC helper."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((dir (expand-file-name "highlevel-locals" tramp-rpc-mock-test-temp-dir)))
+          (make-directory dir t)
+          (with-temp-file (expand-file-name ".dir-locals.el" dir) (insert "x"))
+          (with-temp-file (expand-file-name ".dir-locals-2.el" dir) (insert "y"))
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "highlevel.test_files_in_dir"
+                         `((directory . ,(encode-coding-string dir 'utf-8))
+                           (names . [".dir-locals.el" ".dir-locals-2.el" "missing.el"])))))
+            (should (= 2 (length result)))
+            (should (seq-some (lambda (p) (string-match-p "\\.dir-locals\\.el\\'" p)) result))
+            (should (seq-some (lambda (p) (string-match-p "\\.dir-locals-2\\.el\\'" p)) result)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-highlevel-dir-locals-cache-update ()
+  "Test high-level dir-locals cache update RPC helper."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let* ((root (expand-file-name "highlevel-cache" tramp-rpc-mock-test-temp-dir))
+               (deep (expand-file-name "x/y/z" root))
+               (file (expand-file-name "new-file.txt" deep)))
+          (make-directory deep t)
+          (with-temp-file (expand-file-name ".dir-locals.el" root) (insert "((nil . nil))"))
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "highlevel.dir_locals_find_file_cache_update"
+                          `((file . ,(encode-coding-string file 'utf-8))
+                            (names . [".dir-locals.el" ".dir-locals-2.el"])
+                            (cache_dirs . [,(encode-coding-string root 'utf-8)]))))
+                 (locals (alist-get 'locals result)))
+            (should (alist-get 'file result))
+            (should locals)
+            (should (string-match-p "/highlevel-cache\\'" (alist-get 'dir locals)))
+            (should (alist-get 'files locals)))))
+    (tramp-rpc-mock-test--stop-server)))
+
 (ert-deftest tramp-rpc-mock-test-server-process-run ()
   "Test process.run RPC call."
   :tags '(:server :process)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1396,6 +1396,22 @@ This is the root cause of the lsp-mode crash reported with tramp-rpc."
             (actual (locate-dominating-file target ".git")))
         (should (equal expected actual))))))
 
+(ert-deftest tramp-rpc-test19-locate-dominating-file-stop-regexp ()
+  "Ensure stop-dir regexp behavior matches baseline locate-dominating-file."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir root
+    (let* ((deep (concat root "/a/b/c/d"))
+           (target (concat deep "/target.txt"))
+           (stop-dir (file-name-as-directory (concat root "/a/b")))
+           (locate-dominating-stop-dir-regexp (regexp-quote stop-dir)))
+      (make-directory deep t)
+      (make-directory (concat root "/.git") t)
+      (write-region "x" nil target)
+      (let ((expected (tramp-run-real-handler #'locate-dominating-file
+                                              (list target ".git")))
+            (actual (locate-dominating-file target ".git")))
+        (should (equal expected actual))))))
+
 (ert-deftest tramp-rpc-test19-dir-locals-all-files ()
   "Ensure optimized `dir-locals--all-files' matches baseline behavior."
   (skip-unless (tramp-rpc-test-enabled))

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1271,6 +1271,53 @@ This matches the upstream `tramp-test28-process-file' test."
       (ignore-errors (delete-file file)))))
 
 ;;; ============================================================================
+;;; Test 19: High-level operations parity
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test19-locate-dominating-file ()
+  "Ensure optimized `locate-dominating-file' matches baseline behavior."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir root
+    (let* ((deep (concat root "/a/b/c/d"))
+           (target (concat deep "/target.txt")))
+      (make-directory deep t)
+      (make-directory (concat root "/.git") t)
+      (write-region "x" nil target)
+      (let ((expected (tramp-run-real-handler #'locate-dominating-file
+                                              (list target ".git")))
+            (actual (locate-dominating-file target ".git")))
+        (should (equal expected actual))))))
+
+(ert-deftest tramp-rpc-test19-dir-locals-all-files ()
+  "Ensure optimized `dir-locals--all-files' matches baseline behavior."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir root
+    (let ((deep (concat root "/p/q/r")))
+      (make-directory deep t)
+      (write-region "((nil . ((fill-column . 90))))\n" nil (concat root "/" dir-locals-file))
+      (write-region "((nil . ((tab-width . 8))))\n" nil
+                    (concat root "/" (string-replace ".el" "-2.el" dir-locals-file)))
+      (let ((expected (tramp-run-real-handler #'dir-locals--all-files (list deep)))
+            (actual (dir-locals--all-files deep)))
+        (should (equal expected actual))))))
+
+(ert-deftest tramp-rpc-test19-dir-locals-find-file ()
+  "Ensure optimized `dir-locals-find-file' matches baseline behavior."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir root
+    (let* ((deep (concat root "/alpha/beta/gamma"))
+           (missing (concat deep "/new-file.txt")))
+      (make-directory deep t)
+      (write-region "((nil . ((fill-column . 100))))\n" nil (concat root "/" dir-locals-file))
+      (let ((dir-locals-directory-cache nil)
+            (dir-locals-class-alist nil))
+        (let ((expected (tramp-run-real-handler #'dir-locals-find-file (list missing))))
+          (setq dir-locals-directory-cache nil
+                dir-locals-class-alist nil)
+          (let ((actual (dir-locals-find-file missing)))
+            (should (equal expected actual))))))))
+
+;;; ============================================================================
 ;;; Test Runner
 ;;; ============================================================================
 


### PR DESCRIPTION
This is based on [jsadusk/tramp-hlo](https://github.com/jsadusk/tramp-hlo). That repo provided huge speedups to a few functions that currently don't have tramp methods. I implemented these in tramp-rpc and made them a single remote call.

# Benchmarks

| Test | RPC-with-hlo (new) | RPC-no-hlo (old) | sshx | vs SSH | vs no-hlo |
|---|---|---|---|---|---|
| `locate-dominating-file` | **69.70 ms** | 232.41 ms | 240.51 ms | 3.45x | 3.33x |
| `dir-locals-find-file` | **70.81 ms** | 308.39 ms | 729.26 ms | **10.30x** | 4.36x |
| `dir-locals--all-files` | **69.52 ms** | 223.39 ms | 426.48 ms | 6.13x | 3.21x |


