### PR TITLE
fix: address review feedback from locate-dominating-file PR

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1800,40 +1800,37 @@ If ORIGINAL-LOCALNAME is file-name-quoted, quote NEW-LOCALNAME too."
       (file-name-quote new-localname)
     new-localname))
 
-(defun tramp-rpc--parent-directory (directory)
-  "Return parent directory for DIRECTORY, or nil at filesystem root."
-  (let* ((current (directory-file-name directory))
-         (parent (file-name-directory current)))
-    (when parent
-      (let ((parent (directory-file-name parent)))
-        (unless (equal parent current)
-          parent)))))
-
-(defun tramp-rpc--locate-search-directory (path)
-  "Return lexical search directory for locate-dominating PATH."
-  (if (string-suffix-p "/" path)
-      (directory-file-name path)
-    (let ((normalized (directory-file-name path)))
-      (or (and (file-name-directory normalized)
-               (directory-file-name (file-name-directory normalized)))
-          normalized))))
-
 (defun tramp-rpc--locate-dominating-before-stop-p (search-path dominating-dir)
   "Return non-nil when DOMINATING-DIR is reachable without crossing stop regexp.
-SEARCH-PATH and DOMINATING-DIR must use the same pathname form (remote/local)
-that `locate-dominating-stop-dir-regexp' is expected to match."
+
+Mirrors the stop-regexp loop in stock `locate-dominating-file': the regexp
+is matched against every path visited during the walk, INCLUSIVE of the
+starting path and the dominating directory itself, in whatever form each
+path naturally takes as the walk peels off trailing components.
+
+SEARCH-PATH and DOMINATING-DIR must use the same pathname form (remote
+or local) that `locate-dominating-stop-dir-regexp' is expected to match."
   (let ((stop locate-dominating-stop-dir-regexp))
     (if (or (null stop) (equal stop ""))
         t
-      (let ((current (tramp-rpc--locate-search-directory search-path))
-            (target (directory-file-name dominating-dir))
-            (blocked nil))
-        (while (and current (not blocked) (not (equal current target)))
-          (when (string-match-p stop (file-name-as-directory current))
-            (setq blocked t))
-          (setq current (tramp-rpc--parent-directory current)))
-        (and (not blocked)
-             (equal current target))))))
+      (let ((current search-path)
+            (target (file-name-as-directory dominating-dir))
+            (result nil))
+        (catch 'done
+          (while current
+            ;; Stock `locate-dominating-file' runs `string-match' at every
+            ;; step before looking for the marker, including on the
+            ;; dominating directory when the walk arrives there.
+            (when (string-match stop current)
+              (throw 'done nil))
+            (when (equal (file-name-as-directory current) target)
+              (setq result t)
+              (throw 'done t))
+            (let ((parent (file-name-directory (directory-file-name current))))
+              (if (or (null parent) (equal parent current))
+                  (throw 'done nil)
+                (setq current parent)))))
+        result))))
 
 (defun tramp-rpc-handle-dir-locals--all-files (directory &optional base-el-only)
   "Like `dir-locals--all-files' for TRAMP-RPC files.
@@ -1926,52 +1923,71 @@ to the built-in implementation."
           (setq latest f-time))))))
 
 (defun tramp-rpc--dir-locals-cache-covers-p (locals-dir cache-dir)
-  "Return non-nil when CACHE-DIR is at or below LOCALS-DIR."
-  (let ((locals (directory-file-name locals-dir))
-        (cache (directory-file-name cache-dir)))
-    (or (equal locals cache)
-        (file-in-directory-p cache locals))))
+  "Return non-nil when CACHE-DIR is at or below LOCALS-DIR.
+This is a purely lexical comparison -- unlike `file-in-directory-p' it
+does not require LOCALS-DIR to exist on the filesystem and does not
+issue any remote calls through TRAMP.  Both arguments must already be
+absolute, normalised paths in the same form (e.g. both remote TRAMP
+paths or both local)."
+  (let ((locals (file-name-as-directory locals-dir))
+        (cache (file-name-as-directory cache-dir)))
+    ;; `file-name-as-directory' ensures a boundary slash, so the prefix
+    ;; check correctly rejects siblings like `/tmp/a/' vs `/tmp/a-b/'.
+    (string-prefix-p locals cache)))
 
 (defun tramp-rpc-handle-dir-locals-find-file (file)
   "Like `dir-locals-find-file' for TRAMP-RPC files."
-  (let* ((file (if (file-name-absolute-p file)
-                   file
-                 (file-name-concat default-directory file)))
-         (file-connection (file-remote-p file))
-         (cache-update (tramp-rpc--dir-locals-cache-update file dir-locals-directory-cache))
-         (locals-dir-update (alist-get 'locals cache-update))
-         (locals-dir (when locals-dir-update
-                       (file-name-as-directory
-                        (concat file-connection
-                                (tramp-rpc--decode-string
-                                 (alist-get 'dir locals-dir-update))))))
-         (cache-dir-update (alist-get 'cache cache-update))
-         (cache-dir (when cache-dir-update
-                      (file-name-as-directory
-                       (concat file-connection
-                               (tramp-rpc--decode-string
-                                (alist-get 'dir cache-dir-update))))))
-         (dir-elt (when cache-dir
-                    (seq-find (lambda (elt) (string= (car elt) cache-dir))
-                              dir-locals-directory-cache))))
-    (if (and dir-elt
-             (or (null locals-dir)
-                 (tramp-rpc--dir-locals-cache-covers-p locals-dir (car dir-elt))))
-        ;; Potential cache hit, verify mtimes.
-        (if (or (null (nth 2 dir-elt))
-                (let ((cached-files (alist-get 'files cache-dir-update)))
-                  (and cached-files
-                       (time-equal-p
-                        (nth 2 dir-elt)
-                        (tramp-rpc--dir-locals-latest-mtime cached-files)))))
-            dir-elt
-          (progn
-            ;; Cache entry invalid, clear and return discovered locals dir.
-            (setq dir-locals-directory-cache
-                  (delq dir-elt dir-locals-directory-cache))
-            locals-dir))
-      ;; No cache entry.
-      locals-dir)))
+  (let ((file (if (file-name-absolute-p file)
+                  file
+                (file-name-concat default-directory file))))
+    (with-parsed-tramp-file-name file nil
+      ;; Preserve file-name-quoted (/: prefix) shape when reconstructing
+      ;; returned TRAMP paths, so cache lookups in
+      ;; `dir-locals-directory-cache' match entries populated through the
+      ;; same quoted access path.
+      (let* ((quoted-localname localname)
+             (cache-update (tramp-rpc--dir-locals-cache-update
+                            file dir-locals-directory-cache))
+             (locals-dir-update (alist-get 'locals cache-update))
+             (locals-dir
+              (when locals-dir-update
+                (file-name-as-directory
+                 (tramp-make-tramp-file-name
+                  v
+                  (tramp-rpc--quote-localname
+                   quoted-localname
+                   (tramp-rpc--decode-string
+                    (alist-get 'dir locals-dir-update)))))))
+             (cache-dir-update (alist-get 'cache cache-update))
+             (cache-dir
+              (when cache-dir-update
+                (file-name-as-directory
+                 (tramp-make-tramp-file-name
+                  v
+                  (tramp-rpc--quote-localname
+                   quoted-localname
+                   (tramp-rpc--decode-string
+                    (alist-get 'dir cache-dir-update)))))))
+             (dir-elt (when cache-dir
+                        (seq-find (lambda (elt) (string= (car elt) cache-dir))
+                                  dir-locals-directory-cache))))
+        (if (and dir-elt
+                 (or (null locals-dir)
+                     (tramp-rpc--dir-locals-cache-covers-p locals-dir (car dir-elt))))
+            ;; Potential cache hit, verify mtimes.
+            (if (or (null (nth 2 dir-elt))
+                    (let ((cached-files (alist-get 'files cache-dir-update)))
+                      (and cached-files
+                           (time-equal-p
+                            (nth 2 dir-elt)
+                            (tramp-rpc--dir-locals-latest-mtime cached-files)))))
+                dir-elt
+              ;; Cache entry invalid, clear and return discovered locals dir.
+              (setq dir-locals-directory-cache
+                    (delq dir-elt dir-locals-directory-cache))
+              locals-dir)
+          ;; No cache entry.
+          locals-dir)))))
 
 ;; ============================================================================
 ;; Directory operations
@@ -3046,10 +3062,14 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
-    (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
-    (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
-    (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
     (vc-registered . tramp-rpc-handle-vc-registered)
+
+    ;; Note: `locate-dominating-file', `dir-locals--all-files', and
+    ;; `dir-locals-find-file' are registered via
+    ;; `tramp-add-external-operation' below (after `(provide 'tramp-rpc)').
+    ;; That API adds the handler to this alist AND installs the advice that
+    ;; dispatches these non-magic operations through TRAMP's handler
+    ;; machinery, so a literal entry here would be redundant.
 
     ;; =========================================================================
     ;; Generic TRAMP handlers (work with any backend, no remote I/O needed)

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -227,12 +227,23 @@ fn as_search_dir(path: &Path) -> Option<PathBuf> {
     }
 }
 
-const MAX_DOMINATING_DEPTH: usize = 100;
+/// Default maximum ancestor traversal depth for dominating-file searches.
+///
+/// This is a defensive upper bound to protect against pathological
+/// filesystem layouts (e.g. symlink loops that `Path::parent` would not
+/// detect because it walks the lexical path).  Real filesystems rarely
+/// exceed 30-40 levels; 1024 is effectively unlimited in practice.
+///
+/// When the limit is reached the search returns `Ok(None)` rather than
+/// an error, matching the stock Emacs `locate-dominating-file' behavior
+/// of silently returning nil when no marker is found.
+const DEFAULT_MAX_DOMINATING_DEPTH: usize = 1024;
 
 fn find_dominating_dir(
     start_dir: &Path,
     names: &[String],
-) -> Result<Option<(PathBuf, Vec<String>)>, RpcError> {
+    max_depth: usize,
+) -> Option<(PathBuf, Vec<String>)> {
     let mut current = start_dir.to_path_buf();
     let mut depth = 0usize;
     loop {
@@ -243,35 +254,21 @@ fn find_dominating_dir(
             .collect();
 
         if !found.is_empty() {
-            return Ok(Some((current, found)));
+            return Some((current, found));
+        }
+
+        if depth >= max_depth {
+            // Defensive cap: treat as "no marker found" rather than walking
+            // forever through a pathological path (e.g. symlink loop).
+            return None;
         }
 
         match current.parent() {
             Some(parent) if parent != current => {
-                if depth >= MAX_DOMINATING_DEPTH {
-                    return Err(RpcError::invalid_params(format!(
-                        "Maximum ancestor traversal depth ({}) exceeded",
-                        MAX_DOMINATING_DEPTH
-                    )));
-                }
                 current = parent.to_path_buf();
                 depth += 1;
             }
-            _ => return Ok(None),
-        }
-    }
-}
-
-fn remap_to_lexical_ancestor(start_dir: &Path, found_dir: &Path) -> PathBuf {
-    let canonical_found = canonical_or_original(found_dir);
-    let mut current = start_dir.to_path_buf();
-    loop {
-        if canonical_or_original(&current) == canonical_found {
-            return current;
-        }
-        match current.parent() {
-            Some(parent) if parent != current => current = parent.to_path_buf(),
-            _ => return found_dir.to_path_buf(),
+            _ => return None,
         }
     }
 }
@@ -311,6 +308,10 @@ pub async fn highlevel_test_files_in_dir(params: Value) -> HandlerResult {
     .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?
 }
 
+fn default_max_dominating_depth() -> usize {
+    DEFAULT_MAX_DOMINATING_DEPTH
+}
+
 /// Locate marker files in ancestor directories.
 ///
 /// Returns marker paths from the first ancestor that contains any markers.
@@ -319,6 +320,10 @@ pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerRes
     struct Params {
         file: String,
         names: Vec<String>,
+        /// Maximum ancestor levels to walk (optional, defaults to 1024).
+        /// Primarily for testing; real callers can omit this.
+        #[serde(default = "default_max_dominating_depth")]
+        max_depth: usize,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -334,7 +339,9 @@ pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerRes
             return Ok(Value::Array(vec![]));
         };
 
-        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names)? else {
+        let Some((dir, found_names)) =
+            find_dominating_dir(&start_dir, &params.names, params.max_depth)
+        else {
             return Ok(Value::Array(vec![]));
         };
 
@@ -356,6 +363,10 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
         names: Vec<String>,
         #[serde(default)]
         cache_dirs: Vec<String>,
+        /// Maximum ancestor levels to walk (optional, defaults to 1024).
+        /// Primarily for testing; real callers can omit this.
+        #[serde(default = "default_max_dominating_depth")]
+        max_depth: usize,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -381,33 +392,37 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
             });
         };
 
-        let locals_value =
-            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names)? {
-                let locals_dir = remap_to_lexical_ancestor(&start_dir, &locals_dir);
-                let local_files: Vec<Value> = params
-                    .names
-                    .iter()
-                    .filter_map(|name| {
-                        let p = locals_dir.join(name);
-                        if p.is_file() {
-                            mtime_seconds(&p).map(|mtime| {
-                                msgpack_map! {
-                                    "name" => name.clone(),
-                                    "mtime" => mtime
-                                }
-                            })
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                msgpack_map! {
-                    "dir" => locals_dir.to_string_lossy().to_string(),
-                    "files" => Value::Array(local_files)
-                }
-            } else {
-                Value::Nil
-            };
+        let locals_value = if let Some((locals_dir, _)) =
+            find_dominating_dir(&start_dir, &params.names, params.max_depth)
+        {
+            // `find_dominating_dir` walks the lexical `start_dir` with
+            // `Path::parent()` and never canonicalizes, so `locals_dir` is
+            // already a lexical ancestor of `start_dir`.  No symlink
+            // rewriting is required here.
+            let local_files: Vec<Value> = params
+                .names
+                .iter()
+                .filter_map(|name| {
+                    let p = locals_dir.join(name);
+                    if p.is_file() {
+                        mtime_seconds(&p).map(|mtime| {
+                            msgpack_map! {
+                                "name" => name.clone(),
+                                "mtime" => mtime
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            msgpack_map! {
+                "dir" => locals_dir.to_string_lossy().to_string(),
+                "files" => Value::Array(local_files)
+            }
+        } else {
+            Value::Nil
+        };
 
         let mut best_cache: Option<PathBuf> = None;
         for cache_dir in &params.cache_dirs {

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -551,7 +551,10 @@ Returns the result or signals an error."
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-depth-limit ()
-  "Ensure dominating-file helper errors after 100 ancestor levels."
+  "Ensure dominating-file helper stops silently at configured depth.
+With MAX_DEPTH set below the distance to the marker, the walk returns
+an empty result (matching stock `locate-dominating-file' behavior when
+no marker is found) rather than signalling an error."
   :tags '(:server)
   (skip-unless tramp-rpc-mock-test--msgpack-available)
   (skip-unless (tramp-rpc-mock-test--find-server))
@@ -560,20 +563,32 @@ Returns the result or signals an error."
         (tramp-rpc-mock-test--start-server)
         (let* ((root (expand-file-name "highlevel-depth-limit" tramp-rpc-mock-test-temp-dir))
                (deep-rel (mapconcat (lambda (n) (format "d%03d" n))
-                                    (number-sequence 1 110) "/"))
+                                    (number-sequence 1 20) "/"))
                (deep (expand-file-name deep-rel root))
                (file (expand-file-name "file.txt" deep)))
           (make-directory deep t)
           (make-directory (expand-file-name ".git" root) t)
           (with-temp-file file (insert "x"))
+          ;; max_depth=5 stops the walk well before reaching the .git marker
+          ;; at the 20-deep root.  The server should return an empty array,
+          ;; not a protocol error.
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "highlevel.locate_dominating_file_multi"
+                         `((file . ,(encode-coding-string file 'utf-8))
+                           (names . [".git"])
+                           (max_depth . 5)))))
+            (should-not (plist-get result :error))
+            (should (listp result))
+            (should (null result)))
+          ;; Sanity check: without the limit, the same call finds the marker.
           (let ((result (tramp-rpc-mock-test--rpc-call
                          "highlevel.locate_dominating_file_multi"
                          `((file . ,(encode-coding-string file 'utf-8))
                            (names . [".git"])))))
-            (should (stringp (plist-get result :error)))
-            (should (string-match-p
-                     "Maximum ancestor traversal depth (100) exceeded"
-                     (plist-get result :error))))))
+            (should-not (plist-get result :error))
+            (should (= 1 (length result)))
+            (should (string-match-p "/highlevel-depth-limit/\\.git\\'"
+                                    (car result))))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-test-files-in-dir ()
@@ -655,7 +670,9 @@ Returns the result or signals an error."
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-dir-locals-cache-update-depth-limit ()
-  "Ensure dir-locals cache helper errors after 100 ancestor levels."
+  "Ensure dir-locals cache helper stops silently at configured depth.
+With MAX_DEPTH below the distance to .dir-locals.el, the server returns
+`locals => nil' rather than signalling an error."
   :tags '(:server)
   (skip-unless tramp-rpc-mock-test--msgpack-available)
   (skip-unless (tramp-rpc-mock-test--find-server))
@@ -664,7 +681,7 @@ Returns the result or signals an error."
         (tramp-rpc-mock-test--start-server)
         (let* ((root (expand-file-name "highlevel-cache-depth-limit" tramp-rpc-mock-test-temp-dir))
                (deep-rel (mapconcat (lambda (n) (format "d%03d" n))
-                                    (number-sequence 1 110) "/"))
+                                    (number-sequence 1 20) "/"))
                (deep (expand-file-name deep-rel root))
                (file (expand-file-name "new-file.txt" deep)))
           (make-directory deep t)
@@ -673,11 +690,11 @@ Returns the result or signals an error."
                          "highlevel.dir_locals_find_file_cache_update"
                          `((file . ,(encode-coding-string file 'utf-8))
                            (names . [".dir-locals.el"])
-                           (cache_dirs . [])))))
-            (should (stringp (plist-get result :error)))
-            (should (string-match-p
-                     "Maximum ancestor traversal depth (100) exceeded"
-                     (plist-get result :error))))))
+                           (cache_dirs . [])
+                           (max_depth . 5)))))
+            (should-not (plist-get result :error))
+            (should (alist-get 'file result))
+            (should-not (alist-get 'locals result)))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-process-run ()
@@ -1207,13 +1224,43 @@ as a hop in multi-hop chains."
       (should orig-called))))
 
 (ert-deftest tramp-rpc-mock-test-dir-locals-cache-covers-uses-containment ()
-  "Ensure cache coverage check uses containment, not string length."
+  "Ensure cache coverage check uses containment, not string length.
+A length-based `<=' proxy would false-positive whenever LOCALS-DIR
+happens to have a shorter string than CACHE-DIR even if they share no
+ancestor relationship.  Containment must return nil in that case."
   :tags '(:dir-locals)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((locals "/tmp/a/very-long-dirname/")
-        (cache "/tmp/a/b/c/d/"))
-    ;; String length can disagree with depth here; containment should win.
-    (should (tramp-rpc--dir-locals-cache-covers-p locals cache))))
+  ;; Negative case: unrelated paths where LOCALS is lexically shorter
+  ;; than CACHE.  A `<=' length proxy would incorrectly say "covers".
+  (should-not (tramp-rpc--dir-locals-cache-covers-p
+               "/tmp/short/"
+               "/tmp/different-unrelated-path/"))
+  ;; Positive case: CACHE truly at or below LOCALS.
+  (should (tramp-rpc--dir-locals-cache-covers-p
+           "/tmp/locals/"
+           "/tmp/locals/sub/"))
+  ;; Positive case: same directory (equal).
+  (should (tramp-rpc--dir-locals-cache-covers-p
+           "/tmp/same/"
+           "/tmp/same/")))
+
+(ert-deftest tramp-rpc-mock-test-dir-locals-advice-install-remove-cycle ()
+  "Test that `hack-dir-local-variables' advice install/remove works.
+Guards against `tramp-rpc-advice-install' or `tramp-rpc-advice-remove'
+accidentally dropping the advice during future refactors."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  ;; After loading tramp-rpc-advice, the advice should be active.
+  (should (advice-member-p #'tramp-rpc--hack-dir-local-variables-advice
+                           'hack-dir-local-variables))
+  ;; After removing, it should be gone.
+  (unwind-protect
+      (progn
+        (tramp-rpc-advice-remove)
+        (should-not (advice-member-p #'tramp-rpc--hack-dir-local-variables-advice
+                                     'hack-dir-local-variables)))
+    ;; Restore advice for remaining tests.
+    (tramp-rpc-advice-install)))
 
 (ert-deftest tramp-rpc-mock-test-locate-dominating-file-unquotes-and-requotes-paths ()
   "Ensure locate-dominating handler unquotes RPC paths for transport.
@@ -1246,6 +1293,22 @@ operations and re-quoted on the way back."
             (regexp-quote "/tmp/tramp-rpc-root/a/b/")))
       (should-not (tramp-rpc-handle-locate-dominating-file "foo" ".git")))))
 
+(ert-deftest tramp-rpc-mock-test-locate-dominating-file-stop-regexp-matches-target ()
+  "Stop regexp that matches the dominating directory itself should block.
+Stock `locate-dominating-file' runs `string-match' at every step of the
+walk, including on the dominating directory, so a regexp matching the
+dominating dir causes the lookup to return nil."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (cl-letf (((symbol-function 'tramp-rpc--call)
+             (lambda (_vec method _params)
+               (should (string= method "highlevel.locate_dominating_file_multi"))
+               (list (encode-coding-string "/tmp/tramp-rpc-root/.git" 'utf-8 t)))))
+    (let* ((default-directory "/rpc:host:/tmp/tramp-rpc-root/a/b/")
+           (locate-dominating-stop-dir-regexp
+            (concat "\\`" (regexp-quote "/rpc:host:/tmp/tramp-rpc-root/") "\\'")))
+      (should-not (tramp-rpc-handle-locate-dominating-file "foo" ".git")))))
+
 (ert-deftest tramp-rpc-mock-test-dir-locals-all-files-unquotes-and-requotes-paths ()
   "Ensure dir-locals-all-files handler preserves quoted RPC localnames."
   :tags '(:dir-locals)
@@ -1263,6 +1326,54 @@ operations and re-quoted on the way back."
         (should (equal captured-directory "/tmp/tramp-rpc-root"))
         (should (equal result
                        '("/rpc:host:/:/tmp/tramp-rpc-root/.dir-locals.el")))))))
+
+(ert-deftest tramp-rpc-mock-test-dir-locals-find-file-preserves-quoting ()
+  "Ensure dir-locals-find-file handler preserves file-name-quoted paths.
+When the input FILE has a `/:' prefix, the returned locals directory
+must also carry the prefix so that `dir-locals-directory-cache' lookups
+via `string=' find the matching entry."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (cl-letf (((symbol-function 'tramp-rpc--call)
+             (lambda (_vec method _params)
+               (should (string= method "highlevel.dir_locals_find_file_cache_update"))
+               `((file . ,(encode-coding-string "/tmp/tramp-rpc-root/subdir/foo"
+                                                'utf-8 t))
+                 (locals . ((dir . ,(encode-coding-string
+                                     "/tmp/tramp-rpc-root"
+                                     'utf-8 t))
+                            (files . ())))
+                 (cache . nil)))))
+    (let* ((dir-locals-directory-cache nil)
+           (result (tramp-rpc-handle-dir-locals-find-file
+                    "/rpc:host:/:/tmp/tramp-rpc-root/subdir/foo")))
+      (should (stringp result))
+      (should (equal result "/rpc:host:/:/tmp/tramp-rpc-root/")))))
+
+(ert-deftest tramp-rpc-mock-test-dir-locals-find-file-cache-hit-with-quoting ()
+  "Ensure dir-locals-find-file finds cache entries populated via quoted paths.
+A cache entry keyed by `/rpc:host:/:/...' must be discoverable when the
+current call comes through the same quoted access path."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (cl-letf (((symbol-function 'tramp-rpc--call)
+             (lambda (_vec method _params)
+               (should (string= method "highlevel.dir_locals_find_file_cache_update"))
+               `((file . ,(encode-coding-string "/tmp/root/subdir/foo"
+                                                'utf-8 t))
+                 (locals . ((dir . ,(encode-coding-string "/tmp/root"
+                                                          'utf-8 t))
+                            (files . ())))
+                 (cache . ((dir . ,(encode-coding-string "/tmp/root"
+                                                         'utf-8 t))
+                           (files . ())))))))
+    (let* ((cache-entry '("/rpc:host:/:/tmp/root/" nil nil))
+           (dir-locals-directory-cache (list cache-entry))
+           (result (tramp-rpc-handle-dir-locals-find-file
+                    "/rpc:host:/:/tmp/root/subdir/foo")))
+      ;; The handler should find the existing cache entry via `string='
+      ;; against the re-quoted cache-dir reconstruction.
+      (should (eq result cache-entry)))))
 
 ;;; ============================================================================
 ;;; Non-essential / recentf Tests (No server or SSH required)


### PR DESCRIPTION
## Summary

Follow-up to #140 addressing correctness and cleanliness issues identified in the final review.

## Fixes

### Correctness

- **Preserve file-name-quoted paths in `tramp-rpc-handle-dir-locals-find-file`** — The handler previously reconstructed locals/cache dirs via raw `concat` of `file-remote-p` and the localname, dropping the `/:` prefix that the other two handlers preserve. Cache lookups populated via quoted access paths would silently miss. Now uses `tramp-make-tramp-file-name` with the same `tramp-rpc--quote-localname` pattern as the sibling handlers.

- **Match stock Emacs stop-regexp behavior in `locate-dominating-file`** — Stock Emacs runs `string-match` against every path visited during the walk, including the starting path and the dominating directory itself. The previous helper walked ancestor directories only and skipped those endpoints. Rewritten `tramp-rpc--locate-dominating-before-stop-p` mirrors the stock walk.

- **Silent depth limit (matches stock)** — `find_dominating_dir` previously returned `Err` on depth overflow, surfacing as a Lisp signal that stock Emacs never produces. Now returns `None` on overflow (silent no-match) and the default limit is bumped 100 → 1024. The limit is now a `max_depth` param on the RPC, letting tests exercise it cheaply without creating pathologically deep filesystems.

### Cleanup

- **Remove dead `remap_to_lexical_ancestor`** — `find_dominating_dir` walks `start_dir` via `Path::parent()` with no canonicalization, so `locals_dir` is always a lexical ancestor of `start_dir`. The remap call was a no-op in practice.

- **Remove redundant handler-alist entries** — `locate-dominating-file`, `dir-locals--all-files`, and `dir-locals-find-file` are now registered exclusively via `tramp-add-external-operation`, matching the projectile/magit pattern in `tramp-rpc-magit.el`. The literal `defconst` entries were duplicates that `add-to-list` silently ignored.

- **Lexical `tramp-rpc--dir-locals-cache-covers-p`** — Previously used `file-in-directory-p` which requires LOCALS-DIR to exist on the filesystem and triggers TRAMP remote calls. Replaced with `string-prefix-p` on `file-name-as-directory` paths — pure string comparison, no I/O, still correctly rejects siblings like `/tmp/a/` vs `/tmp/a-b/`.

### Tests

- Fixed broken `tramp-rpc-mock-test-dir-locals-cache-covers-uses-containment` assertion (old assertion checked containment between two unrelated paths and accidentally passed with both length-based and containment-based implementations).
- Added `tramp-rpc-mock-test-dir-locals-find-file-preserves-quoting` and `...-cache-hit-with-quoting` covering the new quote-preservation logic.
- Added `tramp-rpc-mock-test-locate-dominating-file-stop-regexp-matches-target` covering the endpoint-inclusive stop-regexp behavior.
- Re-added `tramp-rpc-mock-test-dir-locals-advice-install-remove-cycle` (the previous `...-advice-installed` test was dropped during #140 but the `hack-dir-local-variables` advice it guarded is still present).
- Updated existing depth-limit tests to use the new `max_depth` parameter and to assert silent no-match instead of error signal.

## Verification

- Byte-compile clean with `byte-compile-error-on-warn`
- `cargo build --release`, `cargo clippy -D warnings`, `cargo fmt --check`: clean
- `cargo test --release`: 19/19 pass
- `tramp-rpc-mock-tests.el` full suite: **80/80 pass** (with tramp 2.8.2-pre)