### PR TITLE
ci: fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,17 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (without v prefix)'
+        description: "Version to release (without v prefix)"
         required: true
-        default: '0.3.0'
+        default: "0.3.0"
+
+permissions:
+  contents: read
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- grant the release workflow top-level read contents and OIDC token permissions
- keep the release creation job on contents: write

## Why
The v0.9.0 tag release run failed at startup because the reusable build workflow requests id-token: write for Nix setup, but the caller workflow did not grant it.

## Testing
- Not run locally; workflow-only change.