### PR TITLE
fix: normalize port to string via tramp-rpc--port-to-string helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,21 @@ NEVER use emacsclient. That will interfer with the users configuration
 Always use `emacs -Q --batch --eval <lisp commands>`
 
 When testing updates to the rust server, always copy it to a temporary location and set `tramp-rpc-deploy-remote-directory` to the temporary path so that testing does not interfere with existing sessions.
+
+# Before pushing Elisp changes
+
+Always byte-compile all `.el` files before pushing to catch cross-module reference errors that CI will fail on. The project uses `byte-compile-error-on-warn`, so any missing `declare-function` for cross-module calls will fail the build.
+
+Run:
+
+```bash
+rm -f lisp/*.elc && emacs -Q --batch \
+  --eval "(require 'package)" \
+  --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+  --eval "(package-initialize)" \
+  --eval "(setq byte-compile-error-on-warn t)" \
+  --eval "(push \"$(pwd)/lisp\" load-path)" \
+  -f batch-byte-compile lisp/*.el
+```
+
+When adding a function in one module (e.g. `tramp-rpc.el`) and calling it from another (e.g. `tramp-rpc-process.el`), add a `declare-function` in the calling module. See the existing declarations at the top of each file for the pattern.

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -560,7 +560,7 @@ LOCALNAME is the remote working directory.
 DIRENV-ENV is an optional alist of environment variables from direnv."
   (let* ((host (tramp-file-name-host vec))
          (user (tramp-file-name-user vec))
-         (port (tramp-file-name-port vec))
+         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
          (program (car command))
          (program-args (cdr command))
          ;; Build environment exports for the remote command
@@ -607,7 +607,7 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
                     tramp-rpc-ssh-args
                     ;; Connection parameters
                     (when user (list "-l" user))
-                    (when port (list "-p" (number-to-string port)))
+                    (when port (list "-p" port))
                     ;; Host and command
                     (list host remote-cmd)))
          ;; Normalize buffer

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -46,6 +46,7 @@
 (declare-function tramp-rpc--decode-output "tramp-rpc")
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
+(declare-function tramp-rpc--port-to-string "tramp-rpc")
 (declare-function tramp-rpc--ensure-inside-emacs-env "tramp-rpc")
 (declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -659,13 +659,24 @@ following the pattern used by standard TRAMP."
      (tramp-rpc--debug "find-executable failed for %s: %S" program err)
      nil)))
 
