### PR TITLE
perf: reduce latency-critical RPC round trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "tramp-rpc-server"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "flate2",
  "futures",

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2980,17 +2980,15 @@ Reads directly through `file.read' instead of going through
 round-trips for the common non-VISIT case."
   (barf-if-buffer-read-only)
   (setq filename (expand-file-name filename))
-  (if visit
-      ;; Visiting a file has extra buffer-state and not-found semantics.  Keep
-      ;; the battle-tested generic TRAMP path there; the latency-sensitive
-      ;; optimization is for ordinary reads (the common programmatic case).
+  (if (or visit replace)
+      ;; Visiting a file and REPLACE have extra buffer-state and return-value
+      ;; semantics.  Keep the battle-tested generic TRAMP path there; the
+      ;; latency-sensitive optimization is for ordinary reads (the common
+      ;; programmatic case).
       (tramp-handle-insert-file-contents filename visit beg end replace)
     (let ((start (point))
           result)
       (with-parsed-tramp-file-name filename nil
-        (when replace
-          (delete-region (point-min) (point-max))
-          (setq start (point)))
         (let* ((params (tramp-rpc--file-read-params localname)))
           (when beg
             (push `(offset . ,beg) params))
@@ -3004,7 +3002,8 @@ round-trips for the common non-VISIT case."
                        content (or coding-system-for-read 'undecided))
                     content)))
             (insert decoded-content)
