### PR TITLE
ci: add i686, armv7, armv5te, and arm/ARMv6 Linux build targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,15 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.armv7-unknown-linux-musleabihf]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.armv5te-unknown-linux-musleabi]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.arm-unknown-linux-musleabihf]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,15 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
+      - name: Cache Nix store
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 4294967296
+          gc-max-store-size-macos: 4294967296
+
       - name: Build
         if: steps.cache-binary.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,18 +63,18 @@ jobs:
 
       - name: Install Nix
         if: steps.cache-binary.outputs.cache-hit != 'true'
-        uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix store
         if: steps.cache-binary.outputs.cache-hit != 'true'
         uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
+          primary-key: nix-v2-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-v2-${{ runner.os }}-
           gc-max-store-size-linux: 4294967296
           gc-max-store-size-macos: 4294967296
+          # Only the nix-setup job needs to write the cache; arch jobs only restore.
+          save: false
 
       - name: Build
         if: steps.cache-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
+          primary-key: nix-v2-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-v2-${{ runner.os }}-
           gc-max-store-size-linux: 4294967296
 
       - name: Build dev shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,64 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust:
+  nix-setup:
+    name: Build Nix dev shell (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 4294967296
+
+      - name: Build dev shell
+        run: nix develop --command true
+
+  rust-linux:
     name: Rust ${{ matrix.name }}
+    needs: nix-setup
     uses: ./.github/workflows/build.yml
     with:
       target: ${{ matrix.target }}
-      os: ${{ matrix.os }}
+      os: ubuntu-latest
       test: true
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Linux x86_64
-            os: ubuntu-latest
             target: x86_64-unknown-linux-musl
           - name: Linux aarch64
-            os: ubuntu-latest
             target: aarch64-unknown-linux-musl
+
+  rust-macos:
+    name: Rust ${{ matrix.name }}
+    uses: ./.github/workflows/build.yml
+    with:
+      target: ${{ matrix.target }}
+      os: macos-latest
+      test: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: macOS x86_64
-            os: macos-latest
             target: x86_64-apple-darwin
           - name: macOS aarch64
-            os: macos-latest
             target: aarch64-apple-darwin
 
   rust-extra:
     name: Build ${{ matrix.name }}
+    needs: nix-setup
     uses: ./.github/workflows/build.yml
     with:
       target: ${{ matrix.target }}
@@ -237,7 +269,7 @@ jobs:
   test-server:
     name: Server Integration Tests
     runs-on: ubuntu-latest
-    needs: [rust, elisp]
+    needs: [rust-linux, elisp]
 
     steps:
       - name: Checkout
@@ -285,7 +317,7 @@ jobs:
   test-full-suite:
     name: Full Test Suite (with SSH)
     runs-on: ubuntu-latest
-    needs: [rust, elisp]
+    needs: [rust-linux, elisp]
 
     steps:
       - name: Checkout
@@ -363,7 +395,7 @@ jobs:
   test-upstream-tramp:
     name: Upstream Tramp Tests
     runs-on: ubuntu-latest
-    needs: [rust, elisp]
+    needs: [rust-linux, elisp]
 
     steps:
       - name: Checkout
@@ -454,14 +486,15 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [rust, rust-extra, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
+    needs: [rust-linux, rust-macos, rust-extra, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
     if: always()
 
     steps:
       - name: Check results
         run: |
           echo "=== CI Summary ==="
-          echo "Rust: ${{ needs.rust.result }}"
+          echo "Rust Linux: ${{ needs.rust-linux.result }}"
+          echo "Rust macOS: ${{ needs.rust-macos.result }}"
           echo "Rust Extra: ${{ needs.rust-extra.result }}"
           echo "Elisp: ${{ needs.elisp.result }}"
           echo "Autoload Tests: ${{ needs.test-autoload.result }}"
@@ -471,7 +504,8 @@ jobs:
           echo "Full Test Suite: ${{ needs.test-full-suite.result }}"
           echo "Upstream Tramp Tests: ${{ needs.test-upstream-tramp.result }}"
 
-          if [[ "${{ needs.rust.result }}" != "success" ]] || \
+          if [[ "${{ needs.rust-linux.result }}" != "success" ]] || \
+             [[ "${{ needs.rust-macos.result }}" != "success" ]] || \
              [[ "${{ needs.rust-extra.result }}" != "success" ]] || \
              [[ "${{ needs.elisp.result }}" != "success" ]] || \
              [[ "${{ needs.test-autoload.result }}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,26 @@ jobs:
             os: macos-latest
             target: aarch64-apple-darwin
 
+  rust-extra:
+    name: Build ${{ matrix.name }}
+    uses: ./.github/workflows/build.yml
+    with:
+      target: ${{ matrix.target }}
+      os: ubuntu-latest
+      test: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux i686
+            target: i686-unknown-linux-musl
+          - name: Linux armv7 (Allwinner A20/H3)
+            target: armv7-unknown-linux-musleabihf
+          - name: Linux armv5te (AST2500)
+            target: armv5te-unknown-linux-musleabi
+          - name: Linux arm/ARMv6 (Raspberry Pi 1)
+            target: arm-unknown-linux-musleabihf
+
   format:
     name: Rust Format Check
     runs-on: ubuntu-latest
@@ -434,7 +454,7 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [rust, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
+    needs: [rust, rust-extra, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
     if: always()
 
     steps:
@@ -442,6 +462,7 @@ jobs:
         run: |
           echo "=== CI Summary ==="
           echo "Rust: ${{ needs.rust.result }}"
+          echo "Rust Extra: ${{ needs.rust-extra.result }}"
           echo "Elisp: ${{ needs.elisp.result }}"
           echo "Autoload Tests: ${{ needs.test-autoload.result }}"
           echo "Protocol Tests: ${{ needs.test-protocol.result }}"
@@ -451,6 +472,7 @@ jobs:
           echo "Upstream Tramp Tests: ${{ needs.test-upstream-tramp.result }}"
 
           if [[ "${{ needs.rust.result }}" != "success" ]] || \
+             [[ "${{ needs.rust-extra.result }}" != "success" ]] || \
              [[ "${{ needs.elisp.result }}" != "success" ]] || \
              [[ "${{ needs.test-autoload.result }}" != "success" ]] || \
              [[ "${{ needs.test-protocol.result }}" != "success" ]] || \

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,32 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
 
+          # Cross-compilation toolchains for extra Linux targets
+          pkgsCrossI686Musl = pkgs.pkgsCross.musl32;
+          pkgsCrossArmv5teMusl = import nixpkgs {
+            inherit system;
+            crossSystem = lib.systems.elaborate {
+              config = "armv5tel-unknown-linux-musleabi";
+              libc = "musl";
+            };
+          };
+          # ARMv7 hard-float: Allwinner A20/H3 (Cortex-A7), Raspberry Pi 2+
+          pkgsCrossArmv7Musl = import nixpkgs {
+            inherit system;
+            crossSystem = lib.systems.elaborate {
+              config = "armv7l-unknown-linux-gnueabihf";
+              libc = "musl";
+            };
+          };
+          # ARMv6 hard-float: original Raspberry Pi (ARM1176JZF-S)
+          pkgsCrossArmMusl = import nixpkgs {
+            inherit system;
+            crossSystem = lib.systems.elaborate {
+              config = "armv6l-unknown-linux-gnueabihf";
+              libc = "musl";
+            };
+          };
+
           # Nightly toolchain with rust-src for build-std (size-optimized builds)
           rustToolchain = rust-overlay.packages.${system}.rust-nightly.override {
             targets = [
@@ -44,6 +70,10 @@
               "aarch64-unknown-linux-musl"
               "x86_64-apple-darwin"
               "aarch64-apple-darwin"
+              "i686-unknown-linux-musl"
+              "armv7-unknown-linux-musleabihf"
+              "armv5te-unknown-linux-musleabi"
+              "arm-unknown-linux-musleabihf"
             ];
             extensions = [ "rust-src" ];
           };
@@ -56,6 +86,10 @@
               pkgs.pkg-config
               pkgs.pkgsCross.musl64.stdenv.cc
               pkgs.pkgsCross.aarch64-multiplatform-musl.stdenv.cc
+              pkgsCrossI686Musl.stdenv.cc
+              pkgsCrossArmv7Musl.stdenv.cc
+              pkgsCrossArmv5teMusl.stdenv.cc
+              pkgsCrossArmMusl.stdenv.cc
               pkgs.rust-analyzer
             ];
 
@@ -70,6 +104,10 @@
 
               export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${pkgs.pkgsCross.musl64.stdenv.cc}/bin/x86_64-unknown-linux-musl-gcc"
               export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="${pkgs.pkgsCross.aarch64-multiplatform-musl.stdenv.cc}/bin/aarch64-unknown-linux-musl-gcc"
+              export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER="${pkgsCrossI686Musl.stdenv.cc}/bin/${pkgsCrossI686Musl.stdenv.cc.targetPrefix}gcc"
+              export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER="${pkgsCrossArmv7Musl.stdenv.cc}/bin/${pkgsCrossArmv7Musl.stdenv.cc.targetPrefix}gcc"
+              export CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER="${pkgsCrossArmv5teMusl.stdenv.cc}/bin/${pkgsCrossArmv5teMusl.stdenv.cc.targetPrefix}gcc"
+              export CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER="${pkgsCrossArmMusl.stdenv.cc}/bin/${pkgsCrossArmMusl.stdenv.cc.targetPrefix}gcc"
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -50,16 +50,14 @@
           pkgsCrossArmv7Musl = import nixpkgs {
             inherit system;
             crossSystem = lib.systems.elaborate {
-              config = "armv7l-unknown-linux-gnueabihf";
-              libc = "musl";
+              config = "armv7l-unknown-linux-musleabihf";
             };
           };
           # ARMv6 hard-float: original Raspberry Pi (ARM1176JZF-S)
           pkgsCrossArmMusl = import nixpkgs {
             inherit system;
             crossSystem = lib.systems.elaborate {
-              config = "armv6l-unknown-linux-gnueabihf";
-              libc = "musl";
+              config = "armv6l-unknown-linux-musleabihf";
             };
           };
 

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -19,7 +19,7 @@ use crate::protocol::path_or_bytes;
 
 /// Extract time and mode fields from libc::stat in a cross-platform way
 /// Returns (atime, mtime, ctime, mode)
-/// - On Linux: st_mode is u32, time fields are i64
+/// - On Linux: st_mode is u32; time fields are i32 on 32-bit, i64 on 64-bit
 /// - On macOS: st_mode is u16, time fields are i64
 #[inline]
 fn extract_stat_fields(stat_buf: &libc::stat) -> (i64, i64, i64, u32) {
@@ -29,9 +29,9 @@ fn extract_stat_fields(stat_buf: &libc::stat) -> (i64, i64, i64, u32) {
     let mode = stat_buf.st_mode;
 
     (
-        stat_buf.st_atime,
-        stat_buf.st_mtime,
-        stat_buf.st_ctime,
+        stat_buf.st_atime.into(),
+        stat_buf.st_mtime.into(),
+        stat_buf.st_ctime.into(),
         mode,
     )
 }

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -512,11 +512,11 @@ fn set_file_times_sync(path: &str, atime: i64, mtime: i64) -> Result<(), RpcErro
 
     let times = [
         libc::timespec {
-            tv_sec: atime,
+            tv_sec: atime as libc::time_t,
             tv_nsec: 0,
         },
         libc::timespec {
-            tv_sec: mtime,
+            tv_sec: mtime as libc::time_t,
             tv_nsec: 0,
         },
     ];
@@ -544,11 +544,11 @@ fn set_file_times_sync_path(
 
     let times = [
         libc::timespec {
-            tv_sec: atime,
+            tv_sec: atime as libc::time_t,
             tv_nsec: 0,
         },
         libc::timespec {
-            tv_sec: mtime,
+            tv_sec: mtime as libc::time_t,
             tv_nsec: 0,
         },
     ];

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -512,11 +512,11 @@ fn set_file_times_sync(path: &str, atime: i64, mtime: i64) -> Result<(), RpcErro
 
     let times = [
         libc::timespec {
-            tv_sec: atime as libc::time_t,
+            tv_sec: atime as _,
             tv_nsec: 0,
         },
         libc::timespec {
-            tv_sec: mtime as libc::time_t,
+            tv_sec: mtime as _,
             tv_nsec: 0,
         },
     ];
@@ -544,11 +544,11 @@ fn set_file_times_sync_path(
 
     let times = [
         libc::timespec {
-            tv_sec: atime as libc::time_t,
+            tv_sec: atime as _,
             tv_nsec: 0,
         },
         libc::timespec {
-            tv_sec: mtime as libc::time_t,
+            tv_sec: mtime as _,
             tv_nsec: 0,
         },
     ];


### PR DESCRIPTION
## Summary

- Adds a `rust-extra` CI job (build-only, no tests) for four additional static musl Linux targets
- Adds the required Nix cross-compilation toolchains to `flake.nix` for local builds
- Adds `crt-static` entries to `.cargo/config.toml` for the new targets

## Targets

| Target | Hardware |
|---|---|
| `i686-unknown-linux-musl` | 32-bit x86 |
| `armv7-unknown-linux-musleabihf` | Allwinner A20/H3 (Cortex-A7) |
| `armv5te-unknown-linux-musleabi` | Aspeed AST2500 (ARM926EJ-S) |
| `arm-unknown-linux-musleabihf` | Original Raspberry Pi (ARM1176JZF-S, ARMv6) |

## Notes

- The ARMv6 target uses `arm-unknown-linux-musleabihf` (not `armv6-*`) following GNU/Debian toolchain convention where bare `arm` means the ARMv6 hard-float ABI
- Nix cross packages for the ARM targets are constructed with `import nixpkgs { crossSystem = ...; }` since no named `pkgsCross` entry exists for musl ARM; linker paths use `targetPrefix` to avoid hardcoding binary names