### PR TITLE
chore: bump version to 0.8.0 across Rust and Lisp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["server"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.8.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 authors = ["Arthur Heymans <arthur@aheymans.xyz>"]

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -37,7 +37,7 @@
   "Deployment settings for TRAMP-RPC."
   :group 'tramp)
 
-(defconst tramp-rpc-deploy-version "0.7.0"
+(defconst tramp-rpc-deploy-version "0.8.0"
   "Current version of tramp-rpc-server.")
 
 (defconst tramp-rpc-deploy-binary-name "tramp-rpc-server"

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
-;; Version: 0.7.0
+;; Version: 0.8.0
 ;; Keywords: comm, processes, files
 ;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.3"))
 


### PR DESCRIPTION
Align Rust workspace version (previously 0.2.0) with the Lisp package version (previously 0.7.0) and bump both to 0.8.0 to maintain a single shared version number going forward.