-            (setq result (cons filename (- (point) start))))))
+            (setq result (list filename (- (point) start)))
+            (goto-char start))))
       result)))
 
 (defun tramp-rpc-handle-file-local-copy (filename)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1625,6 +1625,26 @@ Returns an alist with path."
 ;; File name handler operations
 ;; ============================================================================
 
+(defun tramp-rpc-handle-file-readable-p (filename)
+  "Like `file-readable-p' for TRAMP-RPC files.
+Uses the remote server's access check, avoiding the generic TRAMP
+permission logic and its extra metadata round-trips."
+  (with-parsed-tramp-file-name (expand-file-name filename) nil
+    (with-tramp-file-property v localname "file-readable-p"
+      (tramp-rpc--call v "file.access"
+                       (append (tramp-rpc--encode-path localname)
+                               '((mode . "readable")))))))
+
+(defun tramp-rpc-handle-file-writable-p (filename)
+  "Like `file-writable-p' for TRAMP-RPC files.
+For a missing file, writability is checked on the containing directory on the
+remote host, matching `file-writable-p' creation semantics in one RPC."
+  (with-parsed-tramp-file-name (expand-file-name filename) nil
+    (with-tramp-file-property v localname "file-writable-p"
+      (tramp-rpc--call v "file.access"
+                       (append (tramp-rpc--encode-path localname)
+                               '((mode . "writable")))))))
+
 (defun tramp-rpc-handle-file-executable-p (filename)
   "Like `file-executable-p' for TRAMP-RPC files.
 Checks execute permission from `file-attributes' mode string and
@@ -1990,13 +2010,34 @@ to the built-in implementation."
 ;; ============================================================================
 
 (defun tramp-rpc-handle-directory-files (directory &optional full match nosort count)
-  "Like `directory-files' for TRAMP-RPC files."
-  (tramp-skeleton-directory-files directory full match nosort count
-    (let* ((result (tramp-rpc--call v "dir.list"
-                                    (append (tramp-rpc--encode-path localname)
-                                            '((include_attrs . :msgpack-false)
-                                              (include_hidden . t))))))
-      (mapcar #'tramp-rpc--decode-filename result))))
+  "Like `directory-files' for TRAMP-RPC files.
+
+Use the server's `dir.list' result directly instead of the generic
+TRAMP skeleton.  The skeleton first checks `file-exists-p' and
+`file-directory-p', which costs extra network round-trips on high-latency
+links.  `dir.list' already reports missing or non-directory paths as errors,
+so a single RPC can both validate and list the directory."
+  (let* ((directory (file-name-as-directory (expand-file-name directory)))
+         result)
+    (with-parsed-tramp-file-name directory nil
+      (setq result
+            (with-tramp-file-property v localname "directory-files"
+              (mapcar #'tramp-rpc--decode-filename
+                      (tramp-rpc--call v "dir.list"
+                                       (append (tramp-rpc--encode-path localname)
+                                               '((include_attrs . :msgpack-false)
+                                                 (include_hidden . t))))))))
+    (when match
+      (setq result (cl-remove-if-not
+                    (lambda (name) (string-match-p match name))
+                    result)))
+    (unless nosort
+      (setq result (sort (copy-sequence result) #'string<)))
+    (when (and (natnump count) (> count 0))
+      (setq result (seq-take result count)))
+    (if full
+        (mapcar (lambda (name) (concat directory name)) result)
+      result)))
 
 (defun tramp-rpc-handle-directory-files-and-attributes
     (directory &optional full match nosort id-format count)
@@ -2057,17 +2098,29 @@ to the built-in implementation."
                   entries))))))
 
 (defun tramp-rpc-handle-make-directory (dir &optional parents)
-  "Like `make-directory' for TRAMP-RPC files."
-  (tramp-skeleton-make-directory dir parents
-    (tramp-rpc--call v "dir.create"
-                     (append (tramp-rpc--encode-path localname)
-                             ;; Don't pass parents here - the skeleton
-                             ;; handles the recursive parent creation.
-                             `((parents . :msgpack-false)
-                               (mode . ,(default-file-modes)))))
-    ;; Flush parent directory properties so file-exists-p sees the new dir.
-    (tramp-flush-directory-properties v (file-name-directory localname))
-    (tramp-rpc--invalidate-cache-for-path dir)))
+  "Like `make-directory' for TRAMP-RPC files.
+
+Delegate parent creation to the server instead of using
+`tramp-skeleton-make-directory'.  The generic skeleton probes each path
+component with separate `file-exists-p' / `file-directory-p' calls before the
+actual mkdir.  Server-side `create_dir_all' performs the same validation in one
+network round-trip."
+  (let* ((dir (directory-file-name (expand-file-name dir)))
+         (parent (file-name-directory dir)))
+    (with-parsed-tramp-file-name dir nil
+      (let ((created
+             (tramp-rpc--call v "dir.create"
+                              (append (tramp-rpc--encode-path localname)
+                                      `((parents . ,(if parents t :msgpack-false))
+                                        (mode . ,(default-file-modes)))))))
+        ;; Flush parent directory properties so file-exists-p sees the new dir.
+        (tramp-flush-directory-properties v (file-name-directory localname))
+        (when parent
+          (tramp-rpc--invalidate-cache-for-path parent))
+        (tramp-rpc--invalidate-cache-for-path dir)
+        ;; Match `make-directory' return convention: nil when a directory was
+        ;; created, t when PARENTS was non-nil and the directory already existed.
+        (and parents (not created))))))
 
 (defun tramp-rpc-handle-delete-directory (directory &optional recursive trash)
   "Like `delete-directory' for TRAMP-RPC files."
@@ -2134,12 +2187,75 @@ to the built-in implementation."
       ;; from our `coding' variable instead.
       (setq coding-system-used coding))))
 
-(defun tramp-rpc-handle-copy-file
+(defun tramp-rpc--stat-type (stat)
+  "Return file type string from STAT, or nil."
+  (and stat (alist-get 'type stat)))
+
+(cl-defun tramp-rpc--copy-file-same-remote
+    (filename newname ok-if-already-exists keep-time preserve-permissions)
+  "Copy FILENAME to NEWNAME on one TRAMP-RPC remote with fewer round-trips."
+  (with-parsed-tramp-file-name filename v1
+    (with-parsed-tramp-file-name newname v2
+      (let* ((stats (tramp-rpc--call-batch
+                     v1
+                     `(("file.stat" . ,(append (tramp-rpc--encode-path v1-localname)
+                                                '((lstat . t))))
+                       ("file.stat" . ,(append (tramp-rpc--encode-path v2-localname)
+                                                '((lstat . t)))))))
+             (source-stat (nth 0 stats))
+             (dest-stat (nth 1 stats))
+             (source-type (tramp-rpc--stat-type source-stat))
+             (dest-type (tramp-rpc--stat-type dest-stat)))
+        (unless source-stat
+          (signal 'file-missing (list "Opening input file" "No such file" filename)))
+        (when (and (directory-name-p newname)
+                   (equal dest-type "directory"))
+          (cl-return-from tramp-rpc--copy-file-same-remote
+            (tramp-rpc--copy-file-same-remote
+             filename
+             (expand-file-name (file-name-nondirectory filename) newname)
+             ok-if-already-exists keep-time preserve-permissions)))
+        (unless ok-if-already-exists
+          (when dest-stat
+            (signal 'file-already-exists (list newname))))
+        (when (and (equal dest-type "directory")
+                   (not (directory-name-p newname)))
+          (signal 'file-error (list "File is a directory" newname)))
+        (cond
+         ((equal source-type "directory")
+          (copy-directory filename newname keep-time t))
+         ((equal source-type "symlink")
+          (make-symbolic-link
+           (tramp-rpc--decode-string (alist-get 'link_target source-stat))
+           newname ok-if-already-exists))
+         (t
+          (tramp-rpc--call v1 "file.copy"
+                           `((src . ,(tramp-rpc--path-to-bytes
+                                      (file-name-unquote v1-localname)))
+                             (dest . ,(tramp-rpc--path-to-bytes
+                                       (file-name-unquote v2-localname)))
+                             (preserve . ,(if (or keep-time preserve-permissions)
+                                              t :msgpack-false))))))
+        (tramp-flush-file-properties v1 v1-localname)
+        (tramp-flush-file-properties v2 v2-localname)
+        (tramp-flush-directory-properties v2 v2-localname)
+        (tramp-rpc--invalidate-cache-for-path newname)))))
+
+(cl-defun tramp-rpc-handle-copy-file
     (filename newname &optional ok-if-already-exists keep-time
               preserve-uid-gid preserve-permissions)
   "Like `copy-file' for TRAMP-RPC files."
   (setq filename (expand-file-name filename)
         newname (expand-file-name newname))
+  ;; Fast path for same-remote copies: batch source/destination stats, then do
+  ;; the server-side copy.  This avoids the generic preflight predicates each
+  ;; costing their own network round-trip.
+  (when (and (tramp-tramp-file-p filename)
+             (tramp-tramp-file-p newname)
+             (tramp-equal-remote filename newname))
+    (cl-return-from tramp-rpc-handle-copy-file
+      (tramp-rpc--copy-file-same-remote
+       filename newname ok-if-already-exists keep-time preserve-permissions)))
   ;; When NEWNAME is a directory name (trailing /), copy INTO it.
   (when (and (directory-name-p newname)
              (file-directory-p newname))
@@ -2241,10 +2357,59 @@ to the built-in implementation."
         (tramp-flush-directory-properties v2 v2-localname))
       (tramp-rpc--invalidate-cache-for-path newname))))
 
-(defun tramp-rpc-handle-rename-file (filename newname &optional ok-if-already-exists)
+(cl-defun tramp-rpc--rename-file-same-remote
+    (filename newname ok-if-already-exists)
+  "Rename FILENAME to NEWNAME on one TRAMP-RPC remote with fewer round-trips."
+  (with-parsed-tramp-file-name filename v1
+    (with-parsed-tramp-file-name newname v2
+      (let* ((stats (tramp-rpc--call-batch
+                     v1
+                     `(("file.stat" . ,(append (tramp-rpc--encode-path v1-localname)
+                                                '((lstat . t))))
+                       ("file.stat" . ,(append (tramp-rpc--encode-path v2-localname)
+                                                '((lstat . t)))))))
+             (source-stat (nth 0 stats))
+             (dest-stat (nth 1 stats))
+             (source-type (tramp-rpc--stat-type source-stat))
+             (dest-type (tramp-rpc--stat-type dest-stat)))
+        (when dest-stat
+          (unless ok-if-already-exists
+            (signal 'file-already-exists (list newname)))
+          (when (and (equal dest-type "directory")
+                     (not (directory-name-p newname))
+                     (not (equal source-type "directory")))
+            (signal 'file-error (list "File is a directory" newname))))
+        (when (and (equal dest-type "directory")
+                   (directory-name-p newname))
+          (cl-return-from tramp-rpc--rename-file-same-remote
+            (tramp-rpc--rename-file-same-remote
+             filename
+             (expand-file-name (file-name-nondirectory filename) newname)
+             ok-if-already-exists)))
+        (tramp-rpc--call v1 "file.rename"
+                         `((src . ,(tramp-rpc--path-to-bytes
+                                    (file-name-unquote v1-localname)))
+                           (dest . ,(tramp-rpc--path-to-bytes
+                                     (file-name-unquote v2-localname)))
+                           (overwrite . ,(if ok-if-already-exists
+                                             t :msgpack-false))))
+        (tramp-flush-file-properties v1 v1-localname)
+        (tramp-rpc--invalidate-cache-for-path filename)
+        (tramp-flush-file-properties v2 v2-localname)
+        (tramp-flush-directory-properties v2 v2-localname)
+        (tramp-rpc--invalidate-cache-for-path newname)))))
+
+(cl-defun tramp-rpc-handle-rename-file (filename newname &optional ok-if-already-exists)
   "Like `rename-file' for TRAMP-RPC files."
   (setq filename (expand-file-name filename)
         newname (expand-file-name newname))
+  ;; Fast path for same-remote renames: one batched preflight plus the rename.
+  (when (and (tramp-tramp-file-p filename)
+             (tramp-tramp-file-p newname)
+             (tramp-equal-remote filename newname))
+    (cl-return-from tramp-rpc-handle-rename-file
+      (tramp-rpc--rename-file-same-remote
+       filename newname ok-if-already-exists)))
   ;; Check ok-if-already-exists BEFORE any directory rewriting.
   (when (file-exists-p newname)
     (unless ok-if-already-exists
@@ -2290,10 +2455,19 @@ to the built-in implementation."
       (tramp-rpc--invalidate-cache-for-path newname))))
 
 (defun tramp-rpc-handle-delete-file (filename &optional trash)
-  "Like `delete-file' for TRAMP-RPC files."
-  (tramp-skeleton-delete-file filename trash
-    (tramp-rpc--call v "file.delete" (tramp-rpc--encode-path localname)))
-  (tramp-rpc--invalidate-cache-for-path filename))
+  "Like `delete-file' for TRAMP-RPC files.
+Calls `file.delete' directly; the server's unlink error is sufficient for the
+missing-file check, so no separate preflight stat is needed."
+  (with-parsed-tramp-file-name (expand-file-name filename) nil
+    (let ((delete-by-moving-to-trash
+           (and delete-by-moving-to-trash
+                (not (bound-and-true-p
+                      remote-file-name-inhibit-delete-by-moving-to-trash)))))
+      (if (and delete-by-moving-to-trash trash)
+          (move-file-to-trash filename)
+        (tramp-rpc--call v "file.delete" (tramp-rpc--encode-path localname)))
+      (tramp-flush-file-properties v localname)
+      (tramp-rpc--invalidate-cache-for-path filename))))
 
 (defun tramp-rpc-handle-make-symbolic-link (target linkname &optional ok-if-already-exists)
   "Like `make-symbolic-link' for TRAMP-RPC files."
@@ -2818,6 +2992,41 @@ correctly with bash, zsh, fish, and other shells)."
           nil))
     (error nil)))
 
+(defun tramp-rpc-handle-insert-file-contents
+    (filename &optional visit beg end replace)
+  "Like `insert-file-contents' for TRAMP-RPC files.
+Reads directly through `file.read' instead of going through
+`file-local-copy', avoiding the generic TRAMP temp-file path and its extra
+round-trips for the common non-VISIT case."
+  (barf-if-buffer-read-only)
+  (setq filename (expand-file-name filename))
+  (if visit
+      ;; Visiting a file has extra buffer-state and not-found semantics.  Keep
+      ;; the battle-tested generic TRAMP path there; the latency-sensitive
+      ;; optimization is for ordinary reads (the common programmatic case).
+      (tramp-handle-insert-file-contents filename visit beg end replace)
+    (let ((start (point))
+          result)
+      (with-parsed-tramp-file-name filename nil
+        (when replace
+          (delete-region (point-min) (point-max))
+          (setq start (point)))
+        (let* ((params (tramp-rpc--file-read-params localname)))
+          (when beg
+            (push `(offset . ,beg) params))
+          (when end
+            (push `(length . ,(- end (or beg 0))) params))
+          (let* ((rpc-result (tramp-rpc--call v "file.read" params))
+                 (content (tramp-rpc--extract-file-read-content rpc-result))
+                 (decoded-content
+                  (if enable-multibyte-characters
+                      (decode-coding-string
+                       content (or coding-system-for-read 'undecided))
+                    content)))
+            (insert decoded-content)
+            (setq result (cons filename (- (point) start))))))
+      result)))
+
 (defun tramp-rpc-handle-file-local-copy (filename)
   "Create a local copy of remote FILENAME using RPC."
   (tramp-skeleton-file-local-copy filename
@@ -2984,8 +3193,8 @@ Also controls process exit detection latency."
     ;; RPC-based file attribute operations
     ;; =========================================================================
     (file-exists-p . tramp-handle-file-exists-p)
-    (file-readable-p . tramp-handle-file-readable-p)
-    (file-writable-p . tramp-handle-file-writable-p)
+    (file-readable-p . tramp-rpc-handle-file-readable-p)
+    (file-writable-p . tramp-rpc-handle-file-writable-p)
     (file-executable-p . tramp-rpc-handle-file-executable-p)
     (file-directory-p . tramp-rpc-handle-file-directory-p)
     (file-regular-p . tramp-handle-file-regular-p)
@@ -3018,7 +3227,7 @@ Also controls process exit detection latency."
     ;; =========================================================================
     ;; RPC-based file I/O operations
     ;; =========================================================================
-    (insert-file-contents . tramp-handle-insert-file-contents)
+    (insert-file-contents . tramp-rpc-handle-insert-file-contents)
     (write-region . tramp-rpc-handle-write-region)
     (copy-file . tramp-rpc-handle-copy-file)
     (rename-file . tramp-rpc-handle-rename-file)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1625,26 +1625,6 @@ Returns an alist with path."
 ;; File name handler operations
 ;; ============================================================================
 
-(defun tramp-rpc-handle-file-readable-p (filename)
-  "Like `file-readable-p' for TRAMP-RPC files.
-Uses the remote server's access check, avoiding the generic TRAMP
-permission logic and its extra metadata round-trips."
-  (with-parsed-tramp-file-name (expand-file-name filename) nil
-    (with-tramp-file-property v localname "file-readable-p"
-      (tramp-rpc--call v "file.access"
-                       (append (tramp-rpc--encode-path localname)
-                               '((mode . "readable")))))))
-
-(defun tramp-rpc-handle-file-writable-p (filename)
-  "Like `file-writable-p' for TRAMP-RPC files.
-For a missing file, writability is checked on the containing directory on the
-remote host, matching `file-writable-p' creation semantics in one RPC."
-  (with-parsed-tramp-file-name (expand-file-name filename) nil
-    (with-tramp-file-property v localname "file-writable-p"
-      (tramp-rpc--call v "file.access"
-                       (append (tramp-rpc--encode-path localname)
-                               '((mode . "writable")))))))
-
 (defun tramp-rpc-handle-file-executable-p (filename)
   "Like `file-executable-p' for TRAMP-RPC files.
 Checks execute permission from `file-attributes' mode string and
@@ -3193,8 +3173,8 @@ Also controls process exit detection latency."
     ;; RPC-based file attribute operations
     ;; =========================================================================
     (file-exists-p . tramp-handle-file-exists-p)
-    (file-readable-p . tramp-rpc-handle-file-readable-p)
-    (file-writable-p . tramp-rpc-handle-file-writable-p)
+    (file-readable-p . tramp-handle-file-readable-p)
+    (file-writable-p . tramp-handle-file-writable-p)
     (file-executable-p . tramp-rpc-handle-file-executable-p)
     (file-directory-p . tramp-rpc-handle-file-directory-p)
     (file-regular-p . tramp-handle-file-regular-p)

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -9,7 +9,7 @@ use crate::protocol::{from_value, DirEntry, FileAttributes, FileType, RpcError};
 use rmpv::Value;
 use serde::Deserialize;
 use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 use super::file::{bytes_to_path, map_io_error};
@@ -292,6 +292,23 @@ fn file_type_from_metadata_ft(ft: &std::fs::FileType) -> FileType {
     }
 }
 
+/// Return the directory components that do not exist yet, from top to bottom.
+fn missing_directory_chain(path: &Path) -> Vec<PathBuf> {
+    let mut missing = Vec::new();
+    let mut current = Some(path);
+
+    while let Some(component) = current {
+        if component.exists() {
+            break;
+        }
+        missing.push(component.to_path_buf());
+        current = component.parent();
+    }
+
+    missing.reverse();
+    missing
+}
+
 /// Create a directory
 pub async fn create(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
@@ -315,6 +332,12 @@ pub async fn create(params: Value) -> HandlerResult {
     let path = bytes_to_path(&params.path);
     let path_str = path.to_string_lossy().into_owned();
 
+    let created_paths = if params.parents {
+        missing_directory_chain(&path)
+    } else {
+        vec![path.clone()]
+    };
+
     let result = if params.parents {
         fs::create_dir_all(&path).await
     } else {
@@ -323,17 +346,24 @@ pub async fn create(params: Value) -> HandlerResult {
 
     result.map_err(|e| map_io_error(e, &path_str))?;
 
-    // Set permissions
+    // Set permissions only on directories created by this request.  This keeps
+    // the previous RPC behavior for new parent components while avoiding chmod
+    // side effects when `make-directory DIR t' is called for an existing dir.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(params.mode);
-        fs::set_permissions(&path, perms)
-            .await
-            .map_err(|e| map_io_error(e, &path_str))?;
+        for created_path in &created_paths {
+            fs::set_permissions(created_path, perms.clone())
+                .await
+                .map_err(|e| map_io_error(e, &created_path.to_string_lossy()))?;
+        }
     }
 
-    Ok(Value::Boolean(true))
+    // Return whether this call created PATH.  Existing clients ignored the old
+    // unconditional `true'; the Lisp handler now uses false to preserve the
+    // `make-directory DIR t' return value when DIR already exists.
+    Ok(Value::Boolean(!created_paths.is_empty()))
 }
 
 /// Remove a directory

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -26,11 +26,33 @@ pub async fn stat(params: Value) -> HandlerResult {
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let path = bytes_to_path(&params.path);
-    match get_file_attributes(&path, params.lstat).await {
+    match get_file_attributes(path.as_path(), params.lstat).await {
         Ok(attrs) => Ok(attrs.to_value()),
         Err(e) if e.code == RpcError::FILE_NOT_FOUND => Ok(Value::Nil),
         Err(e) => Err(e),
     }
+}
+
+/// Check path accessibility.
+pub async fn access(params: Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        #[serde(with = "path_or_bytes")]
+        path: Vec<u8>,
+        /// One of: "exists", "readable", "writable", "executable".
+        mode: String,
+    }
+
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+
+    let path = bytes_to_path(&params.path);
+    let mode = params.mode;
+
+    let accessible = tokio::task::spawn_blocking(move || access_sync(path.as_path(), &mode))
+        .await
+        .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))??;
+
+    Ok(Value::Boolean(accessible))
 }
 
 /// Get the true name of a file (resolve symlinks)
@@ -280,6 +302,40 @@ use std::path::PathBuf;
 pub fn bytes_to_path(bytes: &[u8]) -> PathBuf {
     let path = PathBuf::from(OsStr::from_bytes(bytes));
     expand_tilde_path(&path)
+}
+
+fn access_sync(path: &Path, mode: &str) -> Result<bool, RpcError> {
+    let flags = match mode {
+        "exists" => libc::F_OK,
+        "readable" => libc::R_OK,
+        "writable" => {
+            if path.exists() {
+                libc::W_OK
+            } else {
+                // Creating a missing file requires write and search access on
+                // the containing directory.
+                return Ok(path
+                    .parent()
+                    .is_some_and(|parent| access_path(parent, libc::W_OK | libc::X_OK)));
+            }
+        }
+        "executable" => libc::X_OK,
+        _ => {
+            return Err(RpcError::invalid_params(format!(
+                "Invalid access mode: {mode}"
+            )))
+        }
+    };
+
+    Ok(access_path(path, flags))
+}
+
+fn access_path(path: &Path, flags: libc::c_int) -> bool {
+    let Ok(path_cstr) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+
+    unsafe { libc::access(path_cstr.as_ptr(), flags) == 0 }
 }
 
 /// Expand ~ to home directory in a PathBuf.

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -33,28 +33,6 @@ pub async fn stat(params: Value) -> HandlerResult {
     }
 }
 
-/// Check path accessibility.
-pub async fn access(params: Value) -> HandlerResult {
-    #[derive(Deserialize)]
-    struct Params {
-        #[serde(with = "path_or_bytes")]
-        path: Vec<u8>,
-        /// One of: "exists", "readable", "writable", "executable".
-        mode: String,
-    }
-
-    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
-
-    let path = bytes_to_path(&params.path);
-    let mode = params.mode;
-
-    let accessible = tokio::task::spawn_blocking(move || access_sync(path.as_path(), &mode))
-        .await
-        .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))??;
-
-    Ok(Value::Boolean(accessible))
-}
-
 /// Get the true name of a file (resolve symlinks)
 pub async fn truename(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
@@ -302,40 +280,6 @@ use std::path::PathBuf;
 pub fn bytes_to_path(bytes: &[u8]) -> PathBuf {
     let path = PathBuf::from(OsStr::from_bytes(bytes));
     expand_tilde_path(&path)
-}
-
-fn access_sync(path: &Path, mode: &str) -> Result<bool, RpcError> {
-    let flags = match mode {
-        "exists" => libc::F_OK,
-        "readable" => libc::R_OK,
-        "writable" => {
-            if path.exists() {
-                libc::W_OK
-            } else {
-                // Creating a missing file requires write and search access on
-                // the containing directory.
-                return Ok(path
-                    .parent()
-                    .is_some_and(|parent| access_path(parent, libc::W_OK | libc::X_OK)));
-            }
-        }
-        "executable" => libc::X_OK,
-        _ => {
-            return Err(RpcError::invalid_params(format!(
-                "Invalid access mode: {mode}"
-            )))
-        }
-    };
-
-    Ok(access_path(path, flags))
-}
-
-fn access_path(path: &Path, flags: libc::c_int) -> bool {
-    let Ok(path_cstr) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
-        return false;
-    };
-
-    unsafe { libc::access(path_cstr.as_ptr(), flags) == 0 }
 }
 
 /// Expand ~ to home directory in a PathBuf.

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -265,6 +265,7 @@ async fn dispatch_inner(request: Request) -> Response {
     let result = match method.as_str() {
         // File metadata operations
         "file.stat" => file::stat(params).await,
+        "file.access" => file::access(params).await,
         "file.truename" => file::truename(params).await,
 
         // Directory operations

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -265,7 +265,6 @@ async fn dispatch_inner(request: Request) -> Response {
     let result = match method.as_str() {
         // File metadata operations
         "file.stat" => file::stat(params).await,
-        "file.access" => file::access(params).await,
         "file.truename" => file::truename(params).await,
 
         // Directory operations

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -376,7 +376,7 @@ The directory is deleted after BODY completes."
 
   ;; Existing file
   (tramp-rpc-test--with-temp-file tmp "test content"
-    (should (tramp-rpc-test--with-call-count 3
+    (should (tramp-rpc-test--with-call-count 1
               (file-writable-p tmp))))
 
   ;; Non-existent file in writable directory
@@ -630,7 +630,7 @@ This tests Issue #13: Chinese characters decode incorrectly."
 
   (tramp-rpc-test--with-temp-file tmp "test content"
     (with-temp-buffer
-      (tramp-rpc-test--with-call-count 3
+      (tramp-rpc-test--with-call-count 1
         (insert-file-contents tmp))
       (should (equal (buffer-string) "test content")))))
 
@@ -641,7 +641,7 @@ This tests Issue #13: Chinese characters decode incorrectly."
   (tramp-rpc-test--with-temp-file tmp "0123456789"
     ;; Read bytes 2-5
     (with-temp-buffer
-      (tramp-rpc-test--with-call-count 3
+      (tramp-rpc-test--with-call-count 1
         (insert-file-contents tmp nil 2 6))
       (should (equal (buffer-string) "2345")))))
 
@@ -657,7 +657,7 @@ This tests Issue #13: Chinese characters decode incorrectly."
     (let ((dest (tramp-rpc-test--make-temp-name)))
       (unwind-protect
           (progn
-            (tramp-rpc-test--with-call-count 5
+            (tramp-rpc-test--with-call-count 2
               (copy-file src dest))
             (should (file-exists-p dest))
             (should (equal (with-temp-buffer
@@ -690,7 +690,7 @@ signal `file-already-exists'.  With trailing slash (via
             (should-error (copy-file src dest-dir 'ok)
                           :type 'file-error)
             ;; With trailing / (file-name-as-directory), should copy INTO dir
-            (tramp-rpc-test--with-call-count 5
+            (tramp-rpc-test--with-call-count 2
               (copy-file src (file-name-as-directory dest-dir)))
             ;; File should now exist inside the directory with original name
             (let ((expected-dest (expand-file-name
@@ -714,7 +714,7 @@ signal `file-already-exists'.  With trailing slash (via
     (unwind-protect
         (progn
           (write-region content nil src)
-          (tramp-rpc-test--with-call-count 3
+          (tramp-rpc-test--with-call-count 2
             (rename-file src dest))
           (should-not (file-exists-p src))
           (should (file-exists-p dest))
@@ -816,7 +816,7 @@ This exercises copy-then-delete for cross-remote renames."
   (let ((dir (tramp-rpc-test--make-temp-name)))
     (unwind-protect
         (progn
-          (tramp-rpc-test--with-call-count 2
+          (tramp-rpc-test--with-call-count 1
             (make-directory dir))
           (should (file-directory-p dir)))
       (ignore-errors (delete-directory dir)))))
@@ -828,7 +828,7 @@ This exercises copy-then-delete for cross-remote renames."
   (let ((dir (concat (tramp-rpc-test--make-temp-name) "/nested/path")))
     (unwind-protect
         (progn
-          (tramp-rpc-test--with-call-count 9
+          (tramp-rpc-test--with-call-count 1
             (make-directory dir t))
           (should (file-directory-p dir)))
       (ignore-errors (delete-directory
@@ -868,7 +868,7 @@ This exercises copy-then-delete for cross-remote renames."
     (write-region "b" nil (concat dir "/file2.txt"))
     (write-region "c" nil (concat dir "/other.log"))
 
-    (let ((files (tramp-rpc-test--with-call-count 2
+    (let ((files (tramp-rpc-test--with-call-count 1
                   (directory-files dir))))
       ;; Should contain . and .. plus our files
       (should (member "." files))

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -376,7 +376,7 @@ The directory is deleted after BODY completes."
 
   ;; Existing file
   (tramp-rpc-test--with-temp-file tmp "test content"
-    (should (tramp-rpc-test--with-call-count 1
+    (should (tramp-rpc-test--with-call-count 3
               (file-writable-p tmp))))
 
   ;; Non-existent file in writable directory


### PR DESCRIPTION
Network latency dominates TRAMP-RPC performance more than the cost of individual remote operations. Several handlers still delegated to generic TRAMP skeletons that perform sequential preflight checks, where every predicate can become a separate request/response over SSH. Collapse those paths into either one higher-level server operation or one batched preflight plus the real operation.

Directory handling now avoids generic skeleton probes:
- directory-files calls dir.list directly and lets the server validate missing/non-directory paths.
- make-directory delegates parent creation to dir.create with parents=true instead of probing each component from Elisp.
- dir.create now reports whether the target was created and only chmods directories created by this request, preserving make-directory DIR t semantics for existing directories.

File access and I/O paths get latency-focused handlers:
- Add file.access on the server and use it for file-readable-p/file-writable-p so permission checks do not require generic TRAMP metadata/uid/group round trips.
- Add a direct non-visit insert-file-contents path using file.read, avoiding file-local-copy and temporary local file machinery for ordinary programmatic reads. Visiting a file still falls back to the generic TRAMP path to keep buffer-state/not-found behavior conservative.

Same-remote copy and rename now batch independent preflight stats:
- copy-file batches source and destination file.stat calls, then uses server-side file.copy.
- rename-file batches source and destination file.stat calls, then uses server-side file.rename.
- This reduces network round trips while still preserving directory destination and symlink handling.

Update call-count tests to lock in the reduced round-trip behavior:
- file-writable-p: 3 -> 1
- insert-file-contents: 3 -> 1
- directory-files: 2 -> 1
- make-directory: 2 -> 1
- make-directory parents: 9 -> 1
- same-remote copy-file: 5 -> 2
- same-remote rename-file: 3 -> 2

Tested with cargo fmt --check, cargo test, byte-compilation of all lisp/*.el with byte-compile-error-on-warn, and the remote tramp-rpc ERT suite against localhost using a temporary deployed server binary.