### PR TITLE
fix: use tramp-devel@gnu.org as bug report address per TRAMP configure.ac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
           VERSION=$(grep -oP 'AC_INIT\(\[Tramp\],\s*\[\K[^\]]+' ~/src/tramp/configure.ac)
           echo "Upstream Tramp version: $VERSION"
           sed -e "s/@PACKAGE_VERSION@/$VERSION/g" \
-              -e "s/@PACKAGE_BUGREPORT@/bug-gnu-emacs@gnu.org/g" \
+              -e "s/@PACKAGE_BUGREPORT@/tramp-devel@gnu.org/g" \
               -e "s/@EMACS_REQUIRED_VERSION@/28.1/g" \
               -e 's|@PACKAGE_URL@|https://www.gnu.org/software/tramp/|g' \
               -e 's/@TRAMP_EMACS_VERSION_CHECK@/"ok"/g' \


### PR DESCRIPTION
Michael Albinus pointed out that commit 3eca3ad introduced a sed substitution that sets @PACKAGE_BUGREPORT@ to bug-gnu-emacs@gnu.org, but TRAMP's own configure.ac declares the bug report address as tramp-devel@gnu.org.

This change makes the CI-generated trampver.el consistent with upstream TRAMP's configure.ac.