### PR TITLE
Fix VC relay process race for TRAMP-RPC

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -23,6 +23,7 @@
 ;; - process-status / process-exit-status (return remote process state)
 ;; - process-command / process-tty-name (return stored metadata)
 ;; - vc-call-backend (ensure default-directory for remote VC files)
+;; - vc-exec-after (handle native-compiled VC process state races)
 ;; - eglot--cmd (bypass shell wrapping for RPC connections)
 ;; - hack-dir-local-variables (enable dir-locals for RPC remotes)
 
@@ -51,6 +52,10 @@
 (defvar tramp-rpc--closing-local-relay)
 (defvar tramp-rpc--pty-processes)
 (defvar tramp-rpc--async-processes)
+
+;; Functions from vc-dispatcher.el (used by vc-exec-after advice)
+(declare-function vc-set-mode-line-busy-indicator "vc-dispatcher")
+(declare-function vc--process-sentinel "vc-dispatcher")
 
 ;; Variables from vc-dir.el (used in vc-dir-refresh advice)
 (defvar vc-dir-process-buffer)
@@ -300,6 +305,45 @@ process-file calls are routed through the TRAMP handler."
           (apply orig-fun backend function-name args))
       (apply orig-fun backend function-name args))))
 
+(defun tramp-rpc--vc-exec-after-advice (orig-fun code &optional success)
+  "Advice for `vc-exec-after' to handle TRAMP-RPC relay processes.
+
+Some native-compiled VC functions can observe the raw local relay process
+state instead of the logical state provided by `process-status' advice.  A
+short-lived remote command can leave the local cat relay in a non-`run' and
+non-`exit' state while TRAMP-RPC has already recorded the remote exit.  The
+stock `vc-exec-after' then signals \"Unexpected process state\".  For
+TRAMP-RPC processes, reproduce `vc-exec-after' using the logical process
+state."
+  (let ((proc (get-buffer-process (current-buffer))))
+    (if (and (processp proc)
+             (process-get proc :tramp-rpc-pid))
+        (let ((status (cond
+                       ((process-get proc :tramp-rpc-exited) 'exit)
+                       ((memq (process-status proc) '(run open listen connect)) 'run)
+                       (t 'exit))))
+          (cond
+           ((eq status 'exit)
+            ;; Match `vc-exec-after': drain pending output before the next VC
+            ;; stage.  Use zero-timeout accepts so we drain what is immediately
+            ;; available without blocking callers such as Dired/diff-hl that
+            ;; run with `inhibit-quit' bound; Emacs 30 warns about blocking
+            ;; `accept-process-output' in that context.
+            (while (accept-process-output proc 0 nil t))
+            (when (or (not success)
+                      (zerop (process-exit-status success)))
+              (if (functionp code) (funcall code) (eval code t))))
+           ((eq status 'run)
+            (vc-set-mode-line-busy-indicator)
+            (letrec ((fun (lambda (p _msg)
+                            (remove-function (process-sentinel p) fun)
+                            (vc--process-sentinel p code success))))
+              (add-function :after (process-sentinel proc) fun)))
+           (t
+            (funcall orig-fun code success))))
+      (funcall orig-fun code success)))
+  nil)
+
 ;; ============================================================================
 ;; Privilege elevation integration
 ;; ============================================================================
@@ -417,6 +461,7 @@ exited (remote side finished), delete it so the refresh can proceed."
   (advice-add 'process-command :around #'tramp-rpc--process-command-advice)
   (advice-add 'process-tty-name :around #'tramp-rpc--process-tty-name-advice)
   (advice-add 'vc-call-backend :around #'tramp-rpc--vc-call-backend-advice)
+  (advice-add 'vc-exec-after :around #'tramp-rpc--vc-exec-after-advice)
   (with-eval-after-load 'eglot
     (advice-add 'eglot--cmd :around #'tramp-rpc--eglot-cmd-advice))
   (with-eval-after-load 'vc-dir
@@ -438,6 +483,7 @@ exited (remote side finished), delete it so the refresh can proceed."
   (advice-remove 'process-command #'tramp-rpc--process-command-advice)
   (advice-remove 'process-tty-name #'tramp-rpc--process-tty-name-advice)
   (advice-remove 'vc-call-backend #'tramp-rpc--vc-call-backend-advice)
+  (advice-remove 'vc-exec-after #'tramp-rpc--vc-exec-after-advice)
   (advice-remove 'eglot--cmd #'tramp-rpc--eglot-cmd-advice)
   (advice-remove 'vc-dir-refresh #'tramp-rpc--vc-dir-refresh-advice)
   (advice-remove 'magit-start-process #'tramp-rpc--magit-start-process-advice)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1121,6 +1121,57 @@ as a hop in multi-hop chains."
                    (tramp-rpc--controlmaster-socket-path sudo-vec)))))
 
 ;;; ============================================================================
+;;; VC advice tests (No server or SSH required)
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-vc-exec-after-logical-exit-runs-code ()
+  "Test `vc-exec-after' advice treats exited TRAMP-RPC relays as done."
+  :tags '(:vc-advice)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-vc-exec-after-test*"))
+         (proc (make-process :name "tramp-rpc-vc-exec-after-test"
+                             :buffer buffer
+                             :command '("sh" "-c" "sleep 60")
+                             :noquery t))
+         (ran nil))
+    (unwind-protect
+        (with-current-buffer buffer
+          (process-put proc :tramp-rpc-pid 123)
+          (process-put proc :tramp-rpc-exited t)
+          (tramp-rpc--vc-exec-after-advice
+           (lambda (&rest _) (error "Unexpected process state"))
+           (lambda () (setq ran t)))
+          (should ran))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer buffer))))
+
+(ert-deftest tramp-rpc-mock-test-vc-exec-after-raw-closed-state-runs-code ()
+  "Test `vc-exec-after' advice handles raw non-run relay states."
+  :tags '(:vc-advice)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-vc-exec-after-test*"))
+         (proc (make-process :name "tramp-rpc-vc-exec-after-test"
+                             :buffer buffer
+                             :command '("sh" "-c" "sleep 60")
+                             :noquery t))
+         (ran nil))
+    (unwind-protect
+        (with-current-buffer buffer
+          (process-put proc :tramp-rpc-pid 123)
+          ;; Simulate native-compiled VC observing a raw relay state such as
+          ;; `closed' rather than the logical state from TRAMP-RPC advice.
+          (cl-letf (((symbol-function 'process-status)
+                     (lambda (_process) 'closed)))
+            (tramp-rpc--vc-exec-after-advice
+             (lambda (&rest _) (error "Unexpected process state"))
+             (lambda () (setq ran t))))
+          (should ran))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer buffer))))
+
+;;; ============================================================================
 ;;; Dir-locals advice tests (No server or SSH required)
 ;;; ============================================================================
 


### PR DESCRIPTION
## Summary
- add TRAMP-RPC-specific `vc-exec-after` advice that uses logical relay process state
- avoid blocking `accept-process-output` when VC/diff-hl runs with quit inhibited

## Testing
- `emacsclient --eval '(find-file "/rpc:t480-arthur:/home/arthur/src/qemu/")'`
- `rm -f lisp/*.elc && emacs -Q --batch -L /home/arthur/.emacs.d/.local/straight/build-30.2/msgpack -L /home/arthur/.emacs.d/.local/straight/build-30.2/tramp -L "/tmp/tramp-rpc-pr/lisp" --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/*.el`