### PR TITLE
Build Emacs package with Nix

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,6 +87,41 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
    (use-package! tramp-rpc)
    #+end_src
 
+** From Nix flake
+1. Include this repository as a flake input and add its overlay to nixpkgs:
+   #+begin_src nix
+   inputs = {
+     emacs-tramp-rpc.url = "github:ArthurHeymans/emacs-tramp-rpc";
+   };
+
+   outputs = inputs@{ self, ... }:
+     let
+       pkgs = import nixpkgs {
+         overlays = [ inputs.emacs-tramp-rpc.overlays.default ];
+       };
+     in ...;
+   #+end_src
+
+2. Include ~tramp-rpc~ as you would any Elisp package from the ~emacsPackages~ scope, e.g. in Home Manager's ~programs.emacs.extraPackages~:
+   #+begin_src nix
+   programs.emacs.extraPackages = epkgs: [ tramp-rpc ];
+   #+end_src
+
+4. Server binaries for =x86_64-linux= and =aarch64-linux= are automatically built and included in the Emacs package derivation; if you would like to change which systems are built, override the ~archs~ input:
+   #+begin_src nix
+   tramp-rpc.override {
+     archs = [
+       pkgs.pkgsCross.riscv64-musl
+       (import nixpkgs {
+         inherit system;
+         crossSystem = lib.systems.elaborate {
+           config = "armv6l-unknown-linux-musleabihf";
+         };
+       })
+     ];
+   }
+   #+end_src
+
 * Usage
 
 Access remote files using the ~rpc~ method:

--- a/README.org
+++ b/README.org
@@ -91,35 +91,41 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 1. Include this repository as a flake input and add its overlay to nixpkgs:
    #+begin_src nix
    inputs = {
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
      emacs-tramp-rpc.url = "github:ArthurHeymans/emacs-tramp-rpc";
    };
 
-   outputs = inputs@{ self, ... }:
+   outputs = inputs@{ nixpkgs, emacs-tramp-rpc, ... }:
      let
+       system = "x86_64-linux";
+       inherit (nixpkgs) lib;
        pkgs = import nixpkgs {
-         overlays = [ inputs.emacs-tramp-rpc.overlays.default ];
+         inherit system;
+         overlays = [ emacs-tramp-rpc.overlays.default ];
        };
      in ...;
    #+end_src
 
 2. Include ~tramp-rpc~ as you would any Elisp package from the ~emacsPackages~ scope, e.g. in Home Manager's ~programs.emacs.extraPackages~:
    #+begin_src nix
-   programs.emacs.extraPackages = epkgs: [ tramp-rpc ];
+   programs.emacs.extraPackages = epkgs: [ epkgs.tramp-rpc ];
    #+end_src
 
-4. Server binaries for =x86_64-linux= and =aarch64-linux= are automatically built and included in the Emacs package derivation; if you would like to change which systems are built, override the ~archs~ input:
+3. Server binaries for =x86_64-linux= and =aarch64-linux= are automatically built and included in the Emacs package derivation; if you would like to change which systems are built, override the ~archs~ input:
    #+begin_src nix
