### PR TITLE
fix: remove projectile-get-ext-command from external operations

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -702,6 +702,7 @@ magit-status on remote repositories."
 
 (defvar projectile-projects-cache)
 (defvar projectile-projects-cache-time)
+(defvar projectile-git-use-fd)
 
 (defun tramp-rpc-handle-projectile-dir-files (directory)
   "Handler to use alien indexing for remote project files.

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -724,7 +724,8 @@ This bypasses the expensive `file-relative-name' calls in hybrid mode."
       (setq files (gethash project-root projectile-projects-cache)))
     ;; If not cached, fetch and cache
     (unless files
-      (setq files (projectile-dir-files-alien project-root))
+      (setq files (let ((projectile-git-use-fd nil))
+              (projectile-dir-files-alien project-root)))
       (when (and (bound-and-true-p projectile-enable-caching)
                  (boundp 'projectile-projects-cache)
                  (boundp 'projectile-projects-cache-time)

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -703,15 +703,14 @@ magit-status on remote repositories."
 (defvar projectile-projects-cache)
 (defvar projectile-projects-cache-time)
 
-(defun tramp-rpc-handle-projectile-get-ext-command (vcs)
-  "Handler to disable fd for remote directories.
-Projectile checks if fd is available using `executable-find' which
-checks the LOCAL machine, but fd may not be available on the REMOTE.
-This forces git ls-files for remote directories."
-  (or ;; For remote RPC directories, always use git ls-files
-      (and (eq vcs 'git) (bound-and-true-p projectile-git-command))
-      ;; Otherwise, use the original function
-      (tramp-run-real-handler 'projectile-get-ext-command (list vcs))))
+(defun tramp-rpc-handle-projectile-dir-files (directory)
+  "Handler to use alien indexing for remote project files.
+Disables fd for remote directories because `projectile-get-ext-command'
+checks fd availability via `executable-find' on the LOCAL machine,
+but fd may not be available on the REMOTE.  Binding
+`projectile-git-use-fd' to nil forces git ls-files instead."
+  (let ((projectile-git-use-fd nil))
+    (projectile-dir-files-alien directory)))
 
 (defun tramp-rpc-handle-projectile-project-files (project-root)
   "Handler to use alien indexing for remote project files.
@@ -740,11 +739,8 @@ This ensures fd is not used for remote directories where it may not
 be available, and uses alien indexing for better performance."
   (interactive)
   (tramp-add-external-operation
-   'projectile-get-ext-command
-   #'tramp-rpc-handle-projectile-get-ext-command 'tramp-rpc)
-  (tramp-add-external-operation
    'projectile-dir-files
-   #'projectile-dir-files-alien 'tramp-rpc)
+   #'tramp-rpc-handle-projectile-dir-files 'tramp-rpc)
   (tramp-add-external-operation
    'projectile-project-files
    #'tramp-rpc-handle-projectile-project-files 'tramp-rpc)
@@ -754,7 +750,6 @@ be available, and uses alien indexing for better performance."
 (defun tramp-rpc-projectile-disable ()
   "Disable tramp-rpc projectile optimizations."
   (interactive)
-  (tramp-remove-external-operation 'projectile-get-ext-command 'tramp-rpc)
   (tramp-remove-external-operation 'projectile-dir-files 'tramp-rpc)
   (tramp-remove-external-operation 'projectile-project-files 'tramp-rpc)
   (message "tramp-rpc projectile optimizations disabled"))


### PR DESCRIPTION
## Current Issue
`tramp-add-external-operation` wraps the target function with an advice that calls `file-name-absolute-p` on the first argument to determine the file name handler ([tramp.el:2580](https://github.com/emacs-straight/tramp/blob/adb4268/tramp.el#L2580)). `projectile-get-ext-command` takes a VCS symbol (`'git`), so `file-name-absolute-p` errors with `(wrong-type-argument stringp git)`. This happens in the generated advice before our handler is invoked, so fixing the handler is not possible.

## Reproduce
1. Have `fd` installed locally
2. Open any project with Projectile
3. Error running timer: (wrong-type-argument stringp git)

<img width="736" height="172" alt="image" src="https://github.com/user-attachments/assets/e94e2c58-29a8-4be9-9d94-785dd817b978" />

## Fix
Instead of intercepting `projectile-get-ext-command` separately, the fd issue is now handled in a new `tramp-rpc-handle-projectile-dir-files` handler that let-binds `projectile-git-use-fd` to nil before calling `projectile-dir-files-alien`.