+(defsubst tramp-rpc--port-to-string (port)
+  "Normalize PORT to a string, or return nil.
+PORT may be a number (from defaults), a string (from filename
+parsing via `tramp-dissect-file-name'), or nil (when unset).
+Upstream TRAMP always stores port as a string in the
+`tramp-file-name' struct, but defensive handling of numbers
+avoids breakage if callers supply numeric defaults."
+  (cond ((stringp port) port)
+        ((numberp port) (number-to-string port))
+        (t nil)))
+
 (defun tramp-rpc--connection-key (vec)
   "Generate a connection key for VEC.
 Includes the hop chain so that different multi-hop routes to the
 same host produce distinct connections."
   (list (tramp-file-name-host vec)
         (tramp-file-name-user vec)
-        (or (tramp-file-name-port vec) 22)
+        (or (tramp-rpc--port-to-string (tramp-file-name-port vec)) "22")
         (tramp-file-name-hop vec)))
 
 (defun tramp-rpc--get-connection (vec)
@@ -799,9 +810,9 @@ hops are accepted since ProxyJump only needs host connectivity."
                    (when (tramp-file-name-user hop-vec)
                      (concat (tramp-file-name-user hop-vec) "@"))
                    hop-host
-                   (when-let* ((port (tramp-file-name-port hop-vec)))
-                     (concat ":" (if (numberp port)
-                                     (number-to-string port) port))))
+                   (when-let* ((port (tramp-rpc--port-to-string
+                                      (tramp-file-name-port hop-vec))))
+                     (concat ":" port)))
                   proxy-parts))))
       (when proxy-parts
         (mapconcat #'identity (nreverse proxy-parts) ",")))))
@@ -814,7 +825,7 @@ hop so the socket is shared with the normal rpc connection."
   (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
          (host (tramp-file-name-host vec))
          (user (or sudo-ssh-user (tramp-file-name-user vec) (user-login-name)))
-         (port (or (tramp-file-name-port vec) 22))
+         (port (or (tramp-rpc--port-to-string (tramp-file-name-port vec)) "22"))
          ;; For sudo, use only proxy hops (exclude the same-host sudo hop)
          (hop (if sudo-ssh-user
                   (tramp-rpc--proxy-hop-string vec)
@@ -825,7 +836,7 @@ hop so the socket is shared with the normal rpc connection."
     ;; %C = hash of %l%h%p%r (we approximate this)
     (setq path (replace-regexp-in-string "%h" host path t t))
     (setq path (replace-regexp-in-string "%r" user path t t))
-    (setq path (replace-regexp-in-string "%p" (number-to-string port) path t t))
+    (setq path (replace-regexp-in-string "%p" port path t t))
     ;; For %C, use a simple hash approximation
     ;; Include the hop chain so different multi-hop routes get different sockets
     (setq path (replace-regexp-in-string
@@ -841,14 +852,14 @@ hop so the socket is shared with the normal rpc connection."
          (socket-path (tramp-rpc--controlmaster-socket-path vec))
          (host (tramp-file-name-host vec))
          (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-file-name-port vec))
+         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec)))
     (and (file-exists-p socket-path)
          ;; Check if the socket is actually usable via ssh -O check
          (zerop (apply #'call-process "ssh" nil nil nil
                        (append
                         (when user (list "-l" user))
-                        (when port (list "-p" (number-to-string port)))
+                        (when port (list "-p" port))
                         (when proxyjump (list "-J" proxyjump))
                         (list "-o" (format "ControlPath=%s" socket-path)
                               "-O" "check"
@@ -868,7 +879,7 @@ Returns non-nil on success."
   (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
          (host (tramp-file-name-host vec))
          (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-file-name-port vec))
+         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          (socket-path (tramp-rpc--controlmaster-socket-path vec))
          (process-name (format "*tramp-rpc-auth %s*" host))
@@ -877,7 +888,7 @@ Returns non-nil on success."
                     (list "ssh")
                     tramp-rpc-ssh-args
                     (when user (list "-l" user))
-                    (when port (list "-p" (number-to-string port)))
+                    (when port (list "-p" port))
                     ;; Multi-hop via ProxyJump
                     (when proxyjump (list "-J" proxyjump))
                     ;; NO BatchMode - allow password prompts
@@ -923,7 +934,7 @@ Uses `tramp-process-actions' with `tramp-rpc--sudo-actions' for
 password handling, giving auth-source integration and password
 caching for free."
   (let* ((host (tramp-file-name-host vec))
-         (port (tramp-file-name-port vec))
+         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          (socket-path (tramp-rpc--controlmaster-socket-path vec))
          (process-name (format "*tramp-rpc-sudo %s*" host))
@@ -932,7 +943,7 @@ caching for free."
                     (list "ssh")
                     tramp-rpc-ssh-args
                     (when ssh-user (list "-l" ssh-user))
-                    (when port (list "-p" (number-to-string port)))
+                    (when port (list "-p" port))
                     ;; Multi-hop via ProxyJump
                     (when proxyjump (list "-J" proxyjump))
                     ;; Reuse ControlMaster for the SSH layer
@@ -972,7 +983,7 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
   (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
          (host (tramp-file-name-host vec))
          (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-file-name-port vec))
+         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          ;; Build SSH command to run the RPC server
          (ssh-args (append
@@ -980,7 +991,7 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
                     ;; Raw SSH arguments (e.g., -v, -F config)
                     tramp-rpc-ssh-args
                     (when user (list "-l" user))
-                    (when port (list "-p" (number-to-string port)))
+                    (when port (list "-p" port))
                     ;; Multi-hop via ProxyJump
                     (when proxyjump (list "-J" proxyjump))
                     ;; Only use BatchMode=yes when ControlMaster handles auth;
@@ -1165,7 +1176,7 @@ socket, then kills the auth process and buffer."
   (when tramp-rpc-use-controlmaster
     (let* ((host (tramp-file-name-host vec))
            (user (tramp-file-name-user vec))
-           (port (tramp-file-name-port vec))
+           (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
            (proxyjump (tramp-rpc--hops-to-proxyjump vec))
            (socket-path (tramp-rpc--controlmaster-socket-path vec))
            (auth-process-name (format "*tramp-rpc-auth %s*" host))
@@ -1179,7 +1190,7 @@ socket, then kills the auth process and buffer."
           (apply #'call-process "ssh" nil nil nil
                  (append
                   (when user (list "-l" user))
-                  (when port (list "-p" (number-to-string port)))
+                  (when port (list "-p" port))
                   (when proxyjump (list "-J" proxyjump))
                   (list "-o" (format "ControlPath=%s" socket-path)
                         "-O" "exit" host)))))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -680,7 +680,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
   (let ((vec (make-tramp-file-name :method "rpc" :host "target"
                                    :user "user" :localname "/path")))
     (should (equal (tramp-rpc--connection-key vec)
-                   '("target" "user" 22 nil)))))
+                   '("target" "user" "22" nil)))))
 
 (ert-deftest tramp-rpc-mock-test-connection-key-with-hop ()
   "Test connection key includes hop for differentiation."


### PR DESCRIPTION
## Summary

- Fixes `number-to-string` error when port is explicitly specified via `/rpc:host#port:path` syntax (same bug as #155)
- Introduces `tramp-rpc--port-to-string` helper to normalize port values in one place instead of repeating `(if (numberp port) (number-to-string port) port)` at every call site
- Fixes connection-key and controlmaster-socket-path defaults from numeric `22` to string `"22"` for consistent hash keys

## Problem

`tramp-file-name-port` returns a **string** (via `match-string` in upstream TRAMP's `tramp-dissect-file-name`) when port is explicitly specified, but the code unconditionally called `(number-to-string port)` at 7 call sites across `tramp-rpc.el` and `tramp-rpc-process.el`, which signals an error on string arguments.

Additionally, `tramp-rpc--connection-key` and `tramp-rpc--controlmaster-socket-path` defaulted port to numeric `22`, creating type-inconsistent keys: `/rpc:host#22:path` produced key `("host" "user" "22" nil)` while `/rpc:host:path` produced `("host" "user" 22 nil)` -- different keys for the same logical connection.

## Approach

Rather than scattering `(if (numberp port) ...)` guards at each call site (as in #155), this PR introduces a single `defsubst`:

```elisp
(defsubst tramp-rpc--port-to-string (port)
  (cond ((stringp port) port)
        ((numberp port) (number-to-string port))
        (t nil)))
```

This is consistent with how upstream TRAMP handles port (always string-or-nil in the `tramp-file-name` struct), and provides a single normalization point so new call sites cannot forget the guard.

Supersedes #155.