-   tramp-rpc.override {
-     archs = [
-       pkgs.pkgsCross.riscv64-musl
-       (import nixpkgs {
-         inherit system;
-         crossSystem = lib.systems.elaborate {
-           config = "armv6l-unknown-linux-musleabihf";
-         };
-       })
-     ];
-   }
+   programs.emacs.extraPackages = epkgs: [
+     (epkgs.tramp-rpc.override {
+       archs = [
+         pkgs.pkgsCross.riscv64-musl
+         (import nixpkgs {
+           inherit system;
+           crossSystem = lib.systems.elaborate {
+             config = "armv6l-unknown-linux-musleabihf";
+           };
+         })
+       ];
+     })
+   ];
    #+end_src
 
 * Usage

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,50 @@
       forAllSystems = lib.genAttrs lib.systems.flakeExposed;
     in
     {
+      overlays.default = _: super: {
+        emacs-tramp-rpc-server = super.callPackage ./default.nix { };
+
+        emacsPackagesFor =
+          emacs:
+          ((super.emacsPackagesFor emacs).overrideScope (
+            eself: _: {
+              tramp-rpc = eself.callPackage (
+                {
+                  archs ? with super.pkgsCross; [
+                    musl64
+                    aarch64-multiplatform-musl
+                  ],
+                  lib,
+                  melpaBuild,
+                  tramp,
+                  msgpack,
+                }:
+                let
+                  version = builtins.readFile (
+                    super.runCommand "get-package-version" { } ''
+                      ${lib.getExe' emacs "emacs"} --batch -Q --eval "(progn (require 'lisp-mnt) (with-temp-buffer (insert-file-contents \"${self}/lisp/tramp-rpc.el\") (princ (lm-header \"version\"))))" > $out
+                    ''
+                  );
+                in
+                melpaBuild rec {
+                  pname = "tramp-rpc";
+                  inherit version;
+                  src = self;
+                  files = ''("lisp/*")'';
+
+                  postInstall = lib.concatMapStringsSep "\n" (arch: ''
+                    install -m755 -D ${arch.emacs-tramp-rpc-server}/bin/tramp-rpc-server $out/share/emacs/site-lisp/elpa/${pname}-${version}/binaries/${arch.stdenv.hostPlatform.system}/tramp-rpc-server
+                  '') archs;
+
+                  packageRequires = [
+                    tramp
+                    msgpack
+                  ];
+                }
+              ) { };
+            }
+          ));
+      };
       packages = forAllSystems (
         system:
         let

--- a/flake.nix
+++ b/flake.nix
@@ -39,11 +39,13 @@
                   msgpack,
                 }:
                 let
-                  version = builtins.readFile (
-                    super.runCommand "get-package-version" { } ''
-                      ${lib.getExe' emacs "emacs"} --batch -Q --eval "(progn (require 'lisp-mnt) (with-temp-buffer (insert-file-contents \"${self}/lisp/tramp-rpc.el\") (princ (lm-header \"version\"))))" > $out
-                    ''
+                  versionPrefix = ";; Version: ";
+                  version = lib.removePrefix versionPrefix (
+                    lib.findFirst (lib.hasPrefix versionPrefix)
+                      (throw "Could not find Version header in lisp/tramp-rpc.el")
+                      (lib.splitString "\n" (builtins.readFile "${self}/lisp/tramp-rpc.el"))
                   );
+                  serverFor = arch: arch.callPackage ./default.nix { };
                 in
                 melpaBuild rec {
                   pname = "tramp-rpc";
@@ -52,7 +54,7 @@
                   files = ''("lisp/*")'';
 
                   postInstall = lib.concatMapStringsSep "\n" (arch: ''
-                    install -m755 -D ${arch.emacs-tramp-rpc-server}/bin/tramp-rpc-server $out/share/emacs/site-lisp/elpa/${pname}-${version}/binaries/${arch.stdenv.hostPlatform.system}/tramp-rpc-server
+                    install -m755 -D ${serverFor arch}/bin/tramp-rpc-server $out/share/emacs/site-lisp/elpa/${pname}-${version}/binaries/${arch.stdenv.hostPlatform.system}/tramp-rpc-server
                   '') archs;
 
                   packageRequires = [


### PR DESCRIPTION
Just discovered this today, really cool project!

When trying to add this to my Emacs config (which is managed by Nix) I noticed that although the remote server binaries themselves are packaged with Nix, the Emacs package isn't.
I wrote a small derivation for my config and I thought there might be value in upstreaming it.

The idea is that `emacs-tramp-rpc.packages.${system}.tramp-rpc` can be added directly to `programs.emacs.extraPackages` and it comes with some server binaries pre-installed that `tramp-rpc-deploy--bundled-binary-path` will pick up automatically (the architectures to be installed can be changed by the user with `override`).

The patch is probably a little too messy to land in master in its current form (especially the extra `callPackage`), but I'd first like some feedback on e.g. what systems to build by default, what the Emacs package output should be called, whether it should be exposed as an overlay, whether you think this is a worthwhile addition to the repository, etc.