### PR TITLE
refactor: delegate projectile-project-files handler to dir-files handler

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -706,10 +706,10 @@ magit-status on remote repositories."
 
 (defun tramp-rpc-handle-projectile-dir-files (directory)
   "Handler to use alien indexing for remote project files.
-Disables fd for remote directories because `projectile-get-ext-command'
-checks fd availability via `executable-find' on the LOCAL machine,
-but fd may not be available on the REMOTE.  Binding
-`projectile-git-use-fd' to nil forces git ls-files instead."
+`projectile-dir-files-alien' (via `projectile-get-ext-command') checks
+fd availability via `executable-find' on the LOCAL machine, but fd may
+not be available on the REMOTE.  Binding `projectile-git-use-fd' to nil
+forces git ls-files instead."
   (let ((projectile-git-use-fd nil))
     (projectile-dir-files-alien directory)))
 
@@ -724,8 +724,7 @@ This bypasses the expensive `file-relative-name' calls in hybrid mode."
       (setq files (gethash project-root projectile-projects-cache)))
     ;; If not cached, fetch and cache
     (unless files
-      (setq files (let ((projectile-git-use-fd nil))
-              (projectile-dir-files-alien project-root)))
+      (setq files (tramp-rpc-handle-projectile-dir-files project-root))
       (when (and (bound-and-true-p projectile-enable-caching)
                  (boundp 'projectile-projects-cache)
                  (boundp 'projectile-projects-cache-time)


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #159 addressing two review nits:

- **Remove duplication**: `tramp-rpc-handle-projectile-project-files` now calls `tramp-rpc-handle-projectile-dir-files` for the uncached path instead of re-open-coding the `(let ((projectile-git-use-fd nil)) (projectile-dir-files-alien …))` wrapper. Keeps the fd-disable rule in one place and fixes the incidental mis-indentation.
- **Docstring clarity**: rewrite `tramp-rpc-handle-projectile-dir-files` docstring to reference `projectile-dir-files-alien` (what the handler actually calls) and note that `projectile-get-ext-command` is the internal path that consults fd availability.

No behavior change.

## Verification

- `rm -f lisp/*.elc && emacs -Q --batch … -f batch-byte-compile lisp/*.el` clean under `byte-compile-error-on-warn`.