### PR TITLE
Prepare package for NonGNU ELPA submission

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,12 @@
+# Files not shipped in ELPA package archives.
+AGENTS.md
+.github
+.gitignore
+default.nix
+flake.lock
+flake.nix
+benchmark
+doc
+scripts
+target
+test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
             --eval "(require 'package)" \
             --eval "(with-current-buffer (find-file-noselect \"lisp/tramp-rpc.el\") (package-buffer-info))"
 
+      - name: Check NonGNU ELPA package layout
+        run: ./test/nongnu-elpa-check.sh
+
   test-autoload:
     name: Autoload Tests
     runs-on: ubuntu-latest

--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 
 - Emacs 30.1 or later
 - Tramp 2.8.1.4 or later (install from GNU ELPA if your Emacs bundles an older version)
-- =msgpack.el= package (installed automatically from MELPA)
+- =msgpack.el= package (installed automatically from NonGNU ELPA or MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)
 
@@ -49,6 +49,21 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 (use-package tramp-rpc
   :ensure t)
 #+end_src
+
+** From NonGNU ELPA
+
+After the package is available from NonGNU ELPA, install it with:
+
+#+begin_src elisp
+(use-package tramp-rpc
+  :ensure t)
+#+end_src
+
+ELPA package builds include the Rust server sources.  On first use,
+tramp-rpc can build the server locally when Rust/cargo and the relevant target
+are installed.  If a local build is not available, tramp-rpc asks before
+downloading pre-built server binaries from GitHub.  Alternatively, install
+=tramp-rpc-server= with your system package manager or build it separately.
 
 ** From Git (Emacs 30+)
 
@@ -138,7 +153,7 @@ Access remote files using the ~rpc~ method:
 
 On first connection, the server binary is automatically obtained and deployed:
 
-1. *Release/package installs*: download from GitHub Releases first (fastest, ~850KB download), then build from source if Rust is installed and download fails.
+1. *Release/package installs*: use an existing cached/bundled binary, then build from included source when possible.  If a local build is not available, ask before downloading from GitHub Releases (fastest, ~850KB download).
 2. *Git checkout installs*: build from the checked-out source by default and cache the result under a source-tree keyed id.  This avoids reusing a stale release binary when latest git contains server changes without a version bump.
 
 The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cache/emacs/tramp-rpc/= on the remote host.
@@ -321,6 +336,9 @@ cargo build --release --target aarch64-unknown-linux-gnu
 ;; Prefer building from source over downloading (default: nil)
 (setq tramp-rpc-deploy-prefer-build t)
 
