### PR TITLE
fix: avoid recursive load in tramp-rpc-magit with tramp-add-external-operation

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -692,8 +692,9 @@ magit-status on remote repositories."
 
 ;; Fix #m4: Auto-enable behind defcustom gate
 (with-eval-after-load 'magit
-  (when tramp-rpc-magit-optimize
-    (tramp-rpc-magit-enable)))
+  (with-eval-after-load 'tramp-rpc
+    (when tramp-rpc-magit-optimize
+      (tramp-rpc-magit-enable))))
 
 ;; ============================================================================
 ;; Projectile optimizations
@@ -760,7 +761,8 @@ be available, and uses alien indexing for better performance."
 
 ;; Auto-enable when projectile is loaded
 (with-eval-after-load 'projectile
-  (tramp-rpc-projectile-enable))
+  (with-eval-after-load 'tramp-rpc
+    (tramp-rpc-projectile-enable)))
 
 ;; ============================================================================
 ;; Unload support


### PR DESCRIPTION
## Problem

Since 54e5d09 (refactor: use tramp external operations API instead of advice), loading tramp-rpc with magit or projectile already loaded causes a recursive load error:

```
Recursive 'require' for feature 'tramp-rpc'
```

The call chain is:
1. `(require 'tramp-rpc)` — tramp-rpc.el starts loading
2. `(require 'tramp-rpc-magit)` — tramp-rpc.el line 2560
3. `(with-eval-after-load 'magit ...)` fires immediately (magit already loaded)
4. `tramp-rpc-magit-enable` → `(tramp-add-external-operation ... 'tramp-rpc)`
5. `tramp-add-external-operation` internally calls `(require backend)` i.e. `(require 'tramp-rpc)` (tramp.el:2561)
6. tramp-rpc hasn't called `(provide 'tramp-rpc)` yet → **recursive require**

The previous `advice-add` approach didn't have this problem because it never required the backend package.

## Fix

Wrap the auto-enable callbacks in `(with-eval-after-load 'tramp-rpc ...)` so `tramp-add-external-operation` is deferred until after `(provide 'tramp-rpc)` completes.