### PR TITLE
Update file-directory-p to be a single remote call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ NEVER use emacsclient. That will interfer with the users configuration
 
 Always use `emacs -Q --batch --eval <lisp commands>`
 
-When testing updates to the rust server, always copy it to a temporary location and set `tramp-rpc-deploy-remote-directory` to the temporary path so that testing does not interfere with existing sessions. Always test changes to the code.
+When testing updates to the rust server, always copy it to a temporary location and set `tramp-rpc-deploy-remote-directory` to the temporary path so that testing does not interfere with existing sessions. Use `scripts/build_all.sh` to rebuild the server binary. Then SCP it to a new location and set the variable.
+
+Always test changes to the code.
 
 ## Test Example
 

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -36,6 +36,7 @@
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process")
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process")
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
+(declare-function tramp-rpc--handle-process-exit "tramp-rpc-process")
 
 ;; Functions from tramp-cmds.el
 
@@ -220,6 +221,31 @@ It will be added to `signal-process-functions'."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
       (cond
        ((process-get process :tramp-rpc-exited) 'exit)
+       ;; Remote process can exit in the gap before our async read callback
+       ;; marks :tramp-rpc-exited. Probe explicit remote status to avoid
+       ;; stale `process-live-p' true results that trigger extra iterations.
+       ((when-let* ((vec (and (process-get process :tramp-rpc-probe-remote-status)
+                              (process-get process :tramp-rpc-vec)))
+                    (pid (process-get process :tramp-rpc-pid)))
+          (let* ((status (tramp-rpc--call vec "process.status" `((pid . ,pid))))
+                 (exited (alist-get 'exited status))
+                 (exit-code (alist-get 'exit_code status)))
+            (when status
+                (when exited
+                  (unless (null exit-code)
+                    (process-put process :tramp-rpc-exit-code exit-code))
+                  ;; Schedule exit handling soon, but keep reporting local
+                  ;; relay liveness until it drains pending output.
+                  (unless (process-get process :tramp-rpc-exit-scheduled)
+                    (process-put process :tramp-rpc-exit-scheduled t)
+                    (run-at-time
+                     0 nil
+                     (lambda ()
+                       (when (processp process)
+                         (process-put process :tramp-rpc-exit-scheduled nil)
+                         (unless (process-get process :tramp-rpc-exited)
+                           (tramp-rpc--handle-process-exit process exit-code)))))))
+                nil))))
        ;; Use orig-fun to check live status, not process-live-p (which would recurse)
        ((memq (funcall orig-fun process) '(run open listen connect)) 'run)
        (t 'exit))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -107,19 +107,19 @@ Returns plist with :stdout, :stderr, :exited, :exit-code."
 
 (defun tramp-rpc--write-remote-process (vec pid data)
   "Write DATA to stdin of remote process PID on VEC.
-Uses async RPC with queuing to ensure writes are serialized.
-This prevents race conditions where later messages arrive before earlier ones."
-  (let* ((queue-key pid)
-         (queue (gethash queue-key tramp-rpc--process-write-queues))
-         (pending (plist-get queue :pending))
-         (writing (plist-get queue :writing)))
-    ;; Add to pending queue
-    (setq pending (append pending (list (list :vec vec :pid pid :data data))))
-    (puthash queue-key (list :pending pending :writing writing)
-             tramp-rpc--process-write-queues)
-    ;; If not currently writing, start processing the queue
-    (unless writing
-      (tramp-rpc--process-write-queue queue-key))))
+Performs a synchronous RPC call so that callers like
+`start-file-process-shell-command' can rely on write visibility before
+the next `accept-process-output' poll."
+  ;; Native `process-send-string' writes into a local pipe synchronously.
+  ;; For parity, avoid fire-and-forget async writes here: tests and callers
+  ;; may perform immediate follow-up checks (file existence, process output)
+  ;; after sending input.
+  (let ((data-bytes (if (multibyte-string-p data)
+                        (encode-coding-string data 'utf-8-unix)
+                      data)))
+    (tramp-rpc--call vec "process.write"
+                     `((pid . ,pid)
+                       (data . ,(msgpack-bin-make data-bytes))))))
 
 (defun tramp-rpc--process-write-queue (queue-key)
   "Process the next pending write for QUEUE-KEY (remote PID)."
@@ -304,15 +304,27 @@ RESPONSE is the decoded RPC response plist."
                            (if stderr (length stderr) "nil")
                            exited)
 
-          ;; Deliver output - use run-at-time to ensure event loop processes it
-          ;; This is critical for accept-process-output to work correctly
-          (when (or stdout stderr)
-            (run-at-time 0 nil #'tramp-rpc--deliver-process-output
-                         local-process stdout stderr stderr-buffer))
+          ;; Deliver output.  When the remote process reports EXITED, flush
+          ;; data immediately before sending EOF to the local relay; otherwise
+          ;; the deferred delivery can race with relay shutdown and lose output.
+          (if exited
+              (when (or stdout stderr)
+                (tramp-rpc--deliver-process-output
+                 local-process stdout stderr stderr-buffer))
+            ;; Keep deferred delivery for the non-exit hot path so
+            ;; accept-process-output observes normal I/O activity.
+            (when (or stdout stderr)
+              (run-at-time 0 nil #'tramp-rpc--deliver-process-output
+                           local-process stdout stderr stderr-buffer)))
 
           ;; Handle process exit or chain next read
           (if exited
-              (run-at-time 0 nil #'tramp-rpc--handle-process-exit local-process exit-code)
+              ;; Handle exit immediately so `process-live-p' flips to nil
+              ;; before callers can issue another round of remote operations.
+              ;; Deferring this via `run-at-time 0' leaves a small window where
+              ;; loops that poll `process-live-p' can observe a stale live
+              ;; process and run one extra iteration.
+              (tramp-rpc--handle-process-exit local-process exit-code)
             ;; Chain another read - use run-at-time to avoid stack overflow
             (run-at-time 0 nil #'tramp-rpc--start-async-read local-process)))
       (error
@@ -520,10 +532,16 @@ Resolves program path and loads direnv environment from working directory."
   "Start async process on remote host.
 NAME is the process name, BUFFER is the output buffer,
 PROGRAM is the command to run, ARGS are its arguments."
-  (tramp-rpc-handle-make-process
-   :name name
-   :buffer buffer
-   :command (cons program args)))
+  (let ((proc
+         (tramp-rpc-handle-make-process
+          :name name
+          :buffer buffer
+          :command (cons program args))))
+    ;; Only start-file-process style workloads need aggressive remote
+    ;; liveness probing to avoid async race windows in process-status.
+    (when (processp proc)
+      (process-put proc :tramp-rpc-probe-remote-status t))
+    proc))
 
 ;; ============================================================================
 ;; PTY Process Support

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1732,6 +1732,18 @@ path unchanged (after resolving any symlinks in parent directories)."
         (when result
           (tramp-rpc--convert-file-attributes result id-format))))))
 
+(defun tramp-rpc-handle-file-directory-p (filename)
+  "Like `file-directory-p' for TRAMP-RPC files.
+Uses a single `file.stat' call instead of the generic TRAMP path
+which resolves truename and then stats."
+  (or
+   ;; Preserve TRAMP's completion-time fast path semantics.
+   (tramp-string-empty-or-nil-p (tramp-file-local-name filename))
+   (string-equal (tramp-file-local-name filename) "/")
+   (with-parsed-tramp-file-name (expand-file-name filename) nil
+     (let ((stat (tramp-rpc--call-file-stat v localname)))
+       (and stat (equal (alist-get 'type stat) "directory"))))))
+
 (defun tramp-rpc--convert-file-attributes (stat id-format)
   "Convert STAT result to Emacs file-attributes format.
 ID-FORMAT specifies whether to use numeric or string IDs."
@@ -2975,7 +2987,7 @@ Also controls process exit detection latency."
     (file-readable-p . tramp-handle-file-readable-p)
     (file-writable-p . tramp-handle-file-writable-p)
     (file-executable-p . tramp-rpc-handle-file-executable-p)
-    (file-directory-p . tramp-handle-file-directory-p)
+    (file-directory-p . tramp-rpc-handle-file-directory-p)
     (file-regular-p . tramp-handle-file-regular-p)
     (file-symlink-p . tramp-handle-file-symlink-p)
     (file-truename . tramp-rpc-handle-file-truename)

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -289,6 +289,7 @@ async fn dispatch_inner(request: Request) -> Response {
         "process.start" => process::start(params).await,
         "process.write" => process::write(params).await,
         "process.read" => process::read(params).await,
+        "process.status" => process::status(params).await,
         "process.close_stdin" => process::close_stdin(params).await,
         "process.kill" => process::kill(params).await,
         "process.list" => process::list(params).await,

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -381,6 +381,28 @@ pub async fn kill(params: Value) -> HandlerResult {
     Ok(Value::Boolean(true))
 }
 
+/// Return status of an async process without consuming stdout/stderr.
+pub async fn status(params: Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        pid: u32,
+    }
+
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+    let mut processes = get_process_map().lock().await;
+    let managed = processes
+        .get_mut(&params.pid)
+        .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
+
+    let exit_status = managed.child.try_wait().ok().flatten();
+
+    Ok(msgpack_map! {
+        "exited" => exit_status.is_some(),
+        "exit_code" => exit_status.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+    })
+}
+
 /// List all managed async processes
 pub async fn list(_params: Value) -> HandlerResult {
     let mut processes = get_process_map().lock().await;

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -394,7 +394,7 @@ The directory is deleted after BODY completes."
   ;; Test directory
   ;; Measure on a fresh path to avoid cache hits.
   (let ((missing (tramp-rpc-test--make-temp-name)))
-    (should-not (tramp-rpc-test--with-call-count 2
+    (should-not (tramp-rpc-test--with-call-count 1
                   (file-directory-p missing))))
 
   ;; Test file
@@ -731,7 +731,7 @@ signal `file-already-exists'.  With trailing slash (via
   (let ((file (tramp-rpc-test--make-temp-name)))
     (write-region "to be deleted" nil file)
     (should (file-exists-p file))
-    (tramp-rpc-test--with-call-count 3
+    (tramp-rpc-test--with-call-count 2
       (delete-file file))
     (should-not (file-exists-p file))))
 
@@ -828,7 +828,7 @@ This exercises copy-then-delete for cross-remote renames."
   (let ((dir (concat (tramp-rpc-test--make-temp-name) "/nested/path")))
     (unwind-protect
         (progn
-          (tramp-rpc-test--with-call-count 11
+          (tramp-rpc-test--with-call-count 9
             (make-directory dir t))
           (should (file-directory-p dir)))
       (ignore-errors (delete-directory
@@ -868,7 +868,7 @@ This exercises copy-then-delete for cross-remote renames."
     (write-region "b" nil (concat dir "/file2.txt"))
     (write-region "c" nil (concat dir "/other.log"))
 
-    (let ((files (tramp-rpc-test--with-call-count 3
+    (let ((files (tramp-rpc-test--with-call-count 2
                   (directory-files dir))))
       ;; Should contain . and .. plus our files
       (should (member "." files))
@@ -1172,7 +1172,7 @@ This matches the upstream `tramp-test28-process-file' test."
     (write-region "" nil (concat dir "/file-aab.txt"))
     (write-region "" nil (concat dir "/other.txt"))
 
-    (let ((completions (tramp-rpc-test--with-call-count 3
+    (let ((completions (tramp-rpc-test--with-call-count 2
                          (file-name-all-completions "file-" dir))))
       (should (member "file-aaa.txt" completions))
       (should (member "file-aab.txt" completions))
@@ -1187,7 +1187,7 @@ This matches the upstream `tramp-test28-process-file' test."
           (link-dir (concat dir "/link-dir")))
       (make-directory real-dir t)
       (make-symbolic-link "real-dir" link-dir)
-      (let ((completions (tramp-rpc-test--with-call-count 3
+      (let ((completions (tramp-rpc-test--with-call-count 2
                            (file-name-all-completions "" dir))))
         (should (member "real-dir/" completions))
         (should (member "link-dir/" completions))))))


### PR DESCRIPTION
file-directory-p is very common operation that takes 2 round trips (3 on MacOS). We can reduce this to a single call using `file.stat`.