### PR TITLE
Add runtime Tramp version check at load time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,19 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/emacsmirror/tramp.git ~/src/tramp
           echo "Tramp commit: $(git -C ~/src/tramp rev-parse HEAD)"
+          # Generate trampver.el from the autoconf template.  The git
+          # repo only ships trampver.el.in; without a generated
+          # trampver.el Emacs falls back to its bundled copy whose
+          # version string is too old for tramp-rpc.
+          VERSION=$(grep -oP 'AC_INIT\(\[Tramp\],\s*\[\K[^\]]+' ~/src/tramp/configure.ac)
+          echo "Upstream Tramp version: $VERSION"
+          sed -e "s/@PACKAGE_VERSION@/$VERSION/g" \
+              -e "s/@PACKAGE_BUGREPORT@/bug-gnu-emacs@gnu.org/g" \
+              -e "s/@EMACS_REQUIRED_VERSION@/28.1/g" \
+              -e 's|@PACKAGE_URL@|https://www.gnu.org/software/tramp/|g' \
+              -e 's/@TRAMP_EMACS_VERSION_CHECK@/"ok"/g' \
+              -e 's/@configure_input@/Generated from trampver.el.in for CI/g' \
+              ~/src/tramp/lisp/trampver.el.in > ~/src/tramp/lisp/trampver.el
 
       - name: Download server binary
         uses: actions/download-artifact@v4

--- a/README.org
+++ b/README.org
@@ -36,6 +36,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 * Requirements
 
 - Emacs 30.1 or later
+- Tramp 2.8.1.3 or later (install from GNU ELPA if your Emacs bundles an older version)
 - =msgpack.el= package (installed automatically from MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -148,6 +148,13 @@
 (require 'tramp-sh)
 (require 'tramp-rpc-protocol)
 
+;; Check for minimum Tramp version.  The Package-Requires header declares
+;; (tramp "2.8.1.3") but that is only enforced by package.el at install
+;; time.  Guard at load time so that manual installations fail clearly.
+(when (version< tramp-version "2.8.1.3")
+  (error "tramp-rpc requires Tramp >= 2.8.1.3, but %s is loaded"
+         tramp-version))
+
 ;; Give the rpc method all ssh connection parameters so it can serve
 ;; as a hop in tramp-sh multi-hop chains (e.g.
 ;; /rpc:host|sudo:root@host:/path).  For single-hop rpc, the foreign


### PR DESCRIPTION
## Summary

- Add a top-level `(version< tramp-version "2.8.1.3")` guard immediately after `(require 'tramp)` in `tramp-rpc.el`
- Loading tramp-rpc with an older Tramp now fails immediately with a clear error message instead of producing confusing failures later (e.g. unbound `tramp-fnac-add-trailing-slash`)

## Why

The `Package-Requires` header already declares `(tramp "2.8.1.3")` but that is only enforced by `package.el` at install time. Users who load tramp-rpc via `load-path`, `:vc`, or Doom's `package!` bypass that check entirely.

## Idiom

This follows the same pattern Tramp itself uses to check its minimum Emacs version in `trampver.el` -- a bare top-level form that calls `error` at load time if the version predicate fails.