### PR TITLE
fix: avoid blocking async process writes

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -36,7 +36,6 @@
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process")
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process")
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
-(declare-function tramp-rpc--handle-process-exit "tramp-rpc-process")
 
 ;; Functions from tramp-cmds.el
 
@@ -221,32 +220,10 @@ It will be added to `signal-process-functions'."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
       (cond
        ((process-get process :tramp-rpc-exited) 'exit)
-       ;; Remote process can exit in the gap before our async read callback
-       ;; marks :tramp-rpc-exited. Probe explicit remote status to avoid
-       ;; stale `process-live-p' true results that trigger extra iterations.
-       ((when-let* ((vec (and (process-get process :tramp-rpc-probe-remote-status)
-                              (process-get process :tramp-rpc-vec)))
-                    (pid (process-get process :tramp-rpc-pid)))
-          (let* ((status (tramp-rpc--call vec "process.status" `((pid . ,pid))))
-                 (exited (alist-get 'exited status))
-                 (exit-code (alist-get 'exit_code status)))
-            (when status
-                (when exited
-                  (unless (null exit-code)
-                    (process-put process :tramp-rpc-exit-code exit-code))
-                  ;; Schedule exit handling soon, but keep reporting local
-                  ;; relay liveness until it drains pending output.
-                  (unless (process-get process :tramp-rpc-exit-scheduled)
-                    (process-put process :tramp-rpc-exit-scheduled t)
-                    (run-at-time
-                     0 nil
-                     (lambda ()
-                       (when (processp process)
-                         (process-put process :tramp-rpc-exit-scheduled nil)
-                         (unless (process-get process :tramp-rpc-exited)
-                           (tramp-rpc--handle-process-exit process exit-code)))))))
-                nil))))
-       ;; Use orig-fun to check live status, not process-live-p (which would recurse)
+       ;; Use orig-fun to check live status, not process-live-p (which would recurse).
+       ;; Do not perform synchronous remote status RPCs here: callers such as
+       ;; mode-line redisplay, Flymake, and LSP process management may ask for
+       ;; process status while the user is typing.
        ((memq (funcall orig-fun process) '(run open listen connect)) 'run)
        (t 'exit))
     (funcall orig-fun process)))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -107,19 +107,20 @@ Returns plist with :stdout, :stderr, :exited, :exit-code."
 
 (defun tramp-rpc--write-remote-process (vec pid data)
   "Write DATA to stdin of remote process PID on VEC.
-Performs a synchronous RPC call so that callers like
-`start-file-process-shell-command' can rely on write visibility before
-the next `accept-process-output' poll."
-  ;; Native `process-send-string' writes into a local pipe synchronously.
-  ;; For parity, avoid fire-and-forget async writes here: tests and callers
-  ;; may perform immediate follow-up checks (file existence, process output)
-  ;; after sending input.
-  (let ((data-bytes (if (multibyte-string-p data)
-                        (encode-coding-string data 'utf-8-unix)
-                      data)))
-    (tramp-rpc--call vec "process.write"
-                     `((pid . ,pid)
-                       (data . ,(msgpack-bin-make data-bytes))))))
+Uses async RPC with queuing to preserve write order without making
+`process-send-string' wait for a remote round-trip.  This is important
+for LSP servers, where didChange notifications are sent while typing."
+  (let* ((queue-key pid)
+         (queue (gethash queue-key tramp-rpc--process-write-queues))
+         (pending (plist-get queue :pending))
+         (writing (plist-get queue :writing)))
+    ;; Add to pending queue.
+    (setq pending (append pending (list (list :vec vec :pid pid :data data))))
+    (puthash queue-key (list :pending pending :writing writing)
+             tramp-rpc--process-write-queues)
+    ;; If not currently writing, start processing the queue.
+    (unless writing
+      (tramp-rpc--process-write-queue queue-key))))
 
 (defun tramp-rpc--process-write-queue (queue-key)
   "Process the next pending write for QUEUE-KEY (remote PID)."
@@ -532,16 +533,10 @@ Resolves program path and loads direnv environment from working directory."
   "Start async process on remote host.
 NAME is the process name, BUFFER is the output buffer,
 PROGRAM is the command to run, ARGS are its arguments."
-  (let ((proc
-         (tramp-rpc-handle-make-process
-          :name name
-          :buffer buffer
-          :command (cons program args))))
-    ;; Only start-file-process style workloads need aggressive remote
-    ;; liveness probing to avoid async race windows in process-status.
-    (when (processp proc)
-      (process-put proc :tramp-rpc-probe-remote-status t))
-    proc))
+  (tramp-rpc-handle-make-process
+   :name name
+   :buffer buffer
+   :command (cons program args)))
 
 ;; ============================================================================
 ;; PTY Process Support

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -14,8 +14,9 @@ use std::ffi::CString;
 use std::io::ErrorKind;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::process::Stdio;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, Command};
+use std::sync::{Arc, OnceLock};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
 
 use super::HandlerResult;
@@ -23,8 +24,6 @@ use super::HandlerResult;
 // ============================================================================
 // Process management for async processes
 // ============================================================================
-
-use std::sync::OnceLock;
 
 static PROCESS_MAP: OnceLock<Mutex<HashMap<u32, ManagedProcess>>> = OnceLock::new();
 static PID_COUNTER: OnceLock<Mutex<u32>> = OnceLock::new();
@@ -43,6 +42,9 @@ async fn get_next_pid() -> u32 {
 
 struct ManagedProcess {
     child: Child,
+    stdin: Arc<Mutex<Option<ChildStdin>>>,
+    stdout: Arc<Mutex<Option<ChildStdout>>>,
+    stderr: Arc<Mutex<Option<ChildStderr>>>,
     cmd: String,
 }
 
@@ -170,13 +172,16 @@ pub async fn start(params: Value) -> HandlerResult {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    let child = cmd
+    let mut child = cmd
         .spawn()
         .map_err(|e| RpcError::process_error(format!("Failed to spawn process: {}", e)))?;
 
     let pid = get_next_pid().await;
 
     let managed = ManagedProcess {
+        stdin: Arc::new(Mutex::new(child.stdin.take())),
+        stdout: Arc::new(Mutex::new(child.stdout.take())),
+        stderr: Arc::new(Mutex::new(child.stderr.take())),
         child,
         cmd: params.cmd.clone(),
     };
@@ -203,12 +208,17 @@ pub async fn write(params: Value) -> HandlerResult {
     // Data is already binary, no decoding needed!
     let data = params.data;
 
-    let mut processes = get_process_map().lock().await;
-    let managed = processes
-        .get_mut(&params.pid)
-        .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
+    let stdin = {
+        let processes = get_process_map().lock().await;
+        processes
+            .get(&params.pid)
+            .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?
+            .stdin
+            .clone()
+    };
 
-    if let Some(stdin) = managed.child.stdin.as_mut() {
+    let mut stdin_guard = stdin.lock().await;
+    if let Some(stdin) = stdin_guard.as_mut() {
         stdin
             .write_all(&data)
             .await
@@ -241,27 +251,32 @@ pub async fn read(params: Value) -> HandlerResult {
 
     let timeout = params.timeout_ms.unwrap_or(0);
 
-    let mut processes = get_process_map().lock().await;
-    let managed = processes
-        .get_mut(&params.pid)
-        .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
-
-    // Try to read stdout (with optional blocking timeout)
-    let stdout_data = if let Some(stdout) = managed.child.stdout.as_mut() {
-        try_read_async_with_timeout(stdout, params.max_bytes, timeout).await
-    } else {
-        vec![]
+    let (stdout, stderr) = {
+        let processes = get_process_map().lock().await;
+        let managed = processes
+            .get(&params.pid)
+            .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
+        (managed.stdout.clone(), managed.stderr.clone())
     };
 
-    // Try to read stderr (with optional blocking timeout)
-    let stderr_data = if let Some(stderr) = managed.child.stderr.as_mut() {
-        try_read_async_with_timeout(stderr, params.max_bytes, timeout).await
-    } else {
-        vec![]
-    };
+    // Try to read stdout/stderr (with optional blocking timeout) without
+    // holding the global process map lock.  `process.read` is long-polled by
+    // the Emacs client; holding that lock here makes concurrent
+    // `process.write` calls wait behind the read timeout, which turns LSP
+    // typing into a synchronous round-trip bottleneck.
+    let (stdout_data, stderr_data) = tokio::join!(
+        try_read_optional_stream(stdout, params.max_bytes, timeout),
+        try_read_optional_stream(stderr, params.max_bytes, timeout)
+    );
 
-    // Check if process has exited
-    let exit_status = managed.child.try_wait().ok().flatten();
+    // Check if process has exited.  Reacquire the map briefly; do not hold it
+    // across any await points above.
+    let exit_status = {
+        let mut processes = get_process_map().lock().await;
+        processes
+            .get_mut(&params.pid)
+            .and_then(|managed| managed.child.try_wait().ok().flatten())
+    };
 
     // Return binary data directly (no encoding!)
     let stdout_val = if stdout_data.is_empty() {
@@ -284,8 +299,25 @@ pub async fn read(params: Value) -> HandlerResult {
     })
 }
 
-/// Try to read from an async reader with configurable timeout
-async fn try_read_async_with_timeout<R: tokio::io::AsyncRead + Unpin>(
+/// Try to read from an optional async reader with configurable timeout.
+async fn try_read_optional_stream<R>(
+    stream: Arc<Mutex<Option<R>>>,
+    max_bytes: usize,
+    timeout_ms: u64,
+) -> Vec<u8>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut stream_guard = stream.lock().await;
+    if let Some(reader) = stream_guard.as_mut() {
+        try_read_async_with_timeout(reader, max_bytes, timeout_ms).await
+    } else {
+        vec![]
+    }
+}
+
+/// Try to read from an async reader with configurable timeout.
+async fn try_read_async_with_timeout<R: AsyncRead + Unpin>(
     reader: &mut R,
     max_bytes: usize,
     timeout_ms: u64,
@@ -319,16 +351,21 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let mut processes = get_process_map().lock().await;
-    let managed = processes
-        .get_mut(&params.pid)
-        .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
+    let stdin = {
+        let processes = get_process_map().lock().await;
+        processes
+            .get(&params.pid)
+            .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?
+            .stdin
+            .clone()
+    };
 
     // Flush any buffered data before closing stdin, then drop to close the pipe.
     // This is a defensive measure: the client should drain its write queue before
     // calling close_stdin, but flushing here guards against data loss if a
     // concurrent process.write task wrote data that hasn't been flushed yet.
-    if let Some(mut stdin) = managed.child.stdin.take() {
+    let mut stdin_guard = stdin.lock().await;
+    if let Some(mut stdin) = stdin_guard.take() {
         let _ = stdin.flush().await;
         // stdin is dropped here, closing the pipe
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -157,6 +157,84 @@ mod tests {
         assert_eq!(response.error.unwrap().code, RpcError::METHOD_NOT_FOUND);
     }
 
+    fn map_get<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+        value.as_map().and_then(|m| {
+            m.iter()
+                .find(|(k, _)| k.as_str() == Some(key))
+                .map(|(_, v)| v)
+        })
+    }
+
+    #[tokio::test]
+    async fn test_process_write_not_blocked_by_long_poll_read() {
+        let start_params = Value::Map(vec![
+            (
+                Value::String("cmd".into()),
+                Value::String("/bin/cat".into()),
+            ),
+            (Value::String("cwd".into()), Value::String("/tmp".into())),
+        ]);
+        let start_payload = make_request("process.start", start_params);
+        let start_response = process_request(&start_payload).await;
+        assert!(
+            start_response.error.is_none(),
+            "process.start should not error"
+        );
+        let pid = map_get(start_response.result.as_ref().unwrap(), "pid")
+            .and_then(Value::as_u64)
+            .expect("process.start should return pid") as u32;
+
+        let read_payload = make_request(
+            "process.read",
+            Value::Map(vec![
+                (Value::String("pid".into()), Value::Integer(pid.into())),
+                (
+                    Value::String("timeout_ms".into()),
+                    Value::Integer(1_000.into()),
+                ),
+            ]),
+        );
+        let read_task = tokio::spawn(async move { process_request(&read_payload).await });
+
+        // Give the long-polling read request time to enter the handler.  If it
+        // holds the global process map lock across the read timeout,
+        // process.write below will be delayed by roughly timeout_ms.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let write_payload = make_request(
+            "process.write",
+            Value::Map(vec![
+                (Value::String("pid".into()), Value::Integer(pid.into())),
+                (
+                    Value::String("data".into()),
+                    Value::Binary(b"ping\n".to_vec()),
+                ),
+            ]),
+        );
+        let start = std::time::Instant::now();
+        let write_response = process_request(&write_payload).await;
+        let elapsed = start.elapsed();
+        assert!(
+            write_response.error.is_none(),
+            "process.write should not error"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "process.write was blocked behind process.read for {:?}",
+            elapsed
+        );
+
+        let _ = read_task.await;
+        let kill_payload = make_request(
+            "process.kill",
+            Value::Map(vec![
+                (Value::String("pid".into()), Value::Integer(pid.into())),
+                (Value::String("signal".into()), Value::Integer(9.into())),
+            ]),
+        );
+        let _ = process_request(&kill_payload).await;
+    }
+
     /// Test that process.run returns 128+signal for signal-killed processes.
     /// This is required by Emacs `process-file' (tramp-test28-process-file).
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make pipe process writes asynchronous and queued again so `process-send-string` does not wait for a remote RPC round-trip
- avoid synchronous remote `process.status` calls from `process-status` advice
- refactor server async process stdio so long-polling `process.read` does not hold the global process map lock while awaiting output
- add a regression test that `process.write` is not blocked by a long-poll `process.read`

Fixes #179.

## Testing
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p tramp-rpc-server` failed locally because rustup points at a missing Nix linker wrapper (`ld-wrapper.sh`)
- `nix develop -c cargo test -p tramp-rpc-server` timed out while building/downloading the Nix Rust toolchain
