### PR TITLE
ci: update actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Restore binary from cache
         id: cache-binary
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: target/${{ inputs.target }}/release/tramp-rpc-server
           key: rust-binary-${{ inputs.target }}-${{ hashFiles('server/**', 'Cargo.toml', 'Cargo.lock', 'flake.nix', 'flake.lock', '.cargo/**') }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Nix
         if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -88,14 +88,14 @@ jobs:
 
       - name: Save binary to cache
         if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: target/${{ inputs.target }}/release/tramp-rpc-server
           key: rust-binary-${{ inputs.target }}-${{ hashFiles('server/**', 'Cargo.toml', 'Cargo.lock', 'flake.nix', 'flake.lock', '.cargo/**') }}
 
       - name: Upload binary for CI
         if: ${{ !inputs.upload }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tramp-rpc-server-${{ inputs.target }}
           path: target/${{ inputs.target }}/release/tramp-rpc-server
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload artifacts
         if: inputs.upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tramp-rpc-server-${{ inputs.target }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -229,7 +229,7 @@ jobs:
           version: '30.1'
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tramp-rpc-server-x86_64-unknown-linux-musl
           path: target/x86_64-unknown-linux-musl/release/
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -277,7 +277,7 @@ jobs:
           version: '30.1'
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tramp-rpc-server-x86_64-unknown-linux-musl
           path: target/x86_64-unknown-linux-musl/release/
@@ -347,7 +347,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
@@ -373,7 +373,7 @@ jobs:
               ~/src/tramp/lisp/trampver.el.in > ~/src/tramp/lisp/trampver.el
 
       - name: Download server binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tramp-rpc-server-x86_64-unknown-linux-musl
           path: target/x86_64-unknown-linux-musl/release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -151,7 +151,7 @@ jobs:
           ENDOFNOTES
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v5
- `actions/cache/restore` and `cache/save` v4 → v5
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `softprops/action-gh-release` v1 → v3
- `cachix/install-nix-action` v20 → v31

Fixes the Node.js 20 deprecation warnings from GitHub Actions. All updated versions use the Node.js 24 runtime. Node.js 20 actions will be forced to Node.js 24 from June 2026 and removed from runners in September 2026.