### PR TITLE
Convert advice to external operations (Tramp >= 2.8.1.4)

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 * Requirements
 
 - Emacs 30.1 or later
-- Tramp 2.8.1.3 or later (install from GNU ELPA if your Emacs bundles an older version)
+- Tramp 2.8.1.4 or later (install from GNU ELPA if your Emacs bundles an older version)
 - =msgpack.el= package (installed automatically from MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -1,4 +1,4 @@
-;;; tramp-rpc-advice.el --- Process advice for TRAMP-RPC -*- lexical-binding: t; -*-
+;;; tramp-rpc-advice.el --- Process handlers for TRAMP-RPC -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
 
@@ -15,7 +15,7 @@
 
 ;;; Commentary:
 
-;; This file provides all the :around advice functions that tramp-rpc
+;; This file provides all the own Tramp handlers that tramp-rpc
 ;; installs on Emacs built-in process functions:
 ;; - process-send-string / process-send-region (route to remote stdin)
 ;; - process-send-eof (close remote stdin or send Ctrl-D to PTY)
@@ -38,8 +38,6 @@
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process")
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
 
-;; Functions from tramp-cmds.el
-
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")
@@ -52,22 +50,23 @@
 (defvar tramp-rpc--pty-processes)
 (defvar tramp-rpc--async-processes)
 
-;; Functions from vc-dispatcher.el (used by vc-exec-after advice)
+;; Functions from vc-dispatcher.el (used by vc-exec-after handler)
+(declare-function vc-exec-after "vc-dispatcher")
 (declare-function vc-set-mode-line-busy-indicator "vc-dispatcher")
 (declare-function vc--process-sentinel "vc-dispatcher")
 
-;; Variables from vc-dir.el (used in vc-dir-refresh advice)
+;; Variables from vc-dir.el (used in vc-dir-refresh handler)
 (defvar vc-dir-process-buffer)
 
 ;; ============================================================================
-;; Process I/O advice
+;; Process I/O handler
 ;; ============================================================================
 
-(defun tramp-rpc--process-send-string-advice (orig-fun process string)
-  "Advice for `process-send-string' to handle TRAMP-RPC processes."
-  ;; If we're delivering output to the local relay, bypass this advice
+(defun tramp-rpc-handle-process-send-string (process string)
+  "Handler for `process-send-string' for TRAMP-RPC processes."
+  ;; If we're delivering output to the local relay, bypass this handler
   (if tramp-rpc--delivering-output
-      (funcall orig-fun process string)
+      (tramp-run-real-handler #'process-send-string (list process string))
     ;; process-send-string can receive a buffer/buffer-name instead of process
     (let ((proc (cond
                  ((processp process) process)
@@ -77,7 +76,7 @@
       (cond
        ;; Direct SSH PTY - use normal process-send-string (low latency)
        ((and proc (process-get proc :tramp-rpc-direct-ssh))
-        (funcall orig-fun process string))
+        (tramp-run-real-handler #'process-send-string (list process string)))
        ;; RPC-based PTY process - use PTY write (async, fire-and-forget)
        ((and proc (process-get proc :tramp-rpc-pty)
              (process-get proc :tramp-rpc-pid))
@@ -108,13 +107,13 @@
         (error
          (message "tramp-rpc: Error writing to process: %s" err))))
        ;; Not an RPC process, use original function
-       (t (funcall orig-fun process string))))))
+       (t (tramp-run-real-handler #'process-send-string (list process string)))))))
 
-(defun tramp-rpc--process-send-region-advice (orig-fun process start end)
-  "Advice for `process-send-region' to handle TRAMP-RPC processes."
-  ;; If we're delivering output to the local relay, bypass this advice
+(defun tramp-rpc-handle-process-send-region (process start end)
+  "Handler for `process-send-region' for TRAMP-RPC processes."
+  ;; If we're delivering output to the local relay, bypass this handler
   (if tramp-rpc--delivering-output
-      (funcall orig-fun process start end)
+      (tramp-run-real-handler #'process-send-region (list process start end))
     (let ((proc (cond
                  ((processp process) process)
                  ((or (bufferp process) (stringp process))
@@ -123,7 +122,7 @@
       (cond
        ;; Direct SSH PTY - use normal process-send-region (low latency)
        ((and proc (process-get proc :tramp-rpc-direct-ssh))
-        (funcall orig-fun process start end))
+        (tramp-run-real-handler #'process-send-region (list process start end)))
        ;; RPC-based PTY process - use PTY write
        ((and proc (process-get proc :tramp-rpc-pty)
              (process-get proc :tramp-rpc-pid))
@@ -155,19 +154,19 @@
             (error
              (message "tramp-rpc: Error writing to process: %s" err)))))
        ;; Not an RPC process, use original function
-       (t (funcall orig-fun process start end))))))
+       (t (tramp-run-real-handler #'process-send-region (list process start end)))))))
 
-(defun tramp-rpc--process-send-eof-advice (orig-fun &optional process)
-  "Advice for `process-send-eof' to handle TRAMP-RPC processes."
-  ;; When closing a local cat relay, bypass this advice entirely so
+(defun tramp-rpc-handle-process-send-eof (&optional process)
+  "Handler for `process-send-eof' for TRAMP-RPC processes."
+  ;; When closing a local cat relay, bypass this handler entirely so
   ;; the EOF reaches the local process rather than the remote one.
   (if tramp-rpc--closing-local-relay
-      (funcall orig-fun process)
+      (tramp-run-real-handler #'process-send-eof (and process (list process)))
     (let ((proc (or process (get-buffer-process (current-buffer)))))
       (cond
        ;; Direct SSH PTY - use normal process-send-eof
        ((and proc (process-get proc :tramp-rpc-direct-ssh))
-        (funcall orig-fun process))
+         (tramp-run-real-handler #'process-send-eof (and process (list process))))
        ;; RPC-managed process
        ((and proc
              (process-get proc :tramp-rpc-pid)
@@ -182,7 +181,7 @@
             (condition-case err
                 (if (process-get proc :tramp-rpc-pty)
                     ;; PTY processes: send Ctrl-D (EOF character) via the PTY
-                    (let ((eof-char (string 4))) ; ASCII 4 = Ctrl-D
+                    (let ((eof-char (string ?\C-d))) ; ASCII 4 = Ctrl-D
                       (tramp-rpc--call-async vec "process.write_pty"
                                              `((pid . ,pid)
                                                (data . ,(msgpack-bin-make eof-char)))
@@ -196,7 +195,7 @@
                (unless (string-match-p "Process not found" (error-message-string err))
                  (message "tramp-rpc: Error closing stdin: %s" err)))))))
        ;; Not a tramp-rpc process
-       (t (funcall orig-fun process))))))
+       (t (tramp-run-real-handler #'process-send-eof (and process (list process))))))))
 
 (defun tramp-rpc-handle-signal-process (process sigcode &optional _remote)
   "Handler for `signal-process' of TRAMP-RPC processes.
@@ -217,46 +216,49 @@ It will be added to `signal-process-functions'."
        -1))))
 
 ;; ============================================================================
-;; Process metadata advice
+;; Process metadata handlers
 ;; ============================================================================
 
-(defun tramp-rpc--process-status-advice (orig-fun process)
-  "Advice for `process-status' to handle TRAMP-RPC processes."
+(defun tramp-rpc-handle-process-status (process)
+  "Handler for `process-status' for TRAMP-RPC processes."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
       (cond
        ((process-get process :tramp-rpc-exited) 'exit)
-       ;; Use orig-fun to check live status, not process-live-p (which would recurse).
-       ;; Do not perform synchronous remote status RPCs here: callers such as
-       ;; mode-line redisplay, Flymake, and LSP process management may ask for
-       ;; process status while the user is typing.
-       ((memq (funcall orig-fun process) '(run open listen connect)) 'run)
+       ;; Use the real handler to check local relay liveness, not
+       ;; `process-live-p' (which would recurse).  Do not perform synchronous
+       ;; remote status RPCs here: callers such as mode-line redisplay,
+       ;; Flymake, and LSP process management may ask for process status while
+       ;; the user is typing.
+       ((memq (tramp-run-real-handler #'process-status (list process))
+	      '(run open listen connect))
+	'run)
        (t 'exit))
-    (funcall orig-fun process)))
+    (tramp-run-real-handler #'process-status (list process))))
 
-(defun tramp-rpc--process-exit-status-advice (orig-fun process)
-  "Advice for `process-exit-status' to handle TRAMP-RPC processes."
+(defun tramp-rpc-handle-process-exit-status (process)
+  "Handler for `process-exit-status' for TRAMP-RPC processes."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
       (or (process-get process :tramp-rpc-exit-code) 0)
-    (funcall orig-fun process)))
+    (tramp-run-real-handler #'process-exit-status (list process))))
 
-(defun tramp-rpc--process-command-advice (orig-fun process)
-  "Advice for `process-command' to return stored command for PTY processes."
+(defun tramp-rpc-handle-process-command (process)
+  "Handler for `process-command' to return stored command for PTY processes."
   (if (and (processp process) (process-get process :tramp-rpc-command))
       (process-get process :tramp-rpc-command)
-    (funcall orig-fun process)))
+    (tramp-run-real-handler #'process-command (list process))))
 
-(defun tramp-rpc--process-tty-name-advice (orig-fun process &optional stream)
-  "Advice for `process-tty-name' to return stored TTY name for PTY processes.
+(defun tramp-rpc-handle-process-tty-name (process &optional stream)
+  "Handler for `process-tty-name' to return stored TTY name for PTY processes.
 For TRAMP-RPC PTY processes, return the remote TTY name stored during creation.
 For direct SSH PTY processes, use the original function (returns local PTY)."
   (if (and (processp process)
            (process-get process :tramp-rpc-pty)
            (not (process-get process :tramp-rpc-direct-ssh)))
       (process-get process :tramp-rpc-tty-name)
-    (funcall orig-fun process stream)))
+    (tramp-run-real-handler #'process-tty-name (list process stream))))
 
 ;; ============================================================================
-;; VC integration advice
+;; VC integration handler
 ;; ============================================================================
 
 ;; VC backends like vc-git-state use process-file internally, but they don't
@@ -264,29 +266,30 @@ For direct SSH PTY processes, use the original function (returns local PTY)."
 ;; runs locally instead of going through our tramp handler. We fix this by
 ;; advising vc-call-backend to set default-directory when the file is remote.
 
-(defun tramp-rpc--vc-call-backend-advice (orig-fun backend function-name &rest args)
-  "Advice for `vc-call-backend' to handle TRAMP files correctly.
+(defun tramp-rpc--vc-call-backend-file-name-for-operation
+    (_operation _backend function-name &rest args)
+  "Helper function for `vc-call-backend' handler."
+  (or (and ;; Operations that take a file and may call process-file
+           (memq function-name '(registered state state-heuristic dir-status-files
+                                 working-revision previous-revision next-revision
+                                 responsible-p))
+	   (stringp (car args)) (car args))
+      ""))
+
+(defun tramp-rpc-handle-vc-call-backend (backend function-name &rest args)
+  "Handler for `vc-call-backend' for TRAMP files correctly.
 When FUNCTION-NAME is an operation that takes a file argument and that file is
 a TRAMP path, ensure `default-directory' is set to the file's directory so that
 process-file calls are routed through the TRAMP handler."
-  (let* ((file (car args))
-         (should-set-dir (and file
-                              (stringp file)
-                              (tramp-tramp-file-p file)
-                              ;; Operations that take a file and may call process-file
-                              (memq function-name '(registered state state-heuristic dir-status-files
-                                                    working-revision previous-revision next-revision
-                                                    responsible-p)))))
-    (if should-set-dir
-        (let ((default-directory (file-name-directory file)))
-          (apply orig-fun backend function-name args))
-      (apply orig-fun backend function-name args))))
+  (let ((default-directory (file-name-directory (car args))))
+    (tramp-run-real-handler
+     #'vc-call-backend (append `(,backend ,function-name) args))))
 
-(defun tramp-rpc--vc-exec-after-advice (orig-fun code &optional success)
-  "Advice for `vc-exec-after' to handle TRAMP-RPC relay processes.
+(defun tramp-rpc-handle-vc-exec-after (code &optional success)
+  "Handler for `vc-exec-after' to handle TRAMP-RPC relay processes.
 
 Some native-compiled VC functions can observe the raw local relay process
-state instead of the logical state provided by `process-status' advice.  A
+state instead of the logical state provided by the `process-status' handler.  A
 short-lived remote command can leave the local cat relay in a non-`run' and
 non-`exit' state while TRAMP-RPC has already recorded the remote exit.  The
 stock `vc-exec-after' then signals \"Unexpected process state\".  For
@@ -317,8 +320,8 @@ state."
                             (vc--process-sentinel p code success))))
               (add-function :after (process-sentinel proc) fun)))
            (t
-            (funcall orig-fun code success))))
-      (funcall orig-fun code success)))
+            (tramp-run-real-handler #'vc-exec-after (list code success)))))
+      (tramp-run-real-handler #'vc-exec-after (list code success))))
   nil)
 
 ;; ============================================================================
@@ -332,16 +335,16 @@ state."
 ;; 1. Our pipe processes don't have a TTY, so stty fails
 ;; 2. We don't need this workaround - our RPC handles binary data correctly
 ;;
-;; This advice bypasses the shell wrapper for tramp-rpc connections.
+;; This handler bypasses the shell wrapper for tramp-rpc connections.
 
-(defun tramp-rpc--eglot-cmd-advice (orig-fun contact)
-  "Advice for `eglot--cmd' to avoid shell wrapping for tramp-rpc.
+(defun tramp-rpc-handle-eglot--cmd (contact)
+  "Handler for `eglot--cmd' to avoid shell wrapping for tramp-rpc.
 For tramp-rpc connections, return CONTACT directly without wrapping
-in a shell command. This is safe because tramp-rpc uses pipes (not PTYs)
+in a shell command.  This is safe because tramp-rpc uses pipes (not PTYs)
 and handles binary data correctly."
   (if (tramp-rpc-file-name-p default-directory)
       contact
-    (funcall orig-fun contact)))
+    (tramp-run-real-handler 'eglot--cmd (list contact))))
 
 ;; ============================================================================
 ;; Magit: force pipe mode for stdin piping
@@ -357,25 +360,25 @@ and handles binary data correctly."
 ;; The `pty' workaround exists for tramp-sh (#4720, #5220) where pipe stty
 ;; settings broke hunk staging.  tramp-rpc doesn't need it: stdin data goes
 ;; via RPC (pipe processes) or direct SSH pipes, both of which handle EOF
-;; correctly.  This advice forces pipe mode only for tramp-rpc connections
+;; correctly.  This handler forces pipe mode only for tramp-rpc connections
 ;; when input will be piped, leaving other TRAMP methods untouched.
 
-;; Declared special so the dynamic let-binding in the advice below
+;; Declared special so the dynamic let-binding in the handler below
 ;; is not flagged as an unused lexical variable by the byte-compiler.
 (defvar magit-tramp-pipe-stty-settings)
 
-(defun tramp-rpc--magit-start-process-advice (orig-fun program &optional input &rest args)
+(defun tramp-rpc-handle-magit-start-process (program &optional input &rest args)
   "Force pipe mode for tramp-rpc when INPUT will be piped to the process.
 PTY mode breaks stdin piping because `process-send-eof' sends Ctrl-D
 which does not close the pipe — git waits for more input forever."
-  (if (and input
-           (file-remote-p default-directory)
-           (tramp-rpc-file-name-p default-directory))
+  (if input
       ;; Let-bind magit-tramp-pipe-stty-settings to "" so that
       ;; magit-start-process sets process-connection-type to nil (pipe).
       (let ((magit-tramp-pipe-stty-settings ""))
-        (apply orig-fun program input args))
-    (apply orig-fun program input args)))
+	(tramp-run-real-handler
+	 'magit-start-process (append `(,program ,input) args)))
+    (tramp-run-real-handler
+     'magit-start-process (append `(,program ,input) args))))
 
 ;; ============================================================================
 ;; vc-dir stale-process guard
@@ -387,23 +390,29 @@ which does not close the pipe — git waits for more input forever."
 ;; been called.  Normally our deferred `tramp-rpc--install-process-cleanup'
 ;; handles this, but if the timer hasn't fired yet (or if the cat relay got
 ;; stuck), the stale process causes "Another update process is in progress".
-;; This advice acts as a safety net: before `vc-dir-refresh' checks the
+;; This handler acts as a safety net: before `vc-dir-refresh' checks the
 ;; busy flag, we delete any exited tramp-rpc relay process from the buffer.
 
-(defun tramp-rpc--vc-dir-refresh-advice (orig-fun)
-  "Advice for `vc-dir-refresh' to clean up stale TRAMP-RPC relay processes.
+(defun tramp-rpc--vc-dir-refresh-file-name-for-operation
+    (_operation)
+  "Helper function for `vc-dir-refresh' handler."
+  (if (and (bound-and-true-p vc-dir-process-buffer)
+           (buffer-live-p vc-dir-process-buffer))
+      (tramp-get-default-directory vc-dir-process-buffer)
+      ""))
+
+(defun tramp-rpc-handle-vc-dir-refresh ()
+  "Handler for `vc-dir-refresh' to clean up stale TRAMP-RPC relay processes.
 If the vc-dir process buffer has a tramp-rpc cat relay that has already
 exited (remote side finished), delete it so the refresh can proceed."
-  (when (and (bound-and-true-p vc-dir-process-buffer)
-             (buffer-live-p vc-dir-process-buffer))
-    (let ((proc (get-buffer-process vc-dir-process-buffer)))
-      (when (and proc
-                 (process-get proc :tramp-rpc-pid)
-                 (or (process-get proc :tramp-rpc-exited)
-                     (not (process-live-p proc))))
-        (remhash proc tramp-rpc--async-processes)
-        (ignore-errors (delete-process proc)))))
-  (funcall orig-fun))
+  (let ((proc (get-buffer-process vc-dir-process-buffer)))
+    (when (and proc
+               (process-get proc :tramp-rpc-pid)
+               (or (process-get proc :tramp-rpc-exited)
+                   (not (process-live-p proc))))
+      (remhash proc tramp-rpc--async-processes)
+      (ignore-errors (delete-process proc))))
+  (tramp-run-real-handler 'vc-dir-refresh nil))
 
 ;; ============================================================================
 ;; Dir-locals advice
@@ -422,59 +431,91 @@ exited (remote side finished), delete it so the refresh can proceed."
     (funcall orig-fun)))
 
 ;; ============================================================================
-;; Install and uninstall advice
+;; Install and uninstall handler
 ;; ============================================================================
 
-(defun tramp-rpc-advice-install ()
-  "Install all process advice for tramp-rpc."
-  (advice-add 'process-send-string :around #'tramp-rpc--process-send-string-advice)
-  (advice-add 'process-send-region :around #'tramp-rpc--process-send-region-advice)
-  (advice-add 'process-send-eof :around #'tramp-rpc--process-send-eof-advice)
+(defun tramp-rpc-handler-install ()
+  "Install all process handler for tramp-rpc."
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'process-send-string
+     #'tramp-rpc-handle-process-send-string 'tramp-rpc 'process)
+    (tramp-add-external-operation
+     'process-send-region
+     #'tramp-rpc-handle-process-send-region 'tramp-rpc 'process)
+    (tramp-add-external-operation
+     'process-send-eof
+     #'tramp-rpc-handle-process-send-eof 'tramp-rpc 'process))
   ;; This must be before `tramp-signal-process'.  Since tramp.el is
   ;; required, this is guaranteed.
   (add-hook 'signal-process-functions #'tramp-rpc-handle-signal-process)
-  (advice-add 'process-status :around #'tramp-rpc--process-status-advice)
-  (advice-add 'process-exit-status :around #'tramp-rpc--process-exit-status-advice)
-  (advice-add 'process-command :around #'tramp-rpc--process-command-advice)
-  (advice-add 'process-tty-name :around #'tramp-rpc--process-tty-name-advice)
-  (advice-add 'vc-call-backend :around #'tramp-rpc--vc-call-backend-advice)
-  (advice-add 'vc-exec-after :around #'tramp-rpc--vc-exec-after-advice)
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'process-status
+     #'tramp-rpc-handle-process-status 'tramp-rpc 'process)
+    (tramp-add-external-operation
+     'process-exit-status
+     #'tramp-rpc-handle-process-exit-status 'tramp-rpc 'process)
+    (tramp-add-external-operation
+     'process-command
+     #'tramp-rpc-handle-process-command 'tramp-rpc 'process)
+    (tramp-add-external-operation
+     'process-tty-name
+     #'tramp-rpc-handle-process-tty-name 'tramp-rpc 'process))
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'vc-call-backend
+     #'tramp-rpc-handle-vc-call-backend 'tramp-rpc
+     #'tramp-rpc--vc-call-backend-file-name-for-operation)
+    (tramp-add-external-operation
+     'vc-exec-after
+     #'tramp-rpc-handle-vc-exec-after 'tramp-rpc 'default-directory))
   (with-eval-after-load 'eglot
-    (advice-add 'eglot--cmd :around #'tramp-rpc--eglot-cmd-advice))
-  (with-eval-after-load 'vc-dir
-    (advice-add 'vc-dir-refresh :around #'tramp-rpc--vc-dir-refresh-advice))
+    (tramp-add-external-operation
+     'eglot--cmd
+     #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory))
   (with-eval-after-load 'magit-process
-    (advice-add 'magit-start-process :around
-                #'tramp-rpc--magit-start-process-advice))
+    (tramp-add-external-operation
+     'magit-start-process
+     #'tramp-rpc-handle-magit-start-process 'tramp-rpc 'default-directory))
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'vc-dir-refresh
+     #'tramp-rpc-handle-vc-dir-refresh 'tramp-rpc
+     #'tramp-rpc--vc-dir-refresh-file-name-for-operation))
   (advice-add 'hack-dir-local-variables :around
               #'tramp-rpc--hack-dir-local-variables-advice))
 
-(defun tramp-rpc-advice-remove ()
-  "Remove all process advice installed by tramp-rpc."
-  (advice-remove 'process-send-string #'tramp-rpc--process-send-string-advice)
-  (advice-remove 'process-send-region #'tramp-rpc--process-send-region-advice)
-  (advice-remove 'process-send-eof #'tramp-rpc--process-send-eof-advice)
+(defun tramp-rpc-handler-remove ()
+  "Remove all process handler installed by tramp-rpc."
+  (tramp-remove-external-operation 'process-send-string 'tramp-rpc)
+  (tramp-remove-external-operation 'process-send-region 'tramp-rpc)
+  (tramp-remove-external-operation 'process-send-eof 'tramp-rpc)
   (remove-hook 'signal-process-functions #'tramp-rpc-handle-signal-process)
-  (advice-remove 'process-status #'tramp-rpc--process-status-advice)
-  (advice-remove 'process-exit-status #'tramp-rpc--process-exit-status-advice)
-  (advice-remove 'process-command #'tramp-rpc--process-command-advice)
-  (advice-remove 'process-tty-name #'tramp-rpc--process-tty-name-advice)
-  (advice-remove 'vc-call-backend #'tramp-rpc--vc-call-backend-advice)
-  (advice-remove 'vc-exec-after #'tramp-rpc--vc-exec-after-advice)
-  (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
-  (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
-  (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)
+  (tramp-remove-external-operation 'process-status 'tramp-rpc)
+  (tramp-remove-external-operation 'process-exit-status 'tramp-rpc)
+  (tramp-remove-external-operation 'process-command 'tramp-rpc)
+  (tramp-remove-external-operation 'process-tty-name 'tramp-rpc)
+  (tramp-remove-external-operation 'vc-call-backend 'tramp-rpc)
+  (tramp-remove-external-operation 'vc-exec-after 'tramp-rpc)
+  (tramp-remove-external-operation 'eglot--cmd 'tramp-rpc)
+  (tramp-remove-external-operation 'magit-start-process 'tramp-rpc)
+  (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc)
   (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
 
-(defcustom tramp-rpc-install-advice-on-load t
-  "Whether to install process advice when tramp-rpc-advice is loaded.
-Set to nil before loading to prevent automatic advice installation."
+;; FIXME: Do we need this?
+(define-obsolete-variable-alias
+  'tramp-rpc-install-advice-on-load 'tramp-rpc-install-handler-on-load "0.8.0")
+
+(defcustom tramp-rpc-install-handler-on-load t
+  "Whether to install process handler when tramp-rpc-advice is loaded.
+Set to nil before loading to prevent automatic handler installation."
   :type 'boolean
   :group 'tramp-rpc)
 
-;; Install advice when loaded (if enabled)
-(when tramp-rpc-install-advice-on-load
-  (tramp-rpc-advice-install))
+;; Install handler when loaded (if enabled)
+(when tramp-rpc-install-handler-on-load
+  (tramp-rpc-handler-install))
 
 ;; ============================================================================
 ;; Unload support
@@ -482,9 +523,9 @@ Set to nil before loading to prevent automatic advice installation."
 
 (defun tramp-rpc-advice-unload-function ()
   "Unload function for tramp-rpc-advice.
-Removes advices."
-  ;; Remove all advices.
-  (tramp-rpc-advice-remove)
+Removes handler."
+  ;; Remove all handler.
+  (tramp-rpc-handler-remove)
   ;; Return nil to allow normal unload to proceed
   nil)
 

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -216,7 +216,7 @@ Writes to the local cat relay process, which triggers proper I/O events
 that satisfy accept-process-output.
 STDERR-BUFFER is the separate stderr buffer, or nil to mix with stdout."
   (when (and (processp local-process) (process-live-p local-process))
-    ;; Set flag to bypass our advice - we're writing TO the local process,
+    ;; Set flag to bypass our handler - we're writing TO the local process,
     ;; not sending data to the remote process
     (let ((tramp-rpc--delivering-output t))
       ;; Deliver stdout by writing to the cat relay process
@@ -352,7 +352,7 @@ before the cat relay drains its pipe causes a stale FD that makes
         (remhash pid tramp-rpc--process-write-queues))
       ;; Store exit code (the sentinel reads this to construct the event
       ;; string).  Do NOT set :tramp-rpc-exited yet — the process-status
-      ;; advice returns 'exit when that flag is set, which makes
+      ;; handler returns 'exit when that flag is set, which makes
       ;; `process-live-p' return nil and would prevent the EOF below
       ;; from being sent.
       (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
@@ -362,7 +362,7 @@ before the cat relay drains its pipe causes a stale FD that makes
           (ignore-errors (process-send-eof stderr-process))))
       ;; Send EOF to the LOCAL cat relay (not the remote process).
       ;; Bind `tramp-rpc--closing-local-relay' so the `process-send-eof'
-      ;; advice calls the original function instead of routing to the
+      ;; handler calls the original function instead of routing to the
       ;; remote stdin (which has already exited).  Cat will flush any
       ;; remaining data to stdout, then exit naturally on EOF.  Emacs
       ;; fires the sentinel chain; the cleanup installed by
@@ -370,7 +370,7 @@ before the cat relay drains its pipe causes a stale FD that makes
       (when (process-live-p local-process)
         (let ((tramp-rpc--closing-local-relay t))
           (ignore-errors (process-send-eof local-process))))
-      ;; Now mark as exited so process-status advice returns 'exit.
+      ;; Now mark as exited so process-status handler returns 'exit.
       (process-put local-process :tramp-rpc-exited t))))
 
 ;; ============================================================================
@@ -488,6 +488,7 @@ Resolves program path and loads direnv environment from working directory."
 
           (process-put local-process :tramp-rpc-vec v)
           (process-put local-process :tramp-rpc-pid remote-pid)
+          (process-put local-process 'tramp-vector v)
           (process-put local-process 'remote-command command)
 
           (when filter
@@ -661,6 +662,7 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
     (process-put process :tramp-rpc-command command)
     ;; Standard tramp property expected by tests and upstream code
     (process-put process 'remote-command command)
+    (process-put process 'tramp-vector vec)
 
     process))
 
@@ -724,6 +726,7 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
     (process-put local-process :tramp-rpc-tty-name tty-name)
     ;; Standard tramp property expected by tests and upstream code
     (process-put local-process 'remote-command command)
+    (process-put local-process 'tramp-vector vec)
 
     ;; Set up window size adjustment function
     (process-put local-process 'adjust-window-size-function
@@ -923,15 +926,16 @@ Returns the final (width . height) cons, or nil if resize was not handled."
                   (funcall display-updater width height))
                 (cons width height)))))))))
 
-(defun tramp-rpc--vterm-window-adjust-process-window-size-advice (orig-fun process windows)
-  "Advice for vterm's window adjust function to handle TRAMP-RPC PTY processes.
+(defun tramp-rpc-handle-vterm--window-adjust-process-window-size (process windows)
+  "Handler for vterm's window adjust function to handle TRAMP-RPC PTY processes.
 For tramp-rpc processes, resize the remote PTY and update vterm's display.
 For direct SSH PTY, let the original function handle it (SSH handles resize)."
   (cond
    ;; Direct SSH PTY - let original function handle it
    ((and (processp process)
          (process-get process :tramp-rpc-direct-ssh))
-    (funcall orig-fun process windows))
+    (tramp-run-real-handler
+     'vterm--window-adjust-process-window-size (list process windows)))
    ;; RPC-based PTY - resize via RPC
    ((and (processp process)
          (process-get process :tramp-rpc-pty))
@@ -949,17 +953,19 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
                     (fboundp 'vterm--set-size))
              (vterm--set-size vterm--term height width))))))
    ;; Not our process, call original
-   (t (funcall orig-fun process windows))))
+   (t (tramp-run-real-handler
+       'vterm--window-adjust-process-window-size (list process windows)))))
 
-(defun tramp-rpc--eat-adjust-process-window-size-advice (orig-fun process windows)
-  "Advice for eat's window adjust function to handle TRAMP-RPC PTY processes.
+(defun tramp-rpc-handle-eat--adjust-process-window-size (process windows)
+  "Handler for eat's window adjust function to handle TRAMP-RPC PTY processes.
 For tramp-rpc processes, resize the remote PTY and update eat's display.
 For direct SSH PTY, let the original function handle it (SSH handles resize)."
   (cond
    ;; Direct SSH PTY - let original function handle it
    ((and (processp process)
          (process-get process :tramp-rpc-direct-ssh))
-    (funcall orig-fun process windows))
+    (tramp-run-real-handler
+     'eat--adjust-process-window-size (list process windows)))
    ;; RPC-based PTY - resize via RPC
    ((and (processp process)
          (process-get process :tramp-rpc-pty))
@@ -979,7 +985,8 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
            ('eat-mode (run-hooks 'eat-update-hook))
            ('eshell-mode (run-hooks 'eat-eshell-update-hook))))))
    ;; Not our process, call original
-   (t (funcall orig-fun process windows))))
+   (t (tramp-run-real-handler
+       'eat--adjust-process-window-size (list process windows)))))
 
 ;; ============================================================================
 ;; Process cleanup
@@ -1029,21 +1036,25 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
 ;; Forward declare for cleanup
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 
-;; Install terminal emulator advice
+;; Install terminal emulator handler
 (with-eval-after-load 'vterm
-  (advice-add 'vterm--window-adjust-process-window-size :around
-              #'tramp-rpc--vterm-window-adjust-process-window-size-advice))
+  (tramp-add-external-operation
+   'vterm--window-adjust-process-window-size
+   #'tramp-rpc-handle-vterm--window-adjust-process-window-size
+   'tramp-rpc 'process))
 
 (with-eval-after-load 'eat
-  (advice-add 'eat--adjust-process-window-size :around
-              #'tramp-rpc--eat-adjust-process-window-size-advice))
+  (tramp-add-external-operation
+   'eat--adjust-process-window-size
+   #'tramp-rpc-handle-eat--adjust-process-window-size
+   'tramp-rpc 'process))
 
-(defun tramp-rpc--process-advice-remove ()
-  "Remove advices."
-  (advice-remove 'vterm--window-adjust-process-window-size
-              #'tramp-rpc--vterm-window-adjust-process-window-size-advice)
-  (advice-remove 'eat--adjust-process-window-size
-              #'tramp-rpc--eat-adjust-process-window-size-advice))
+(defun tramp-rpc--process-handler-remove ()
+  "Remove handlers."
+  (tramp-remove-external-operation
+   'vterm--window-adjust-process-window-size 'tramp-rpc)
+  (tramp-remove-external-operation
+   'eat--adjust-process-window-size 'tramp-rpc))
 
 ;; ============================================================================
 ;; Unload support
@@ -1051,9 +1062,9 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
 
 (defun tramp-rpc-process-unload-function ()
   "Unload function for tramp-rpc-process.
-Removes advices and cleans up async processes."
-  ;; Remove all advices
-  (tramp-rpc--process-advice-remove)
+Removes handlers and cleans up async processes."
+  ;; Remove all handlers
+  (tramp-rpc--process-handler-remove)
   ;; Clean up all async processes.
   (tramp-rpc--cleanup-async-processes)
   ;; Clean up PTY processes.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -5,7 +5,7 @@
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Version: 0.8.0
 ;; Keywords: comm, processes, files
-;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.3"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.4"))
 
 ;; This file is part of tramp-rpc.
 
@@ -149,10 +149,10 @@
 (require 'tramp-rpc-protocol)
 
 ;; Check for minimum Tramp version.  The Package-Requires header declares
-;; (tramp "2.8.1.3") but that is only enforced by package.el at install
+;; (tramp "2.8.1.4") but that is only enforced by package.el at install
 ;; time.  Guard at load time so that manual installations fail clearly.
-(when (version< tramp-version "2.8.1.3")
-  (error "tramp-rpc requires Tramp >= 2.8.1.3, but %s is loaded"
+(when (version< tramp-version "2.8.1.4")
+  (error "tramp-rpc requires Tramp >= 2.8.1.4, but %s is loaded"
          tramp-version))
 
 ;; Give the rpc method all ssh connection parameters so it can serve
@@ -167,7 +167,7 @@
   (setcdr rpc-entry ssh-params))
 
 ;; Silence byte-compiler warnings for functions defined in with-eval-after-load
-(declare-function tramp-rpc-advice-remove "tramp-rpc-advice")
+;; (declare-function tramp-rpc-handler-remove "tramp-rpc-advice")
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
 (declare-function tramp-rpc--multi-hop-advice "tramp-rpc")
@@ -911,6 +911,12 @@ Returns non-nil on success."
                     ;; Connect and immediately exit, leaving ControlMaster running
                     (list "-N" host)))
          process)
+    ;; If the socket file exists but `tramp-rpc--controlmaster-active-p' did
+    ;; not accept it, it is stale.  OpenSSH exits immediately when asked to
+    ;; create a ControlMaster on top of a stale ControlPath, which later shows
+    ;; up as a generic "Tramp failed to connect" during unrelated file ops.
+    (when (file-exists-p socket-path)
+      (ignore-errors (delete-file socket-path)))
     (with-current-buffer buffer
       (erase-buffer))
     ;; Start SSH with PTY for interactive password prompt
@@ -1055,6 +1061,7 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
 
     ;; Store vec on the process so notifications can identify the connection
     (process-put process :tramp-rpc-vec vec)
+    (process-put process 'tramp-vector vec)
 
     ;; Wait for server to be ready by sending a ping
     (let ((response (tramp-rpc--call vec "system.info" nil)))
@@ -1125,7 +1132,20 @@ accidentally routing file operations through tramp-sh."
   ;; - Key-based: connects silently
   ;; - Password: prompts user, then subsequent connections reuse it
   (when tramp-rpc-use-controlmaster
-    (tramp-rpc--establish-controlmaster vec))
+    (condition-case err
+        (tramp-rpc--establish-controlmaster vec)
+      (remote-file-error
+       ;; A stale ControlMaster socket can make OpenSSH exit immediately while
+       ;; TRAMP reports only a generic connection failure.  Remove the socket
+       ;; and retry once before surfacing the error.
+       (let ((socket-path (tramp-rpc--controlmaster-socket-path vec)))
+         (when (file-exists-p socket-path)
+           (ignore-errors (delete-file socket-path)))
+         (sleep-for 0.1)
+         (condition-case nil
+             (tramp-rpc--establish-controlmaster vec)
+           (remote-file-error
+            (signal (car err) (cdr err))))))))
   ;; For sudo-via-RPC, pre-authenticate sudo so the server can be
   ;; started with `sudo -n' (non-interactive) via pipes.
   (when-let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec)))
@@ -1938,11 +1958,12 @@ to the built-in implementation."
           (setq latest f-time))))))
 
 (defun tramp-rpc--dir-locals-cache-covers-p (locals-dir cache-dir)
-  "Return non-nil when CACHE-DIR is at or below LOCALS-DIR."
-  (let ((locals (directory-file-name locals-dir))
-        (cache (directory-file-name cache-dir)))
+  "Return non-nil when CACHE-DIR is at or below LOCALS-DIR.
+This is a lexical path check: the directories can be remote or not yet exist."
+  (let ((locals (file-name-as-directory (directory-file-name locals-dir)))
+        (cache (file-name-as-directory (directory-file-name cache-dir))))
     (or (equal locals cache)
-        (file-in-directory-p cache locals))))
+        (string-prefix-p locals cache))))
 
 (defun tramp-rpc-handle-dir-locals-find-file (file)
   "Like `dir-locals-find-file' for TRAMP-RPC files."
@@ -3246,9 +3267,10 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
-    (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
-    (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
-    (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
+    ;; Not needed.  They are added by `tramp-add-external-operation'.
+    ;; (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
+    ;; (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
+    ;; (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
     (vc-registered . tramp-rpc-handle-vc-registered)
 
     ;; =========================================================================
@@ -3460,7 +3482,8 @@ Removes advice and cleans up async processes."
   (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc)
   (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
   ;; Remove all advice (from tramp-rpc-advice module)
-  (tramp-rpc-advice-remove)
+  ;; Not needed. This is called in `tramp-rpc-advice-unload-function'.
+  ;; (tramp-rpc-handler-remove)
   ;; Remove legacy multi-hop advice and cleanup hooks.
   (advice-remove 'tramp-multi-hop-p #'tramp-rpc--multi-hop-advice)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1121,12 +1121,12 @@ as a hop in multi-hop chains."
                    (tramp-rpc--controlmaster-socket-path sudo-vec)))))
 
 ;;; ============================================================================
-;;; VC advice tests (No server or SSH required)
+;;; VC handler tests (No server or SSH required)
 ;;; ============================================================================
 
 (ert-deftest tramp-rpc-mock-test-vc-exec-after-logical-exit-runs-code ()
-  "Test `vc-exec-after' advice treats exited TRAMP-RPC relays as done."
-  :tags '(:vc-advice)
+  "Test `vc-exec-after' handler treats exited TRAMP-RPC relays as done."
+  :tags '(:vc-handler)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let* ((buffer (generate-new-buffer " *tramp-rpc-vc-exec-after-test*"))
          (proc (make-process :name "tramp-rpc-vc-exec-after-test"
@@ -1138,17 +1138,18 @@ as a hop in multi-hop chains."
         (with-current-buffer buffer
           (process-put proc :tramp-rpc-pid 123)
           (process-put proc :tramp-rpc-exited t)
-          (tramp-rpc--vc-exec-after-advice
-           (lambda (&rest _) (error "Unexpected process state"))
-           (lambda () (setq ran t)))
+          (cl-letf (((symbol-function 'tramp-run-real-handler)
+                     (lambda (&rest _) (error "Unexpected process state"))))
+            (tramp-rpc-handle-vc-exec-after
+             (lambda () (setq ran t))))
           (should ran))
       (when (process-live-p proc)
         (delete-process proc))
       (kill-buffer buffer))))
 
 (ert-deftest tramp-rpc-mock-test-vc-exec-after-raw-closed-state-runs-code ()
-  "Test `vc-exec-after' advice handles raw non-run relay states."
-  :tags '(:vc-advice)
+  "Test `vc-exec-after' handler handles raw non-run relay states."
+  :tags '(:vc-handler)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let* ((buffer (generate-new-buffer " *tramp-rpc-vc-exec-after-test*"))
          (proc (make-process :name "tramp-rpc-vc-exec-after-test"
@@ -1160,11 +1161,12 @@ as a hop in multi-hop chains."
         (with-current-buffer buffer
           (process-put proc :tramp-rpc-pid 123)
           ;; Simulate native-compiled VC observing a raw relay state such as
-          ;; `closed' rather than the logical state from TRAMP-RPC advice.
+          ;; `closed' rather than the logical state from TRAMP-RPC handler.
           (cl-letf (((symbol-function 'process-status)
-                     (lambda (_process) 'closed)))
-            (tramp-rpc--vc-exec-after-advice
-             (lambda (&rest _) (error "Unexpected process state"))
+                     (lambda (_process) 'closed))
+                    ((symbol-function 'tramp-run-real-handler)
+                     (lambda (&rest _) (error "Unexpected process state"))))
+            (tramp-rpc-handle-vc-exec-after
              (lambda () (setq ran t))))
           (should ran))
       (when (process-live-p proc)
@@ -1261,10 +1263,14 @@ as a hop in multi-hop chains."
   "Ensure cache coverage check uses containment, not string length."
   :tags '(:dir-locals)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((locals "/tmp/a/very-long-dirname/")
-        (cache "/tmp/a/b/c/d/"))
-    ;; String length can disagree with depth here; containment should win.
-    (should (tramp-rpc--dir-locals-cache-covers-p locals cache))))
+  (let ((locals "/tmp/a/b/")
+        (cache "/tmp/a/b/c/d/")
+        (sibling "/tmp/a/very-long-dirname/"))
+    ;; These directories need not exist; this is a lexical containment check.
+    (should (tramp-rpc--dir-locals-cache-covers-p locals locals))
+    (should (tramp-rpc--dir-locals-cache-covers-p locals cache))
+    ;; A sibling with a longer string must not be treated as contained.
+    (should-not (tramp-rpc--dir-locals-cache-covers-p locals sibling))))
 
 (ert-deftest tramp-rpc-mock-test-locate-dominating-file-unquotes-and-requotes-paths ()
   "Ensure locate-dominating handler unquotes RPC paths for transport.


### PR DESCRIPTION
Patch from Michael Albinus that converts all tramp-rpc advice functions into Tramp external operations, using the new `tramp-add-external-operation` API from Tramp 2.8.1.4.

**Changes:**
- Replace all `advice-add ... :around` with `tramp-add-external-operation` handlers
- Rename `tramp-rpc-advice-install/remove` → `tramp-rpc-handler-install/remove`
- Use `tramp-run-real-handler` instead of `funcall orig-fun`
- Set `'tramp-vector` process property on all RPC processes (needed for external operation dispatch)
- Add helper `file-name-for-operation` functions for `vc-call-backend` and `vc-dir-refresh`
- Define obsolete variable alias: `tramp-rpc-install-advice-on-load` → `tramp-rpc-install-handler-on-load`
- Bump Tramp requirement from 2.8.1.3 to 2.8.1.4
- `hack-dir-local-variables` and `multi-hop` remain as advice (pending investigation)

**Note:** This requires Tramp 2.8.1.4 (scheduled end of April 2026) for the external operation process support.