### PR TITLE
cleanup: post-0.9.0 cleanups from Michael Albinus

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 
 * Installation
 
-** From MELPA (coming soon)
+** From NonGNU ELPA (coming soon)
 
 #+begin_src elisp
 (use-package tramp-rpc
@@ -281,7 +281,7 @@ cargo build --release --target aarch64-unknown-linux-gnu
 (setq tramp-rpc-deploy-prefer-build t)
 
 ;; Local cache directory (default: ~/.emacs.d/tramp-rpc/)
-(setq tramp-rpc-deploy-local-cache-directory "~/.cache/tramp-rpc-binaries")
+(setq tramp-rpc-deploy-local-cache-directory "~/.cache/emacs/tramp-rpc-binaries")
 
 ;; Remote installation directory (default: ~/.cache/emacs/tramp-rpc)
 (setq tramp-rpc-deploy-remote-directory "~/.local/bin/tramp-rpc")

--- a/doc/TECHNICAL_COMPARISON.org
+++ b/doc/TECHNICAL_COMPARISON.org
@@ -366,7 +366,7 @@ On first connection, TRAMP-RPC:
 2. Selects appropriate pre-compiled binary (from local cache or GitHub Releases)
 3. Transfers via scp (scpx method) with retry support
 4. Verifies SHA256 checksum
-5. Makes executable and stores in ~/.cache/tramp-rpc/
+5. Makes executable and stores in ~/.cache/emacs/tramp-rpc/
 
 #+begin_src elisp
 (defun tramp-rpc-deploy-ensure-binary (vec)

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -25,7 +25,8 @@
 ;; - vc-call-backend (ensure default-directory for remote VC files)
 ;; - vc-exec-after (handle native-compiled VC process state races)
 ;; - eglot--cmd (bypass shell wrapping for RPC connections)
-;; - hack-dir-local-variables (enable dir-locals for RPC remotes)
+;; - magit-start-process (force pipe mode when INPUT will be piped to the process)
+;; - vc-dir-refresh (clean up stale processes)
 
 ;;; Code:
 
@@ -419,22 +420,6 @@ exited (remote side finished), delete it so the refresh can proceed."
   (tramp-run-real-handler 'vc-dir-refresh nil))
 
 ;; ============================================================================
-;; Dir-locals advice
-;; ============================================================================
-
-;; Emacs's `enable-remote-dir-locals' defaults to nil because looking for
-;; .dir-locals.el on remote hosts can be slow for traditional TRAMP methods.
-;; TRAMP-RPC uses a fast binary protocol and dedicated high-level operations,
-;; so enable this only for buffers using the rpc method.
-(defun tramp-rpc--hack-dir-local-variables-advice (orig-fun)
-  "Enable remote dir-locals in `hack-dir-local-variables' for RPC files."
-  (let ((enable-remote-dir-locals
-         (or enable-remote-dir-locals
-             (when-let* ((file (or (buffer-file-name) default-directory)))
-               (tramp-rpc-file-name-p file)))))
-    (funcall orig-fun)))
-
-;; ============================================================================
 ;; Install and uninstall handler
 ;; ============================================================================
 
@@ -491,9 +476,7 @@ exited (remote side finished), delete it so the refresh can proceed."
     (tramp-add-external-operation
      'vc-dir-refresh
      #'tramp-rpc-handle-vc-dir-refresh 'tramp-rpc
-     #'tramp-rpc--vc-dir-refresh-file-name-for-operation))
-  (advice-add 'hack-dir-local-variables :around
-              #'tramp-rpc--hack-dir-local-variables-advice))
+     #'tramp-rpc--vc-dir-refresh-file-name-for-operation)))
 
 (defun tramp-rpc-handler-remove ()
   "Remove all process handler installed by tramp-rpc."
@@ -509,8 +492,7 @@ exited (remote side finished), delete it so the refresh can proceed."
   (tramp-remove-external-operation 'vc-exec-after 'tramp-rpc)
   (tramp-remove-external-operation 'eglot--cmd 'tramp-rpc)
   (tramp-remove-external-operation 'magit-start-process 'tramp-rpc)
-  (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc)
-  (advice-remove 'hack-dir-local-variables #'tramp-rpc--hack-dir-local-variables-advice))
+  (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc))
 
 (defcustom tramp-rpc-install-handler-on-load t
   "Whether to install process handler when tramp-rpc-advice is loaded.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -169,7 +169,6 @@ This is called from `tramp-multi-hop-p-hook'."
   (setcdr rpc-entry ssh-params))
 
 ;; Silence byte-compiler warnings for functions defined in with-eval-after-load
-;; (declare-function tramp-rpc-handler-remove "tramp-rpc-advice")
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
@@ -3269,10 +3268,6 @@ Also controls process exit detection latency."
     ;; RPC-based path and VC operations
     ;; =========================================================================
     (expand-file-name . tramp-rpc-handle-expand-file-name)
-    ;; Not needed.  They are added by `tramp-add-external-operation'.
-    ;; (locate-dominating-file . tramp-rpc-handle-locate-dominating-file)
-    ;; (dir-locals--all-files . tramp-rpc-handle-dir-locals--all-files)
-    ;; (dir-locals-find-file . tramp-rpc-handle-dir-locals-find-file)
     (vc-registered . tramp-rpc-handle-vc-registered)
 
     ;; =========================================================================
@@ -3475,7 +3470,6 @@ Removes advice and cleans up async processes."
   (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
   ;; Remove all advice (from tramp-rpc-advice module)
   ;; Not needed. This is called in `tramp-rpc-advice-unload-function'.
-  ;; (tramp-rpc-handler-remove)
   ;; Remove multi-hop hook and cleanup hooks.
   (remove-hook 'tramp-multi-hop-p-hook #'tramp-rpc-multi-hop-p)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)


### PR DESCRIPTION
Applied cleanups from Michael Albinus (TRAMP maintainer).

Changes:
- Remove `hack-dir-local-variables` advice (discussed previously with Michael)
- Update README: MELPA → NonGNU ELPA, fix cache directory path (`~/.cache/emacs/tramp-rpc-binaries`)
- Update TECHNICAL_COMPARISON: fix cache directory path
- Clean up commented-out code in tramp-rpc.el
- Update header comments to reflect actual handlers (`magit-start-process`, `vc-dir-refresh`)

See email from Michael Albinus dated 2026-05-03.