### PR TITLE
Fix recursive require during handler registration

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -32,6 +32,10 @@
 (require 'tramp)
 (require 'msgpack)
 
+;; Functions from tramp.el
+(declare-function tramp-add-external-operation "tramp")
+(declare-function tramp-remove-external-operation "tramp")
+
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process")
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process")
@@ -470,14 +474,19 @@ exited (remote side finished), delete it so the refresh can proceed."
     (tramp-add-external-operation
      'vc-exec-after
      #'tramp-rpc-handle-vc-exec-after 'tramp-rpc 'default-directory))
+  ;; If eglot/magit-process is already loaded while `tramp-rpc' is being
+  ;; required, defer registration until `tramp-rpc' is provided; otherwise
+  ;; `tramp-add-external-operation' calls `(require 'tramp-rpc)' recursively.
   (with-eval-after-load 'eglot
-    (tramp-add-external-operation
-     'eglot--cmd
-     #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory))
+    (with-eval-after-load 'tramp-rpc
+      (tramp-add-external-operation
+       'eglot--cmd
+       #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory)))
   (with-eval-after-load 'magit-process
-    (tramp-add-external-operation
-     'magit-start-process
-     #'tramp-rpc-handle-magit-start-process 'tramp-rpc 'default-directory))
+    (with-eval-after-load 'tramp-rpc
+      (tramp-add-external-operation
+       'magit-start-process
+       #'tramp-rpc-handle-magit-start-process 'tramp-rpc 'default-directory)))
   (with-eval-after-load 'tramp-rpc
     (tramp-add-external-operation
      'vc-dir-refresh

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -31,6 +31,10 @@
 (require 'cl-lib)
 (require 'tramp)
 
+;; Functions from tramp.el
+(declare-function tramp-add-external-operation "tramp")
+(declare-function tramp-remove-external-operation "tramp")
+
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -30,6 +30,10 @@
 (require 'tramp)
 (require 'tramp-rpc-protocol)
 
+;; Functions from tramp.el
+(declare-function tramp-add-external-operation "tramp")
+(declare-function tramp-remove-external-operation "tramp")
+
 ;; Silence byte-compiler warnings for variables defined in vterm
 (defvar vterm-copy-mode)
 (defvar vterm-min-window-width)
@@ -1036,18 +1040,22 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
 ;; Forward declare for cleanup
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 
-;; Install terminal emulator handler
+;; Install terminal emulator handler.  When vterm/eat is already loaded while
+;; `tramp-rpc' is being required, defer until `tramp-rpc' is provided; otherwise
+;; `tramp-add-external-operation' calls `(require 'tramp-rpc)' recursively.
 (with-eval-after-load 'vterm
-  (tramp-add-external-operation
-   'vterm--window-adjust-process-window-size
-   #'tramp-rpc-handle-vterm--window-adjust-process-window-size
-   'tramp-rpc 'process))
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'vterm--window-adjust-process-window-size
+     #'tramp-rpc-handle-vterm--window-adjust-process-window-size
+     'tramp-rpc 'process)))
 
 (with-eval-after-load 'eat
-  (tramp-add-external-operation
-   'eat--adjust-process-window-size
-   #'tramp-rpc-handle-eat--adjust-process-window-size
-   'tramp-rpc 'process))
+  (with-eval-after-load 'tramp-rpc
+    (tramp-add-external-operation
+     'eat--adjust-process-window-size
+     #'tramp-rpc-handle-eat--adjust-process-window-size
+     'tramp-rpc 'process)))
 
 (defun tramp-rpc--process-handler-remove ()
   "Remove handlers."


### PR DESCRIPTION
## Summary
- defer external operation registration until tramp-rpc is provided when optional packages are already loaded
- add missing declare-function forms for TRAMP external operation helpers

## Tests
- test/run-autoload-tests.sh
- emacs -Q batch repro with eglot preloaded
- emacs -Q batch repro with magit-process preloaded
- emacs -Q batch repro with vterm/eat provided
- byte-compile lisp/*.el with byte-compile-error-on-warn