### PR TITLE
ci: cache Rust binaries to skip rebuild when server code is unchanged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v20
+      - name: Restore binary from cache
+        id: cache-binary
+        uses: actions/cache/restore@v4
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          path: target/${{ inputs.target }}/release/tramp-rpc-server
+          key: rust-binary-${{ inputs.target }}-${{ hashFiles('server/**', 'Cargo.toml', 'Cargo.lock', 'flake.nix', 'flake.lock', '.cargo/**') }}
 
       - name: Determine version
         id: version
@@ -59,7 +61,14 @@ jobs:
             echo "version=ci" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install Nix
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
       - name: Build
+        if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |
           nix develop --command bash -c '
           RUSTFLAGS="-D warnings -C target-feature=+crt-static -Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort" \
@@ -72,10 +81,17 @@ jobs:
           STATIC: ${{ inputs.static }}
 
       - name: Test
-        if: inputs.test
+        if: inputs.test && steps.cache-binary.outputs.cache-hit != 'true'
         run: nix develop --command cargo test --manifest-path server/Cargo.toml
         env:
           RUSTFLAGS: "-D warnings"
+
+      - name: Save binary to cache
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: target/${{ inputs.target }}/release/tramp-rpc-server
+          key: rust-binary-${{ inputs.target }}-${{ hashFiles('server/**', 'Cargo.toml', 'Cargo.lock', 'flake.nix', 'flake.lock', '.cargo/**') }}
 
       - name: Upload binary for CI
         if: ${{ !inputs.upload }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           STATIC: ${{ inputs.static }}
 
       - name: Test
-        if: inputs.test && steps.cache-binary.outputs.cache-hit != 'true'
+        if: ${{ inputs.test && steps.cache-binary.outputs.cache-hit != 'true' }}
         run: nix develop --command cargo test --manifest-path server/Cargo.toml
         env:
           RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
## Summary

- Add `Restore binary from cache` step in `build.yml` keyed on a hash of all Rust-affecting files (`server/**`, `Cargo.toml`, `Cargo.lock`, `flake.nix`, `flake.lock`, `.cargo/**`)
- Gate `Install Nix`, `Build`, and `Test` steps on a cache miss so they are skipped entirely when the Rust source is unchanged
- Add `Save binary to cache` step (cache-miss path only) so the binary is persisted for subsequent runs
- `Determine version` and all artifact upload/package steps are unconditional and always run from whichever binary is present (cached or freshly built)

Pushes that only touch Emacs Lisp files will restore the cached binaries for all 4 targets in seconds instead of running four full Nix+Rust builds.