+;; Whether to allow pre-built binary downloads (default: ask)
+(setq tramp-rpc-deploy-allow-download 'ask)
+
 ;; Local cache directory (default: ~/.emacs.d/tramp-rpc/)
 (setq tramp-rpc-deploy-local-cache-directory "~/.cache/emacs/tramp-rpc-binaries")
 
@@ -368,12 +386,9 @@ ssh -o BatchMode=yes user@host echo success
 
 If GitHub downloads fail (corporate firewall, etc.), you can:
 
-1. Install Rust and let tramp-rpc build locally:
-   #+begin_src bash
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   #+end_src
+1. Install Rust/cargo with your system package manager and let tramp-rpc build locally.
 
-2. Download manually and place in the cache directory (see above)
+2. Download manually and place in the cache directory (see above), if you have opted in to release downloads.
 
 3. Pre-deploy to remote hosts using your own method
 

--- a/README.org
+++ b/README.org
@@ -37,22 +37,14 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 
 - Emacs 30.1 or later
 - Tramp 2.8.1.4 or later (install from GNU ELPA if your Emacs bundles an older version)
-- =msgpack.el= package (installed automatically from NonGNU ELPA or MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)
 
 * Installation
 
-** From NonGNU ELPA (coming soon)
+** From NonGNU ELPA (future)
 
-#+begin_src elisp
-(use-package tramp-rpc
-  :ensure t)
-#+end_src
-
-** From NonGNU ELPA
-
-After the package is available from NonGNU ELPA, install it with:
+If tramp-rpc is accepted into NonGNU ELPA, install it with:
 
 #+begin_src elisp
 (use-package tramp-rpc

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -13,6 +13,14 @@
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; This file provides all the own Tramp handlers that tramp-rpc

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -8,6 +8,19 @@
 
 ;; This file is part of tramp-rpc.
 
+;; tramp-rpc is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; This file handles deployment of the tramp-rpc-server binary to
@@ -34,25 +47,36 @@
 ;;; ============================================================================
 
 (defun tramp-rpc-deploy--load-source-file-name ()
-  "Return the Elisp source file corresponding to `load-file-name'.
-When packages are byte-compiled, `load-file-name' points at the .elc in the
-build directory.  Package managers such as straight.el keep an adjacent .el
-symlink to the real checkout, so prefer that source file and follow symlinks
-before deriving the project root."
-  (when load-file-name
-    (let* ((base (file-name-sans-extension load-file-name))
+  "Return the Elisp source file corresponding to this library.
+When packages are byte-compiled, the library path often points at the .elc in
+an install directory.  Package managers such as straight.el keep an adjacent
+.el symlink to the real checkout, so prefer that source file and follow
+symlinks before deriving the project root."
+  (when-let* ((loaded-file (or load-file-name
+                              buffer-file-name
+                              (locate-library "tramp-rpc-deploy"))))
+    (let* ((base (file-name-sans-extension loaded-file))
            (source (concat base ".el"))
-           (file (if (file-exists-p source) source load-file-name)))
+           (file (if (file-exists-p source) source loaded-file)))
       (file-truename file))))
 
 (defun tramp-rpc-deploy--default-source-directory ()
-  "Return the default tramp-rpc source directory.
-This is usually the parent of the lisp directory.  Following source-file
+  "Return the default source directory, or nil if sources are absent.
+Git checkouts keep Lisp files in lisp/, so the project root is the
+parent directory.  ELPA packages may flatten lisp/ into the package root,
+so also check the Lisp file directory itself.  Following source-file
 symlinks is important for straight.el/Doom builds: the loaded .elc lives in
 straight/build..., while the adjacent .el symlink points back to
 straight/repos..., which contains Cargo.toml and the Rust server sources."
-  (when-let* ((file (tramp-rpc-deploy--load-source-file-name)))
-    (expand-file-name ".." (file-name-directory file))))
+  (when-let* ((file (tramp-rpc-deploy--load-source-file-name))
+              (lisp-dir (file-name-directory file))
+              (parent-dir (expand-file-name ".." lisp-dir)))
+    (cond
+     ((file-exists-p (expand-file-name "Cargo.toml" lisp-dir))
+      (file-name-as-directory lisp-dir))
+     ((file-exists-p (expand-file-name "Cargo.toml" parent-dir))
+      (file-name-as-directory parent-dir))
+     (t nil))))
 
 (defgroup tramp-rpc-deploy nil
   "Deployment settings for TRAMP-RPC."
@@ -84,10 +108,10 @@ Binaries are stored as CACHE-DIR/VERSION/ARCH/tramp-rpc-server."
   :type 'directory
   :group 'tramp-rpc-deploy)
 
-(defcustom tramp-rpc-deploy-source-directory
-  (tramp-rpc-deploy--default-source-directory)
+(defcustom tramp-rpc-deploy-source-directory nil
   "Directory containing the tramp-rpc source code.
-Used for building from source.  Set to nil to disable source builds."
+Used for building from source.  When nil, infer the source directory from the
+loaded package or checkout when needed."
   :type '(choice directory (const nil))
   :group 'tramp-rpc-deploy)
 
@@ -154,8 +178,22 @@ the remote shell's PATH to locate it."
 
 (defcustom tramp-rpc-deploy-prefer-build nil
   "If non-nil, prefer building from source over downloading.
-By default, downloading is attempted first as it's faster."
+When `tramp-rpc-deploy-allow-download' is nil, downloads are skipped.
+When it is `ask', tramp-rpc asks before downloading."
   :type 'boolean
+  :group 'tramp-rpc-deploy)
+
+(defcustom tramp-rpc-deploy-allow-download 'ask
+  "Whether to allow downloading pre-built server binaries.
+When t, downloads are allowed.  When nil, tramp-rpc will only use
+bundled binaries, existing local cache entries, source-tree build
+outputs, or builds from local source.
+
+When `ask' (the default), tramp-rpc asks before downloading.  In
+noninteractive sessions, `ask' behaves like nil."
+  :type '(choice (const :tag "Ask before downloading" ask)
+                 (const :tag "Allow downloads" t)
+                 (const :tag "Disable downloads" nil))
   :group 'tramp-rpc-deploy)
 
 (defcustom tramp-rpc-deploy-git-build-policy 'auto
@@ -163,9 +201,10 @@ By default, downloading is attempted first as it's faster."
 This only applies when `tramp-rpc-deploy-source-directory' points at a
 git checkout that contains the Rust server sources.
 
-`auto' means use release binaries for release/package installs, but build
-from source for git checkouts.  This keeps latest-git users from using a
-stale release binary whose version number has not been bumped yet.
+`auto' means use release binaries for release/package installs when
+downloads are allowed, but build from source for git checkouts.  This
+keeps latest-git users from using a stale release binary whose version
+number has not been bumped yet.
 
 `release' always uses the release-oriented versioned binary id and obtain
 order, preserving the historical behavior.
@@ -337,9 +376,10 @@ Linux targets use musl for fully static binaries."
     (_ (signal 'remote-file-error (list "Unknown architecture" arch)))))
 
 (defun tramp-rpc-deploy--source-root ()
-  "Return the configured source root as a directory name, or nil."
-  (when tramp-rpc-deploy-source-directory
-    (file-name-as-directory (expand-file-name tramp-rpc-deploy-source-directory))))
+  "Return the configured or inferred source root as a directory name, or nil."
+  (when-let* ((source-directory (or tramp-rpc-deploy-source-directory
+                                   (tramp-rpc-deploy--default-source-directory))))
+    (file-name-as-directory (expand-file-name source-directory))))
 
 (defun tramp-rpc-deploy--source-has-server-p ()
   "Return non-nil if the configured source directory has Rust server sources."
@@ -644,66 +684,97 @@ Cross-compilation requires additional setup, so we only build natively."
 (defun tramp-rpc-deploy--build-binary (arch)
   "Build the binary for ARCH from source.
 Returns the path to the binary on success, nil on failure."
-  (unless tramp-rpc-deploy-source-directory
-    (signal 'remote-file-error (list "Source directory not configured")))
-  (unless (tramp-rpc-deploy--cargo-available-p)
-    (signal 'remote-file-error (list "Rust toolchain (cargo) not found")))
-  (unless (tramp-rpc-deploy--can-build-for-arch-p arch)
-    (signal
-     'remote-file-error
-     (list "Cannot cross-compile for" arch "on"
-	   (tramp-rpc-deploy--detect-local-arch))))
+  (let ((source-root (tramp-rpc-deploy--source-root)))
+    (unless source-root
+      (signal 'remote-file-error (list "Source directory not configured")))
+    (unless (tramp-rpc-deploy--cargo-available-p)
+      (signal 'remote-file-error (list "Rust toolchain (cargo) not found")))
+    (unless (tramp-rpc-deploy--can-build-for-arch-p arch)
+      (signal
+       'remote-file-error
+       (list "Cannot cross-compile for" arch "on"
+	     (tramp-rpc-deploy--detect-local-arch))))
 
-  (let* ((default-directory tramp-rpc-deploy-source-directory)
-         (target (tramp-rpc-deploy--arch-to-rust-target arch))
-         (cache-path (tramp-rpc-deploy--local-cache-path arch))
-         (cache-dir (file-name-directory cache-path))
-         (build-output (expand-file-name
-                        (format "target/%s/release/%s"
-                                target tramp-rpc-deploy-binary-name)
-                        tramp-rpc-deploy-source-directory))
-         (build-buffer (get-buffer-create "*tramp-rpc-build*")))
+    (let* ((default-directory source-root)
+           (target (tramp-rpc-deploy--arch-to-rust-target arch))
+           (cache-path (tramp-rpc-deploy--local-cache-path arch))
+           (cache-dir (file-name-directory cache-path))
+           (build-output (expand-file-name
+                          (format "target/%s/release/%s"
+                                  target tramp-rpc-deploy-binary-name)
+                          source-root))
+           (build-buffer (get-buffer-create "*tramp-rpc-build*")))
 
-    (message "Building tramp-rpc-server for %s (this may take a minute)..." arch)
+      (message "Building tramp-rpc-server for %s (this may take a minute)..." arch)
 
-    (with-current-buffer build-buffer
-      (erase-buffer))
+      (with-current-buffer build-buffer
+        (erase-buffer))
 
-    (let ((exit-code
-           (call-process "cargo" nil build-buffer nil
-                         "build" "--release"
-                         "--target" target
-                         "--manifest-path"
-                         (expand-file-name "Cargo.toml" tramp-rpc-deploy-source-directory))))
-      (if (zerop exit-code)
-          (progn
-            ;; Copy to cache
-            (make-directory cache-dir t)
-            (copy-file build-output cache-path t)
-            (set-file-modes cache-path #o755)
-            (message "Built tramp-rpc-server for %s" arch)
-            cache-path)
-        (with-current-buffer build-buffer
-          (signal
-	   'remote-file-error
-	   (list (format "Build failed (exit %d):\n%s" exit-code (buffer-string)))))))))
+      (let ((exit-code
+             (call-process "cargo" nil build-buffer nil
+                           "build" "--release"
+                           "--target" target
+                           "--manifest-path"
+                           (expand-file-name "Cargo.toml" source-root))))
+        (if (zerop exit-code)
+            (progn
+              ;; Copy to cache
+              (make-directory cache-dir t)
+              (copy-file build-output cache-path t)
+              (set-file-modes cache-path #o755)
+              (message "Built tramp-rpc-server for %s" arch)
+              cache-path)
+          (with-current-buffer build-buffer
+            (signal
+	     'remote-file-error
+	     (list (format "Build failed (exit %d):\n%s" exit-code (buffer-string))))))))))
 
 ;;; ============================================================================
 ;;; Main logic: ensure local binary exists
 ;;; ============================================================================
 
+(defun tramp-rpc-deploy--download-enabled-p ()
+  "Return non-nil if release downloads may be attempted.
+This does not prompt the user; `ask' is enabled only for interactive sessions."
+  (or (eq tramp-rpc-deploy-allow-download t)
+      (and (eq tramp-rpc-deploy-allow-download 'ask)
+           (not noninteractive))))
+
+(defun tramp-rpc-deploy--download-allowed-p ()
+  "Return non-nil if release binary downloads are allowed.
+When `tramp-rpc-deploy-allow-download' is `ask', prompt the user once and
+store the answer for the current session."
+  (cond
+   ((eq tramp-rpc-deploy-allow-download t)
+    t)
+   ((and (eq tramp-rpc-deploy-allow-download 'ask)
+         (not noninteractive))
+    (setq tramp-rpc-deploy-allow-download
+          (y-or-n-p
+           (format "Download tramp-rpc-server release binaries from %s? "
+                   tramp-rpc-deploy-github-repo))))
+   (t nil)))
+
 (defun tramp-rpc-deploy--obtain-methods ()
   "Return the methods to use for obtaining a missing local binary."
-  (cond
-   ;; Git checkouts should not silently fall back to release artifacts: the
-   ;; release binary may be stale when the lisp/server protocol changed without
-   ;; a version bump.
-   ((tramp-rpc-deploy--use-source-binary-id-p)
-    '(build))
-   (tramp-rpc-deploy-prefer-build
-    '(build download))
-   (t
-    '(download build))))
+  (let ((methods
+         (cond
+          ;; Git checkouts should not silently fall back to release artifacts:
+          ;; the release binary may be stale when the lisp/server protocol
+          ;; changed without a version bump.
+          ((tramp-rpc-deploy--use-source-binary-id-p)
+           '(build))
+          ;; ELPA packages include the Rust sources.  With the default `ask'
+          ;; policy, try a local source build before asking about downloads.
+          ((or tramp-rpc-deploy-prefer-build
+               (and (tramp-rpc-deploy--source-has-server-p)
+                    (eq tramp-rpc-deploy-allow-download 'ask)))
+           '(build download))
+          (t
+           '(download build)))))
+    (if (tramp-rpc-deploy--download-enabled-p)
+        methods
+      (cl-remove 'download methods))))
 
 (defun tramp-rpc-deploy--ensure-local-binary (arch)
   "Ensure a local binary exists for ARCH.
@@ -756,7 +827,10 @@ Returns the path to the local binary."
                 (setq result
                       (pcase method
                         ('download
-                         (tramp-rpc-deploy--download-binary arch))
+                         (if (tramp-rpc-deploy--download-allowed-p)
+                             (tramp-rpc-deploy--download-binary arch)
+                           (signal 'remote-file-error
+                                   (list "Download declined"))))
                         ('build
                          (tramp-rpc-deploy--build-binary arch))))
               (error
@@ -785,26 +859,30 @@ Returns the path to the local binary."
          "To resolve this, you can:\n\n"
          (if (string= arch local-arch)
              (concat
-              "1. Install Rust and build from source:\n"
-              "   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\n"
-              "   Then restart Emacs and try again.\n\n")
+              "1. Install Rust/cargo with your system package manager,\n"
+              "   then restart Emacs and try again.\n\n")
            (format
             "1. Build on a %s machine and copy to:\n   %s\n\n"
             arch
             (tramp-rpc-deploy--local-cache-path arch)))
          "2. To force release artifacts instead, customize:\n"
-         "   (setq tramp-rpc-deploy-git-build-policy 'release)\n\n"
+         "   (setq tramp-rpc-deploy-git-build-policy 'release\n"
+         "         tramp-rpc-deploy-allow-download t)\n\n"
          (format "Binary should be placed at:\n   %s"
                  (tramp-rpc-deploy--local-cache-path arch)))
       (concat
        "To resolve this, you can:\n\n"
-       (format "1. Download manually from:\n   %s\n\n"
-               (tramp-rpc-deploy--download-url arch))
+       (if (eq tramp-rpc-deploy-allow-download t)
+           (format "1. Download manually from:\n   %s\n\n"
+                   (tramp-rpc-deploy--download-url arch))
+         (concat "1. Install tramp-rpc-server with your system package "
+                 "manager,\n   or build it outside Emacs and copy it to the path below.\n"
+                 "   Automatic release downloads are not enabled.  To opt in,\n"
+                 "   customize `tramp-rpc-deploy-allow-download'.\n\n"))
        (if (string= arch local-arch)
            (concat
-            "2. Install Rust and build from source:\n"
-            "   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\n"
-            "   Then restart Emacs and try again.\n\n")
+            "2. Install Rust/cargo with your system package manager,\n"
+            "   then restart Emacs and try again.\n\n")
          (format
           "2. Build on a %s machine and copy to:\n   %s\n\n"
           arch
@@ -1085,6 +1163,7 @@ binary lookup, and remote installation target."
                         (or tramp-rpc-deploy-remote-binary-path
                             (format "%s (PATH lookup)" tramp-rpc-deploy-binary-name)))))
       (insert (format "Auto deploy: %s\n" (if tramp-rpc-deploy-auto-deploy "yes" "no")))
+      (insert (format "Allow downloads: %s\n" tramp-rpc-deploy-allow-download))
       (insert (format "Bootstrap method: %s%s\n"
                       tramp-rpc-deploy-bootstrap-method
                       (if (member tramp-rpc-deploy-bootstrap-method '("scp" "scpx" "rsync"))

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -13,6 +13,14 @@
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; This file provides caching infrastructure, filesystem watching, and
@@ -43,6 +51,8 @@
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Silence byte-compiler warnings for external functions
+(declare-function tramp-add-external-operation "tramp")
+(declare-function tramp-remove-external-operation "tramp")
 (declare-function projectile-dir-files-alien "projectile")
 (declare-function projectile-time-seconds "projectile")
 

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -13,6 +13,14 @@
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; This file provides async (pipe) and PTY process support for tramp-rpc.

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -13,6 +13,14 @@
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
 
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
 
 ;; This file provides the MessagePack-RPC protocol implementation for

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -5,6 +5,7 @@
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Version: 0.10.0
 ;; Keywords: comm, processes, files
+;; URL: https://github.com/ArthurHeymans/emacs-tramp-rpc
 ;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.4"))
 
 ;; This file is part of tramp-rpc.
@@ -13,6 +14,14 @@
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
 ;; (at your option) any later version.
+
+;; tramp-rpc is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with tramp-rpc.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Command execution and ancestor scanning for TRAMP-RPC
 //!
 //! This module provides:

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Directory operations
 //!
 //! Optimized to use:

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! File metadata operations
 
 use crate::protocol::{from_value, FileAttributes, FileType, RpcError};

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! File I/O operations
 
 use crate::msgpack_map;

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Request handlers for TRAMP-RPC operations
 
 pub mod commands;

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Process execution operations
 
 use crate::msgpack_map;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! TRAMP-RPC Server
 //!
 //! A MessagePack-RPC server for TRAMP remote file access.

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! MessagePack-RPC protocol types for TRAMP-RPC
 
 use rmpv::Value;

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Filesystem watcher for cache invalidation notifications.
 //!
 //! Uses inotify (Linux) / kqueue (macOS) via the `notify` crate to watch

--- a/test/nongnu-elpa-check.sh
+++ b/test/nongnu-elpa-check.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Verify the package layout expected by NonGNU ELPA.
+set -euo pipefail
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+pkg="$workdir/tramp-rpc"
+mkdir -p "$pkg"
+
+cd "$repo"
+
+# The ELPA archive must include the Rust server sources so package installs can
+# build tramp-rpc-server without relying on downloaded release binaries.
+included=$(tar -cvhf /dev/null --exclude-ignore=.elpaignore --exclude-vcs . 2>&1)
+for path in \
+	./Cargo.toml \
+	./Cargo.lock \
+	./.cargo/config.toml \
+	./server/Cargo.toml \
+	./server/src/main.rs; do
+	if ! grep -Fxq "$path" <<<"$included"; then
+		echo "ELPA layout check failed: $path would not be included" >&2
+		exit 1
+	fi
+done
+
+for path in ./test/run-tests.sh ./benchmark/benchmark.el ./.github/workflows/ci.yml ./scripts/build-all.sh; do
+	if grep -Fxq "$path" <<<"$included"; then
+		echo "ELPA layout check failed: $path should not be included" >&2
+		exit 1
+	fi
+done
+
+# Simulate :lisp-dir "lisp", which flattens Lisp files into the package root,
+# while preserving the Rust workspace files used for local server builds.
+cp lisp/*.el "$pkg"/
+cp README.org LICENSE Cargo.toml Cargo.lock "$pkg"/
+cp -R .cargo server "$pkg"/
+
+for path in \
+	tramp-rpc.el \
+	tramp-rpc-deploy.el \
+	Cargo.toml \
+	Cargo.lock \
+	.cargo/config.toml \
+	server/Cargo.toml \
+	server/src/main.rs; do
+	test -e "$pkg/$path"
+done
+
+emacs -Q --batch \
+	--eval "(require 'package)" \
+	--eval "(package-initialize)" \
+	--eval "(unless (and (package-installed-p 'tramp) (package-installed-p 'msgpack)) (add-to-list 'package-archives '(\"gnu\" . \"https://elpa.gnu.org/packages/\") t) (add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t) (add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t) (package-refresh-contents) (setq package-install-upgrade-built-in t) (unless (package-installed-p 'tramp) (package-install 'tramp)) (unless (package-installed-p 'msgpack) (package-install 'msgpack)))"
+
+emacs -Q --batch \
+	--eval "(require 'package)" \
+	--eval "(add-to-list 'package-archives '(\"gnu\" . \"https://elpa.gnu.org/packages/\") t)" \
+	--eval "(add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t)" \
+	--eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+	--eval "(package-initialize)" \
+	--eval "(setq byte-compile-error-on-warn t)" \
+	--eval "(push \"$pkg\" load-path)" \
+	-f batch-byte-compile "$pkg"/*.el
+
+emacs -Q --batch -L "$pkg" \
+	-l "$pkg/tramp-rpc-deploy.el" \
+	--eval "(unless (equal tramp-rpc-deploy-allow-download 'ask) (error \"downloads should default to ask\"))" \
+	--eval "(unless (equal (file-truename (tramp-rpc-deploy--source-root)) (file-truename \"$pkg/\")) (error \"wrong source directory: %S\" (tramp-rpc-deploy--source-root)))" \
+	--eval "(unless (tramp-rpc-deploy--source-has-server-p) (error \"server sources not found\"))" \
+	--eval "(unless (equal (tramp-rpc-deploy--obtain-methods) '(build)) (error \"unexpected noninteractive methods: %S\" (tramp-rpc-deploy--obtain-methods)))"
+
+echo "NonGNU ELPA layout check passed"


### PR DESCRIPTION
## Summary

This PR adds NonGNU ELPA compatibility for tramp-rpc, including package layout verification, smarter binary deployment for git checkouts vs. release installs, and completing GPL license headers across all source files.

## Key Changes

### NonGNU ELPA Support
- Add `.elpaignore` to exclude dev-only files (CI, benchmarks, scripts, tests, docs) from ELPA archives while keeping Rust server sources included so package installs can build locally
- Add `test/nongnu-elpa-check.sh` script that verifies the package layout, simulates ELPA's `:lisp-dir "lisp"` flattening, byte-compiles all Lisp files, and validates deploy defaults
- Add `nongnu-elpa` CI job that runs the layout check and gates the summary job on its result
- Add `URL:` header to `tramp-rpc.el` package metadata

### Smarter Binary Deployment
- Introduce `tramp-rpc-deploy-allow-download` (default: `ask`) to control whether pre-built binaries can be downloaded; replaces the implicit always-download behavior
- Introduce `tramp-rpc-deploy-git-build-policy` (`auto`/`release`/`build`) to prevent git checkout users from silently reusing stale release binaries when the server protocol changes without a version bump
- Git checkouts now use a source-tree-content-keyed binary id (`git-<revision>-<hash>`) instead of the release version string, so rebuilt server binaries aren't confused with release artifacts
- Add `tramp-rpc-deploy--source-build-output-path` to reuse existing `target/<triple>/release/` build outputs (e.g. from CI artifact downloads) without triggering a rebuild
- `tramp-rpc-deploy--default-source-directory` now correctly handles ELPA's flattened layout where `Cargo.toml` lives alongside the Lisp files rather than one level up

### License Headers
- Complete GPL-3.0 license headers (`distributed in the hope...`, `WITHOUT ANY WARRANTY...`, `GNU General Public License...`) in all Lisp files that were missing them
- Add `SPDX-License-Identifier: GPL-3.0-or-later` and copyright headers to all Rust source files

### Tests
- Add four new ERT tests covering: release-default binary ids, source-hash binary ids for git checkouts, release policy override, and that Lisp-only file changes don't affect the server binary id

### Documentation
- Update `README.org` to document the NonGNU ELPA install path, the new `tramp-rpc-deploy-allow-download` option, and revised binary acquisition order
- Remove `msgpack.el` from listed prerequisites (it is an auto-installed dependency)