### PR TITLE
Handle RPC transport loss for child processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,35 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+  upstream-tramp:
+    name: Prepare upstream Tramp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone upstream tramp
+        run: |
+          git clone --depth 1 https://github.com/emacsmirror/tramp.git upstream-tramp
+          echo "Tramp commit: $(git -C upstream-tramp rev-parse HEAD)"
+          # Generate trampver.el from the autoconf template.  The git
+          # repo only ships trampver.el.in; without a generated
+          # trampver.el Emacs falls back to its bundled copy whose
+          # version string is too old for tramp-rpc.
+          VERSION=$(grep -oP 'AC_INIT\(\[Tramp\],\s*\[\K[^\]]+' upstream-tramp/configure.ac)
+          echo "Upstream Tramp version: $VERSION"
+          sed -e "s/@PACKAGE_VERSION@/$VERSION/g" \
+              -e "s/@PACKAGE_BUGREPORT@/tramp-devel@gnu.org/g" \
+              -e "s/@EMACS_REQUIRED_VERSION@/28.1/g" \
+              -e 's|@PACKAGE_URL@|https://www.gnu.org/software/tramp/|g' \
+              -e 's/@TRAMP_EMACS_VERSION_CHECK@/"ok"/g' \
+              -e 's/@configure_input@/Generated from trampver.el.in for CI/g' \
+              upstream-tramp/lisp/trampver.el.in > upstream-tramp/lisp/trampver.el
+
+      - name: Upload upstream tramp
+        uses: actions/upload-artifact@v7
+        with:
+          name: upstream-tramp-source
+          path: upstream-tramp/
+          retention-days: 1
+
   elisp:
     name: Emacs Lisp
     runs-on: ubuntu-latest
@@ -231,7 +260,7 @@ jobs:
   test-multi-hop:
     name: Multi-Hop Tests
     runs-on: ubuntu-latest
-    needs: elisp
+    needs: [elisp, upstream-tramp]
 
     steps:
       - name: Checkout
@@ -242,10 +271,11 @@ jobs:
         with:
           version: '30.1'
 
-      - name: Clone upstream tramp
-        run: |
-          git clone --depth 1 https://github.com/emacsmirror/tramp.git ~/src/tramp
-          echo "Tramp commit: $(git -C ~/src/tramp rev-parse HEAD)"
+      - name: Download upstream tramp
+        uses: actions/download-artifact@v8
+        with:
+          name: upstream-tramp-source
+          path: upstream-tramp/
 
       - name: Install dependencies
         run: |
@@ -266,7 +296,7 @@ jobs:
         run: |
           emacs -Q --batch \
             -L lisp \
-            -L ~/src/tramp/lisp \
+            -L upstream-tramp/lisp \
             --eval "(require 'package)" \
             --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
             --eval "(package-initialize)" \
@@ -325,7 +355,7 @@ jobs:
   test-full-suite:
     name: Full Test Suite (with SSH)
     runs-on: ubuntu-latest
-    needs: [rust-linux, elisp]
+    needs: [rust-linux, elisp, upstream-tramp]
 
     steps:
       - name: Checkout
@@ -335,6 +365,12 @@ jobs:
         uses: purcell/setup-emacs@master
         with:
           version: '30.1'
+
+      - name: Download upstream tramp
+        uses: actions/download-artifact@v8
+        with:
+          name: upstream-tramp-source
+          path: upstream-tramp/
 
       - name: Download server binary
         uses: actions/download-artifact@v8
@@ -392,6 +428,7 @@ jobs:
           TRAMP_RPC_TEST_HOST: localhost
         run: |
           emacs -Q --batch \
+            -L upstream-tramp/lisp \
             --eval "(require 'package)" \
             --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
             --eval "(package-initialize)" \
@@ -403,7 +440,7 @@ jobs:
   test-upstream-tramp:
     name: Upstream Tramp Tests
     runs-on: ubuntu-latest
-    needs: [rust-linux, elisp]
+    needs: [rust-linux, elisp, upstream-tramp]
 
     steps:
       - name: Checkout
@@ -414,23 +451,11 @@ jobs:
         with:
           version: '30.1'
 
-      - name: Clone upstream tramp
-        run: |
-          git clone --depth 1 https://github.com/emacsmirror/tramp.git ~/src/tramp
-          echo "Tramp commit: $(git -C ~/src/tramp rev-parse HEAD)"
-          # Generate trampver.el from the autoconf template.  The git
-          # repo only ships trampver.el.in; without a generated
-          # trampver.el Emacs falls back to its bundled copy whose
-          # version string is too old for tramp-rpc.
-          VERSION=$(grep -oP 'AC_INIT\(\[Tramp\],\s*\[\K[^\]]+' ~/src/tramp/configure.ac)
-          echo "Upstream Tramp version: $VERSION"
-          sed -e "s/@PACKAGE_VERSION@/$VERSION/g" \
-              -e "s/@PACKAGE_BUGREPORT@/tramp-devel@gnu.org/g" \
-              -e "s/@EMACS_REQUIRED_VERSION@/28.1/g" \
-              -e 's|@PACKAGE_URL@|https://www.gnu.org/software/tramp/|g' \
-              -e 's/@TRAMP_EMACS_VERSION_CHECK@/"ok"/g' \
-              -e 's/@configure_input@/Generated from trampver.el.in for CI/g' \
-              ~/src/tramp/lisp/trampver.el.in > ~/src/tramp/lisp/trampver.el
+      - name: Download upstream tramp
+        uses: actions/download-artifact@v8
+        with:
+          name: upstream-tramp-source
+          path: upstream-tramp/
 
       - name: Download server binary
         uses: actions/download-artifact@v8
@@ -479,7 +504,7 @@ jobs:
       - name: Run upstream tramp tests
         env:
           TRAMP_RPC_TEST_HOST: localhost
-          TRAMP_TEST_SOURCE: ~/src/tramp
+          TRAMP_TEST_SOURCE: ${{ github.workspace }}/upstream-tramp
         run: |
           # Exclude known unfixable tests:
           #   :unstable: not recommended by upstream Tramp
@@ -496,7 +521,7 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [rust-linux, rust-macos, rust-extra, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
+    needs: [rust-linux, rust-macos, rust-extra, format, upstream-tramp, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
     if: always()
 
     steps:
@@ -506,6 +531,8 @@ jobs:
           echo "Rust Linux: ${{ needs.rust-linux.result }}"
           echo "Rust macOS: ${{ needs.rust-macos.result }}"
           echo "Rust Extra: ${{ needs.rust-extra.result }}"
+          echo "Rust Format: ${{ needs.format.result }}"
+          echo "Upstream Tramp Prep: ${{ needs.upstream-tramp.result }}"
           echo "Elisp: ${{ needs.elisp.result }}"
           echo "Autoload Tests: ${{ needs.test-autoload.result }}"
           echo "Protocol Tests: ${{ needs.test-protocol.result }}"
@@ -517,6 +544,8 @@ jobs:
           if [[ "${{ needs.rust-linux.result }}" != "success" ]] || \
              [[ "${{ needs.rust-macos.result }}" != "success" ]] || \
              [[ "${{ needs.rust-extra.result }}" != "success" ]] || \
+             [[ "${{ needs.format.result }}" != "success" ]] || \
+             [[ "${{ needs.upstream-tramp.result }}" != "success" ]] || \
              [[ "${{ needs.elisp.result }}" != "success" ]] || \
              [[ "${{ needs.test-autoload.result }}" != "success" ]] || \
              [[ "${{ needs.test-protocol.result }}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: ['30.1']
+        emacs_version: ["30.1"]
 
     steps:
       - name: Checkout
@@ -198,7 +198,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Install dependencies
         run: |
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Install dependencies
         run: |
@@ -269,7 +269,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Download upstream tramp
         uses: actions/download-artifact@v8
@@ -304,6 +304,18 @@ jobs:
             -l test/tramp-rpc-mock-tests.el \
             --eval "(ert-run-tests-batch-and-exit '(tag :multi-hop))"
 
+      - name: Run connection cleanup tests
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            -L upstream-tramp/lisp \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(setq debug-on-error t)" \
+            -l test/tramp-rpc-mock-tests.el \
+            --eval "(ert-run-tests-batch-and-exit '(tag :connection-cleanup))"
+
   test-server:
     name: Server Integration Tests
     runs-on: ubuntu-latest
@@ -316,7 +328,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Download server binary
         uses: actions/download-artifact@v8
@@ -364,7 +376,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Download upstream tramp
         uses: actions/download-artifact@v8
@@ -449,7 +461,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: '30.1'
+          version: "30.1"
 
       - name: Download upstream tramp
         uses: actions/download-artifact@v8
@@ -521,7 +533,21 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [rust-linux, rust-macos, rust-extra, format, upstream-tramp, elisp, test-autoload, test-protocol, test-multi-hop, test-server, test-full-suite, test-upstream-tramp]
+    needs:
+      [
+        rust-linux,
+        rust-macos,
+        rust-extra,
+        format,
+        upstream-tramp,
+        elisp,
+        test-autoload,
+        test-protocol,
+        test-multi-hop,
+        test-server,
+        test-full-suite,
+        test-upstream-tramp,
+      ]
     if: always()
 
     steps:

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -263,8 +263,12 @@ process's exit status rather than cat's."
     (let* ((info (gethash proc tramp-rpc--async-processes))
            (vec (plist-get info :vec))
            (pid (plist-get info :pid)))
-      ;; Kill remote process if still running (unexpected cat death)
-      (unless (process-get proc :tramp-rpc-exited)
+      ;; Kill remote process if still running (unexpected cat death).
+      ;; When the RPC transport itself is gone, do not try to kill the remote
+      ;; PID via `tramp-rpc--kill-remote-process': that would reconnect a new
+      ;; server just to report that the old PID no longer exists.
+      (unless (or (process-get proc :tramp-rpc-exited)
+                  (process-get proc :tramp-rpc-connection-lost))
         (when (and vec pid)
           (ignore-errors
             (tramp-rpc--kill-remote-process vec pid 9))))
@@ -292,46 +296,51 @@ RESPONSE is the decoded RPC response plist."
              (process-live-p local-process)
              (gethash local-process tramp-rpc--async-processes))
     (condition-case err
-        (let* ((info (gethash local-process tramp-rpc--async-processes))
-               (stderr-buffer (plist-get info :stderr-buffer))
-               (result (plist-get response :result))
-               (stdout (when-let* ((s (alist-get 'stdout result)))
-                         (tramp-rpc--decode-output
-                          s (alist-get 'stdout_encoding result))))
-               (stderr (when-let* ((s (alist-get 'stderr result)))
-                         (tramp-rpc--decode-output
-                          s (alist-get 'stderr_encoding result))))
-               (exited (alist-get 'exited result))
-               (exit-code (alist-get 'exit_code result)))
+        (if (tramp-rpc-protocol-error-p response)
+            (progn
+              (tramp-rpc--debug "ASYNC-READ RPC error: %s"
+                                (tramp-rpc-protocol-error-message response))
+              (tramp-rpc--handle-process-exit local-process 255))
+          (let* ((info (gethash local-process tramp-rpc--async-processes))
+                 (stderr-buffer (plist-get info :stderr-buffer))
+                 (result (plist-get response :result))
+                 (stdout (when-let* ((s (alist-get 'stdout result)))
+                           (tramp-rpc--decode-output
+                            s (alist-get 'stdout_encoding result))))
+                 (stderr (when-let* ((s (alist-get 'stderr result)))
+                           (tramp-rpc--decode-output
+                            s (alist-get 'stderr_encoding result))))
+                 (exited (alist-get 'exited result))
+                 (exit-code (alist-get 'exit_code result)))
 
-          (tramp-rpc--debug "ASYNC-READ response: stdout=%s stderr=%s exited=%s"
-                           (if stdout (length stdout) "nil")
-                           (if stderr (length stderr) "nil")
-                           exited)
+            (tramp-rpc--debug "ASYNC-READ response: stdout=%s stderr=%s exited=%s"
+                              (if stdout (length stdout) "nil")
+                              (if stderr (length stderr) "nil")
+                              exited)
 
-          ;; Deliver output.  When the remote process reports EXITED, flush
-          ;; data immediately before sending EOF to the local relay; otherwise
-          ;; the deferred delivery can race with relay shutdown and lose output.
-          (if exited
+            ;; Deliver output.  When the remote process reports EXITED, flush
+            ;; data immediately before sending EOF to the local relay; otherwise
+            ;; the deferred delivery can race with relay shutdown and lose output.
+            (if exited
+                (when (or stdout stderr)
+                  (tramp-rpc--deliver-process-output
+                   local-process stdout stderr stderr-buffer))
+              ;; Keep deferred delivery for the non-exit hot path so
+              ;; accept-process-output observes normal I/O activity.
               (when (or stdout stderr)
-                (tramp-rpc--deliver-process-output
-                 local-process stdout stderr stderr-buffer))
-            ;; Keep deferred delivery for the non-exit hot path so
-            ;; accept-process-output observes normal I/O activity.
-            (when (or stdout stderr)
-              (run-at-time 0 nil #'tramp-rpc--deliver-process-output
-                           local-process stdout stderr stderr-buffer)))
+                (run-at-time 0 nil #'tramp-rpc--deliver-process-output
+                             local-process stdout stderr stderr-buffer)))
 
-          ;; Handle process exit or chain next read
-          (if exited
-              ;; Handle exit immediately so `process-live-p' flips to nil
-              ;; before callers can issue another round of remote operations.
-              ;; Deferring this via `run-at-time 0' leaves a small window where
-              ;; loops that poll `process-live-p' can observe a stale live
-              ;; process and run one extra iteration.
-              (tramp-rpc--handle-process-exit local-process exit-code)
-            ;; Chain another read - use run-at-time to avoid stack overflow
-            (run-at-time 0 nil #'tramp-rpc--start-async-read local-process)))
+            ;; Handle process exit or chain next read
+            (if exited
+                ;; Handle exit immediately so `process-live-p' flips to nil
+                ;; before callers can issue another round of remote operations.
+                ;; Deferring this via `run-at-time 0' leaves a small window where
+                ;; loops that poll `process-live-p' can observe a stale live
+                ;; process and run one extra iteration.
+                (tramp-rpc--handle-process-exit local-process exit-code)
+              ;; Chain another read - use run-at-time to avoid stack overflow
+              (run-at-time 0 nil #'tramp-rpc--start-async-read local-process))))
       (error
        (tramp-rpc--debug "ASYNC-READ-ERROR: %S" err)
        ;; On error, clean up
@@ -800,28 +809,30 @@ RESPONSE is the decoded RPC response plist."
              (process-live-p local-process)
              (gethash local-process tramp-rpc--pty-processes))
     (condition-case nil
-        (let* ((result (plist-get response :result))
-               (output (when-let* ((o (alist-get 'output result)))
-                         (tramp-rpc--decode-output
-                          o (alist-get 'output_encoding result))))
-               (exited (alist-get 'exited result))
-                (exit-code (alist-get 'exit_code result)))
+        (if (tramp-rpc-protocol-error-p response)
+            (tramp-rpc--handle-pty-exit local-process 255)
+          (let* ((result (plist-get response :result))
+                 (output (when-let* ((o (alist-get 'output result)))
+                           (tramp-rpc--decode-output
+                            o (alist-get 'output_encoding result))))
+                 (exited (alist-get 'exited result))
+                 (exit-code (alist-get 'exit_code result)))
 
-          ;; Deliver output via filter
-          (when (and output (> (length output) 0))
-            (if-let* ((filter (process-filter local-process)))
-                (funcall filter local-process output)
-              (when-let* ((buf (process-buffer local-process)))
-                (when (buffer-live-p buf)
-                  (with-current-buffer buf
-                    (goto-char (point-max))
-                    (insert output))))))
+            ;; Deliver output via filter
+            (when (and output (> (length output) 0))
+              (if-let* ((filter (process-filter local-process)))
+                  (funcall filter local-process output)
+                (when-let* ((buf (process-buffer local-process)))
+                  (when (buffer-live-p buf)
+                    (with-current-buffer buf
+                      (goto-char (point-max))
+                      (insert output))))))
 
-          ;; Handle process exit or chain next read
-          (if exited
-              (tramp-rpc--handle-pty-exit local-process exit-code)
-            ;; Chain another read immediately
-            (tramp-rpc--pty-start-async-read local-process)))
+            ;; Handle process exit or chain next read
+            (if exited
+                (tramp-rpc--handle-pty-exit local-process exit-code)
+              ;; Chain another read immediately
+              (tramp-rpc--pty-start-async-read local-process))))
       (error
        ;; On error, clean up
        (tramp-rpc--handle-pty-exit local-process nil)))))
@@ -858,15 +869,24 @@ RESPONSE is the decoded RPC response plist."
 PROCESS is the local relay process, EVENT is the process event."
   ;; Handle local process termination (e.g., user killed it)
   (when (memq (process-status process) '(exit signal))
-    ;; Clean up remote PTY if still tracked
+    ;; Clean up remote PTY if still tracked.  Skip the remote RPC when the
+    ;; transport was already lost; otherwise this sentinel could reconnect a
+    ;; new server just to kill an old, invalid PID.
     (when (gethash process tramp-rpc--pty-processes)
-      (when-let* ((vec (process-get process :tramp-rpc-vec))
-                 (pid (process-get process :tramp-rpc-pid)))
-        (ignore-errors
-          (tramp-rpc--call vec "process.kill_pty"
-                           `((pid . ,pid) (signal . 9)))))
+      (unless (process-get process :tramp-rpc-connection-lost)
+        (when-let* ((vec (process-get process :tramp-rpc-vec))
+                    (pid (process-get process :tramp-rpc-pid)))
+          (ignore-errors
+            (tramp-rpc--call vec "process.kill_pty"
+                             `((pid . ,pid) (signal . 9))))))
       ;; Remove from tracking
       (remhash process tramp-rpc--pty-processes))
+    ;; Use the remote/connection-lost exit code for the event string when
+    ;; available, matching `tramp-rpc--pipe-process-sentinel'.
+    (when-let* ((remote-exit (process-get process :tramp-rpc-exit-code)))
+      (setq event (if (= remote-exit 0)
+                      "finished\n"
+                    (format "exited abnormally with code %d\n" remote-exit))))
     ;; Call user sentinel
     (when-let* ((user-sentinel (process-get process :tramp-rpc-user-sentinel)))
       (funcall user-sentinel process event))))
@@ -996,28 +1016,35 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
 ;; Process cleanup
 ;; ============================================================================
 
-(defun tramp-rpc--cleanup-pty-processes (&optional vec)
-  "Clean up PTY processes, optionally only those for VEC."
+(defun tramp-rpc--cleanup-pty-processes (&optional vec connection-lost)
+  "Clean up PTY processes, optionally only those for VEC.
+When CONNECTION-LOST is non-nil, do not issue remote kill RPCs."
   (maphash
    (lambda (local-process info)
      (when (or (null vec)
                (equal (tramp-rpc--connection-key (plist-get info :vec))
                       (tramp-rpc--connection-key vec)))
-       ;; Kill remote PTY
-       (when-let* ((pv (plist-get info :vec))
-                   (pid (plist-get info :pid)))
-         (ignore-errors
-           (tramp-rpc--call pv "process.kill_pty"
-                            `((pid . ,pid) (signal . 9)))))
+       ;; Kill remote PTY unless the transport is already gone.
+       (unless connection-lost
+         (when-let* ((pv (plist-get info :vec))
+                     (pid (plist-get info :pid)))
+           (ignore-errors
+             (tramp-rpc--call pv "process.kill_pty"
+                              `((pid . ,pid) (signal . 9))))))
        ;; Kill local process
        (when (process-live-p local-process)
+         (when connection-lost
+           (process-put local-process :tramp-rpc-connection-lost t)
+           (process-put local-process :tramp-rpc-exit-code 255))
          (delete-process local-process))
        ;; Remove from tracking
        (remhash local-process tramp-rpc--pty-processes)))
    tramp-rpc--pty-processes))
 
-(defun tramp-rpc--cleanup-async-processes (&optional vec)
-  "Clean up async processes, optionally only those for VEC."
+(defun tramp-rpc--cleanup-async-processes (&optional vec connection-lost)
+  "Clean up async processes, optionally only those for VEC.
+When CONNECTION-LOST is non-nil, relay sentinels report an abnormal exit
+without trying to kill remote PIDs through the broken RPC connection."
   (maphash
    (lambda (local-process info)
      (when (or (null vec)
@@ -1030,8 +1057,14 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
        (when-let* ((stderr-process (plist-get info :stderr-process)))
          (when (process-live-p stderr-process)
            (ignore-errors (delete-process stderr-process))))
+       ;; Clean up queued writes for the old remote PID.
+       (when-let* ((pid (plist-get info :pid)))
+         (remhash pid tramp-rpc--process-write-queues))
        ;; Kill local process
        (when (process-live-p local-process)
+         (when connection-lost
+           (process-put local-process :tramp-rpc-connection-lost t)
+           (process-put local-process :tramp-rpc-exit-code 255))
          (delete-process local-process))
        ;; Remove from tracking
        (remhash local-process tramp-rpc--async-processes)))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1182,13 +1182,20 @@ Kills the process if still alive and removes the connection entry."
 
 (defun tramp-rpc--cleanup-bootstrap-connection (vec)
   "Close the scpx/scp bootstrap connection for VEC if it exists.
-The bootstrap connection is only needed during deploy and should be
-closed afterward to prevent other packages (vc, diff-hl) from
-accidentally routing file operations through tramp-sh."
-  (let* ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
-         (proc (tramp-get-connection-process bootstrap-vec)))
-    (when (and proc (process-live-p proc))
-      (delete-process proc))))
+The bootstrap connection is only needed during deploy.  Leaving it in
+TRAMP's connection cache lets unrelated timers (vc, diff-hl, etc.) keep
+using tramp-sh for the same host while tramp-rpc is active.  In
+particular, tramp-sh's periodic `echo are you awake' liveness probe can
+interleave with timer driven file operations and corrupt the Lisp-reader
+protocol buffer.  Remove the cached connection completely, not just the
+process, so subsequent operations use the rpc handler instead."
+  (let ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec)))
+    (when (or (process-live-p (tramp-get-connection-process bootstrap-vec))
+              (tramp-connection-property-p bootstrap-vec "process-buffer")
+              (tramp-connection-property-p bootstrap-vec " process-buffer")
+              (tramp-connection-property-p bootstrap-vec " connected"))
+      (tramp-cleanup-connection
+       bootstrap-vec 'keep-debug 'keep-password 'keep-processes))))
 
 (defun tramp-rpc--connect (vec)
   "Establish an RPC connection to VEC."
@@ -1221,7 +1228,12 @@ accidentally routing file operations through tramp-sh."
       ;; Never-deploy mode: use the configured path directly, no fallback.
       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
         (condition-case err
-            (tramp-rpc--start-server-process vec binary-path)
+            (progn
+              ;; No deployment is happening in this mode; remove any stale
+              ;; bootstrap shell before the RPC startup probe exchanges
+              ;; `system.info' with the server.
+              (tramp-rpc--cleanup-bootstrap-connection vec)
+              (tramp-rpc--start-server-process vec binary-path))
           (remote-file-error
            (tramp-rpc--cleanup-failed-connection vec)
            (signal 'remote-file-error
@@ -1237,17 +1249,27 @@ accidentally routing file operations through tramp-sh."
     ;; version bump), SSH exits immediately, we catch the error, deploy
     ;; via scpx, and retry.
     (condition-case nil
-        (tramp-rpc--start-server-process
-         vec (tramp-rpc-deploy-expected-binary-localname))
+        (progn
+          ;; A bootstrap connection may exist from an earlier deployment in
+          ;; this Emacs session.  Remove it before the direct RPC startup probe
+          ;; so tramp-sh timers cannot interleave with the `system.info'
+          ;; exchange performed by `tramp-rpc--start-server-process'.
+          (tramp-rpc--cleanup-bootstrap-connection vec)
+          (tramp-rpc--start-server-process
+           vec (tramp-rpc-deploy-expected-binary-localname)))
       (remote-file-error
        ;; Connection failed - binary likely missing.  Clean up and deploy.
        (tramp-rpc--cleanup-failed-connection vec)
-       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
-         ;; Close the bootstrap connection - it's no longer needed and
-         ;; leaving it alive can cause vc/diff-hl sentinels to route
-         ;; file operations through tramp-sh instead of tramp-rpc.
-         (tramp-rpc--cleanup-bootstrap-connection vec)
-         (tramp-rpc--start-server-process vec binary-path))))))
+       ;; Close the bootstrap connection after any deploy attempt - it's no
+       ;; longer needed and leaving it alive can cause vc/diff-hl sentinels to
+       ;; route file operations through tramp-sh instead of tramp-rpc.  Cover
+       ;; both deploy failures and retry startup failures, and clean it before
+       ;; the retry startup probe if deployment succeeded.
+       (unwind-protect
+           (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
+             (tramp-rpc--cleanup-bootstrap-connection vec)
+             (tramp-rpc--start-server-process vec binary-path))
+         (tramp-rpc--cleanup-bootstrap-connection vec))))))
 
 (defun tramp-rpc--disconnect (vec)
   "Disconnect the RPC connection to VEC."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -417,6 +417,8 @@ Key is (host user port hop), value is a plist with :process and :buffer.")
 
 ;; tramp-rpc--async-processes and tramp-rpc--pty-processes are defined in
 ;; tramp-rpc-process.el (loaded via require below)
+(declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
+(declare-function tramp-rpc--cleanup-pty-processes "tramp-rpc-process")
 
 (defvar tramp-rpc--async-callbacks (make-hash-table :test 'eql)
   "Hash table mapping request IDs to callback functions for async RPC calls.")
@@ -709,6 +711,56 @@ Also clears the executable, exec-path, and login shell caches."
     (remhash key tramp-rpc--login-shell-cache))
   (tramp-rpc--clear-executable-cache vec))
 
+(defun tramp-rpc--connection-lost (vec &optional process event)
+  "Clean up VEC after its RPC transport PROCESS is lost.
+EVENT is a diagnostic string from the process sentinel or timeout.
+
+This is intentionally stronger than just removing the RPC server
+connection: remote child processes (for example gopls started by
+lsp-mode) are tied to that server instance.  If the SSH/RPC transport
+is gone, their remote PIDs are no longer meaningful, so the local relay
+processes must be terminated as well.  That lets process clients observe
+an abnormal process exit and restart instead of keeping a live but
+silent relay around."
+  (let ((conn (tramp-rpc--get-connection vec))
+        (connecting (and process (process-get process :tramp-rpc-connecting))))
+    ;; If PROCESS is provided, only act when it is still the connection we
+    ;; know about.  A late sentinel from an old SSH process must not tear down
+    ;; a freshly reconnected session for the same TRAMP vector.
+    (when (or (null process)
+              (and conn (eq process (plist-get conn :process))))
+      (tramp-rpc--debug "CONNECTION-LOST host=%s event=%s"
+                        (tramp-file-name-host vec) (or event "unknown"))
+      (let ((conn-buffer (or (and conn (plist-get conn :buffer))
+                             (and process (process-buffer process)))))
+        (when (and process (process-live-p process))
+          (process-put process :tramp-rpc-disconnecting t)
+          (ignore-errors (delete-process process)))
+        ;; Remove connection state before cleaning children so accidental
+        ;; remote cleanup attempts cannot reuse the broken transport.
+        (tramp-rpc--remove-connection vec)
+        (when conn-buffer
+          (remhash conn-buffer tramp-rpc--pending-responses)))
+      (unless connecting
+        ;; Terminate local relay processes without trying to kill remote PIDs
+        ;; through the broken connection.  Their sentinels will notify clients
+        ;; (LSP, compilation, etc.) that the process died abnormally.
+        (tramp-rpc--cleanup-async-processes vec 'connection-lost)
+        (tramp-rpc--cleanup-pty-processes vec 'connection-lost)
+        (tramp-rpc--cleanup-watches-for-connection vec)
+        (tramp-rpc--clear-direnv-cache vec)
+        (tramp-rpc--clear-file-caches-for-connection vec)
+        (ignore-errors (tramp-flush-directory-properties vec "/"))
+        (ignore-errors (tramp-flush-connection-properties vec))
+        (tramp-rpc--cleanup-controlmaster vec)))))
+
+(defun tramp-rpc--connection-sentinel (process event)
+  "Sentinel for the SSH process carrying the RPC server connection."
+  (when (and (memq (process-status process) '(exit signal))
+             (not (process-get process :tramp-rpc-disconnecting)))
+    (when-let* ((vec (process-get process :tramp-rpc-vec)))
+      (tramp-rpc--connection-lost vec process event))))
+
 (defun tramp-rpc--ensure-connection (vec)
   "Ensure we have an active RPC connection to VEC.
 Returns the connection plist.
@@ -721,9 +773,12 @@ completion) from blocking on unreachable hosts."
              (process-live-p (plist-get conn :process))
              (buffer-live-p (plist-get conn :buffer)))
         conn
-      ;; Stale connection - remove it before reconnecting
+      ;; Stale connection - clean up the whole RPC session before reconnecting.
+      ;; Remote child processes belong to the old server instance; keeping their
+      ;; local relays alive makes clients such as lsp-mode think the process is
+      ;; still running even though it can never answer again.
       (when conn
-        (tramp-rpc--remove-connection vec))
+        (tramp-rpc--connection-lost vec (plist-get conn :process) "stale connection"))
       ;; During non-essential operations, don't open new connections.
       ;; This mirrors the (unless (tramp-connectable-p vec)
       ;; (throw 'non-essential 'non-essential)) pattern used by every
@@ -1060,9 +1115,14 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
     ;; Store connection
     (tramp-rpc--set-connection vec process buffer)
 
-    ;; Store vec on the process so notifications can identify the connection
+    ;; Store vec on the process so notifications can identify the connection.
+    ;; Keep startup failures distinct from an established transport loss: the
+    ;; expected-path probe deliberately starts a possibly-missing binary and
+    ;; should fall back to deployment without killing the ControlMaster or
+    ;; unrelated child processes.
     (process-put process :tramp-rpc-vec vec)
     (process-put process 'tramp-vector vec)
+    (process-put process :tramp-rpc-connecting t)
 
     ;; Wait for server to be ready by sending a ping
     (let ((response (tramp-rpc--call vec "system.info" nil)))
@@ -1081,6 +1141,11 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
              ("macos" "Darwin")
              ("linux" "Linux")
              (_ os))))))
+
+    ;; From this point on, process death means an established transport was
+    ;; lost and dependent remote child processes must be cleaned up.
+    (process-put process :tramp-rpc-connecting nil)
+    (set-process-sentinel process #'tramp-rpc--connection-sentinel)
 
     ;; Set connection-local variables in the connection buffer.
     ;; Every TRAMP backend must call this after establishing the connection
@@ -1111,6 +1176,7 @@ Kills the process if still alive and removes the connection entry."
     (when conn
       (let ((proc (plist-get conn :process)))
         (when (process-live-p proc)
+          (process-put proc :tramp-rpc-disconnecting t)
           (delete-process proc)))
       (tramp-rpc--remove-connection vec))))
 
@@ -1194,6 +1260,7 @@ accidentally routing file operations through tramp-sh."
     (when conn
       (let ((process (plist-get conn :process)))
         (when (process-live-p process)
+          (process-put process :tramp-rpc-disconnecting t)
           (delete-process process)))
       (tramp-rpc--remove-connection vec)))
   ;; Flush TRAMP caches so a reconnect gets fresh data (home dir, uid, etc.)
@@ -1286,7 +1353,15 @@ Returns the request ID."
     ;; Register callback
     (puthash id callback tramp-rpc--async-callbacks)
     ;; Send request (binary data with length prefix, no newline)
-    (process-send-string process request)
+    (condition-case err
+        (process-send-string process request)
+      (error
+       (remhash id tramp-rpc--async-callbacks)
+       (tramp-rpc--connection-lost
+        vec process (format "send failed for %s: %s" method err))
+       (signal 'remote-file-error
+               (list (format "Failed to send RPC request %s: %s"
+                             method (error-message-string err))))))
     id))
 
 (defun tramp-rpc--call (vec method params)
@@ -1331,7 +1406,14 @@ Returns the result or signals an error."
     (tramp-rpc--debug "SEND id=%s method=%s" expected-id method)
 
     ;; Send request (binary data with length prefix, no newline)
-    (process-send-string process request)
+    (condition-case err
+        (process-send-string process request)
+      (error
+       (tramp-rpc--connection-lost
+        vec process (format "send failed for %s: %s" method err))
+       (signal 'remote-file-error
+               (list (format "Failed to send RPC request %s: %s"
+                             method (error-message-string err))))))
 
     ;; Wait for response with matching ID using wall-clock deadline.
     ;; NOTE: We use (float-time) instead of decrementing a counter because
@@ -1385,6 +1467,8 @@ Returns the result or signals an error."
             (tramp-rpc--debug
              "TIMEOUT id=%s method=%s elapsed=%.1fs buffer-size=%d process-live=%s"
              expected-id method elapsed (buffer-size) (process-live-p process))
+            (tramp-rpc--connection-lost
+             vec process (format "timeout waiting for %s" method))
             (signal
 	     'remote-file-error
 	     (list (format
@@ -1448,7 +1532,14 @@ Returns:
     (tramp-rpc--debug "SEND-BATCH id=%s count=%d" expected-id (length requests))
 
     ;; Send batch request (binary data with length prefix, no newline)
-    (process-send-string process request)
+    (condition-case err
+        (process-send-string process request)
+      (error
+       (tramp-rpc--connection-lost
+        vec process (format "send failed for batch RPC: %s" err))
+       (signal 'remote-file-error
+               (list (format "Failed to send batch RPC request: %s"
+                             (error-message-string err))))))
 
     ;; Wait for response with matching ID using wall-clock deadline
     (with-current-buffer buffer
@@ -1484,6 +1575,8 @@ Returns:
             (tramp-rpc--debug
              "TIMEOUT-BATCH id=%s elapsed=%.1fs buffer-size=%d process-live=%s"
              expected-id elapsed (buffer-size) (process-live-p process))
+            (tramp-rpc--connection-lost
+             vec process "timeout waiting for batch RPC")
             (signal
 	     'remote-file-error
 	     (list (format
@@ -1520,7 +1613,15 @@ Returns a list of request IDs in the same order."
         (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
         (push id ids)
         ;; Send binary data with length prefix, no newline
-        (process-send-string process bytes)))
+        (condition-case err
+            (process-send-string process bytes)
+          (error
+           (tramp-rpc--connection-lost
+            vec process (format "send failed for pipelined RPC %s: %s"
+                                (car req) err))
+           (signal 'remote-file-error
+                   (list (format "Failed to send pipelined RPC request %s: %s"
+                                 (car req) (error-message-string err))))))))
     (nreverse ids)))
 
 (defun tramp-rpc--receive-responses (vec ids &optional timeout)
@@ -1530,6 +1631,7 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
   (let* ((conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
+         (start-time (float-time))
          (deadline (+ (float-time) (or timeout 30)))
          (remaining-ids (copy-sequence ids))
          (responses (make-hash-table :test 'eql)))
@@ -1571,7 +1673,16 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
             (tramp-rpc--debug "RECV-PIPE quit (user interrupted)")
             (keyboard-quit)))))
     (when remaining-ids
-      (tramp-rpc--debug "RECV-PIPE timeout, missing ids: %S" remaining-ids))
+      (let ((elapsed (- (float-time) start-time)))
+        (tramp-rpc--debug
+         "RECV-PIPE timeout after %.1fs, missing ids: %S process-live=%s"
+         elapsed remaining-ids (process-live-p process))
+        (tramp-rpc--connection-lost
+         vec process "timeout waiting for pipelined RPC responses")
+        (signal 'remote-file-error
+                (list (format
+                       "Timeout waiting for pipelined RPC responses from %s (missing ids=%S, waited %.1fs)"
+                       (tramp-file-name-host vec) remaining-ids elapsed)))))
     ;; Convert hash table to alist in original order
     (mapcar (lambda (id)
               (cons id (gethash id responses)))
@@ -3427,6 +3538,7 @@ cleanup of all connections has run."
     (maphash (lambda (_key conn)
                (let ((process (plist-get conn :process)))
                  (when (process-live-p process)
+                   (process-put process :tramp-rpc-disconnecting t)
                    (delete-process process))))
              tramp-rpc--connections)
     (clrhash tramp-rpc--connections)

--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -114,6 +114,14 @@
     (error "Upstream tramp-tests.el not found at %s.\nSet TRAMP_TEST_SOURCE to the tramp source tree" test-file))
   (load test-file))
 
+;; The upstream availability test computes its `:expected-result' while the
+;; file is loaded.  With tramp-rpc this can be pessimistic during first-contact
+;; deployment, even though the actual test subsequently succeeds.  CI treats a
+;; successful test with an expected failure as an unexpected result, so force the
+;; availability smoke test to be expected to pass for this adapter.
+(when-let* ((test (ert-get-test 'tramp-test00-availability)))
+  (setf (ert-test-expected-result-type test) :passed))
+
 ;; ============================================================================
 ;; Predicate overrides
 ;; ============================================================================

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1693,6 +1693,255 @@ cat relay for gopls must exit so lsp-mode can offer to restart it."
       (remhash relay-process tramp-rpc--async-processes)
       (tramp-rpc--remove-connection vec))))
 
+(defun tramp-rpc-mock-test--cleanup-bootstrap-with-state (state)
+  "Run `tramp-rpc--cleanup-bootstrap-connection' with mocked bootstrap STATE.
+STATE is one of `live-process', `process-buffer', `process-buffer-nil',
+`connected', `connected-nil' or nil.  Return the arguments passed to
+`tramp-cleanup-connection', or nil when cleanup was not called."
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "bootstrap-host"
+                                    :localname "/tmp"))
+         (proc (when (eq state 'live-process)
+                 (start-process "tramp-rpc-test-bootstrap-cleanup" nil
+                                "sleep" "60")))
+         (cleanup-args nil))
+    (unwind-protect
+        (progn
+          (when proc
+            (set-process-query-on-exit-flag proc nil))
+          (cl-letf (((symbol-function 'tramp-get-connection-process)
+                     (lambda (_vec) proc))
+                    ((symbol-function 'tramp-connection-property-p)
+                     (lambda (_vec prop)
+                       (or (and (memq state '(process-buffer process-buffer-nil))
+                                (equal prop "process-buffer"))
+                           (and (memq state '(connected connected-nil))
+                                (equal prop " connected")))))
+                    ((symbol-function 'tramp-cleanup-connection)
+                     (lambda (&rest args)
+                       (setq cleanup-args args))))
+            (tramp-rpc--cleanup-bootstrap-connection vec))
+          cleanup-args)
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(defun tramp-rpc-mock-test--check-bootstrap-cleanup-args (cleanup-args)
+  "Assert that CLEANUP-ARGS preserve non-bootstrap password/process state."
+  (should cleanup-args)
+  (let ((bootstrap-vec (car cleanup-args)))
+    (should (equal (tramp-file-name-method bootstrap-vec)
+                   tramp-rpc-deploy-bootstrap-method))
+    (should (equal (tramp-file-name-host bootstrap-vec) "bootstrap-host")))
+  (should (equal (cdr cleanup-args)
+                 '(keep-debug keep-password keep-processes))))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-uses-tramp-cleanup ()
+  "Bootstrap shell cleanup must clear TRAMP's cached connection state."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (tramp-rpc-mock-test--check-bootstrap-cleanup-args
+   (tramp-rpc-mock-test--cleanup-bootstrap-with-state 'live-process)))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-process-buffer-cache ()
+  "Bootstrap cleanup should run when only `process-buffer' cache remains."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (tramp-rpc-mock-test--check-bootstrap-cleanup-args
+   (tramp-rpc-mock-test--cleanup-bootstrap-with-state 'process-buffer)))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-process-buffer-nil-cache ()
+  "Bootstrap cleanup should run for a nil-valued `process-buffer' marker."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (tramp-rpc-mock-test--check-bootstrap-cleanup-args
+   (tramp-rpc-mock-test--cleanup-bootstrap-with-state 'process-buffer-nil)))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-connected-cache ()
+  "Bootstrap cleanup should run when only ` connected' cache remains."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (tramp-rpc-mock-test--check-bootstrap-cleanup-args
+   (tramp-rpc-mock-test--cleanup-bootstrap-with-state 'connected)))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-connected-nil-cache ()
+  "Bootstrap cleanup should run for a nil-valued ` connected' marker."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (tramp-rpc-mock-test--check-bootstrap-cleanup-args
+   (tramp-rpc-mock-test--cleanup-bootstrap-with-state 'connected-nil)))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-no-state ()
+  "Bootstrap cleanup should not run without process or cached state."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (should-not (tramp-rpc-mock-test--cleanup-bootstrap-with-state nil)))
+
+(ert-deftest tramp-rpc-mock-test-connect-direct-success-cleans-bootstrap-before-start ()
+  "Direct RPC startup cleans stale bootstrap state before system.info startup."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "direct-success-host"
+                                   :localname "/tmp"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        (events nil))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path)
+                 (push (if (equal binary-path "/expected/tramp-rpc-server")
+                           'start-expected
+                         'start-deployed)
+                       events)
+                 'connection))
+              ((symbol-function 'tramp-rpc-deploy-expected-binary-localname)
+               (lambda () "/expected/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events))))
+      (should (eq (tramp-rpc--connect vec) 'connection))
+      (should (equal (nreverse events)
+                     '(cleanup-bootstrap start-expected))))))
+
+(ert-deftest tramp-rpc-mock-test-connect-never-deploy-cleans-bootstrap-before-start ()
+  "Never-deploy startup cleans stale bootstrap state before system.info startup."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "never-deploy-host"
+                                   :localname "/tmp"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy t)
+        (events nil))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc-deploy-ensure-binary)
+               (lambda (_vec)
+                 (push 'ensure-binary events)
+                 "/configured/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path)
+                 (should (equal binary-path "/configured/tramp-rpc-server"))
+                 (push 'start-configured events)
+                 'connection))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events))))
+      (should (eq (tramp-rpc--connect vec) 'connection))
+      (should (equal (nreverse events)
+                     '(ensure-binary cleanup-bootstrap start-configured))))))
+
+(ert-deftest tramp-rpc-mock-test-connect-fallback-cleans-before-retry-start ()
+  "Deploy fallback cleanup runs after deploy and before retry startup."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "retry-success-host"
+                                   :localname "/tmp"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        (events nil))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path)
+                 (push (if (equal binary-path "/expected/tramp-rpc-server")
+                           'start-expected
+                         'start-deployed)
+                       events)
+                 (if (equal binary-path "/expected/tramp-rpc-server")
+                     (signal 'remote-file-error (list "mock start failure"))
+                   'connection)))
+              ((symbol-function 'tramp-rpc--cleanup-failed-connection)
+               (lambda (_vec) (push 'cleanup-failed events)))
+              ((symbol-function 'tramp-rpc-deploy-expected-binary-localname)
+               (lambda () "/expected/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy-ensure-binary)
+               (lambda (_vec) (push 'deploy events) "/deployed/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events))))
+      (should (eq (tramp-rpc--connect vec) 'connection))
+      (should (equal (nreverse events)
+                     '(cleanup-bootstrap start-expected cleanup-failed
+                       deploy cleanup-bootstrap start-deployed
+                       cleanup-bootstrap))))))
+
+(ert-deftest tramp-rpc-mock-test-connect-fallback-cleans-bootstrap-on-retry-failure ()
+  "Deploy fallback cleanup runs even when the post-deploy RPC retry fails."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "retry-fail-host"
+                                   :localname "/tmp"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        (start-calls 0)
+        (events nil))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path)
+                 (setq start-calls (1+ start-calls))
+                 (push (if (equal binary-path "/expected/tramp-rpc-server")
+                           'start-expected
+                         'start-deployed)
+                       events)
+                 (signal 'remote-file-error (list "mock start failure"))))
+              ((symbol-function 'tramp-rpc--cleanup-failed-connection)
+               (lambda (_vec) (push 'cleanup-failed events)))
+              ((symbol-function 'tramp-rpc-deploy-expected-binary-localname)
+               (lambda () "/expected/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy-ensure-binary)
+               (lambda (_vec) (push 'deploy events) "/deployed/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events))))
+      (should-error (tramp-rpc--connect vec) :type 'remote-file-error)
+      (should (= start-calls 2))
+      (should (equal (nreverse events)
+                     '(cleanup-bootstrap start-expected cleanup-failed
+                       deploy cleanup-bootstrap start-deployed
+                       cleanup-bootstrap))))))
+
+(ert-deftest tramp-rpc-mock-test-connect-fallback-cleans-bootstrap-on-deploy-failure ()
+  "Deploy fallback cleanup runs even when deployment itself fails."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "deploy-fail-host"
+                                   :localname "/tmp"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        (start-calls 0)
+        (events nil))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path)
+                 (setq start-calls (1+ start-calls))
+                 (push (if (equal binary-path "/expected/tramp-rpc-server")
+                           'start-expected
+                         'start-deployed)
+                       events)
+                 (signal 'remote-file-error (list "mock start failure"))))
+              ((symbol-function 'tramp-rpc--cleanup-failed-connection)
+               (lambda (_vec) (push 'cleanup-failed events)))
+              ((symbol-function 'tramp-rpc-deploy-expected-binary-localname)
+               (lambda () "/expected/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy-ensure-binary)
+               (lambda (_vec)
+                 (push 'deploy events)
+                 (signal 'remote-file-error (list "mock deploy failure"))))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events))))
+      (should-error (tramp-rpc--connect vec) :type 'remote-file-error)
+      (should (= start-calls 1))
+      (should (equal (nreverse events)
+                     '(cleanup-bootstrap start-expected cleanup-failed
+                       deploy cleanup-bootstrap))))))
+
 (ert-deftest tramp-rpc-mock-test-cleanup-all-does-not-trigger-connection-lost ()
   "Manual cleanup-all should not be mistaken for transport loss."
   :tags '(:connection-cleanup)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1580,6 +1580,149 @@ discard it for being unreadable."
     (should (equal recentf-list (list (abbreviate-file-name local-file))))))
 
 ;;; ============================================================================
+;;; Connection Loss Cleanup Tests (No server or SSH required)
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-mock-test-connection-loss-cleans-async-processes ()
+  "A lost RPC transport should kill dependent async relay processes.
+This covers LSP servers: if the server-side RPC process dies, the local
+cat relay for gopls must exit so lsp-mode can offer to restart it."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "lost-host"
+                                    :localname "/tmp"))
+         (conn-buffer (generate-new-buffer " *tramp-rpc-test-conn*"))
+         (conn-process (start-process "tramp-rpc-test-conn" conn-buffer
+                                      "sleep" "60"))
+         (relay-process (start-process "tramp-rpc-test-relay" nil "cat"))
+         (sentinel-event nil)
+         (remote-kill-called nil))
+    (unwind-protect
+        (progn
+          (set-process-query-on-exit-flag conn-process nil)
+          (set-process-query-on-exit-flag relay-process nil)
+          (process-put conn-process :tramp-rpc-vec vec)
+          (process-put conn-process 'tramp-vector vec)
+          (tramp-rpc--set-connection vec conn-process conn-buffer)
+          (process-put relay-process :tramp-rpc-vec vec)
+          (process-put relay-process :tramp-rpc-pid 4242)
+          (process-put relay-process 'tramp-vector vec)
+          (set-process-sentinel
+           relay-process
+           (lambda (proc event)
+             (tramp-rpc--pipe-process-sentinel
+              proc event
+              (lambda (_proc user-event)
+                (setq sentinel-event user-event)))))
+          (puthash relay-process
+                   (list :vec vec :pid 4242)
+                   tramp-rpc--async-processes)
+
+          (cl-letf (((symbol-function 'tramp-rpc--kill-remote-process)
+                     (lambda (&rest _args)
+                       (setq remote-kill-called t))))
+            (tramp-rpc--connection-lost vec conn-process "test connection loss")
+            (accept-process-output relay-process 0.1))
+
+          (should-not remote-kill-called)
+          (should-not (tramp-rpc--get-connection vec))
+          (should-not (gethash relay-process tramp-rpc--async-processes))
+          (should-not (process-live-p relay-process))
+          (should (equal sentinel-event "exited abnormally with code 255\n")))
+      (when (process-live-p conn-process)
+        (delete-process conn-process))
+      (when (process-live-p relay-process)
+        (delete-process relay-process))
+      (when (buffer-live-p conn-buffer)
+        (kill-buffer conn-buffer))
+      (remhash relay-process tramp-rpc--async-processes)
+      (tramp-rpc--remove-connection vec))))
+
+(ert-deftest tramp-rpc-mock-test-connection-sentinel-cleans-async-processes ()
+  "The RPC transport sentinel should clean dependent async relay processes."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "sentinel-host"
+                                    :localname "/tmp"))
+         (conn-buffer (generate-new-buffer " *tramp-rpc-test-sentinel-conn*"))
+         (conn-process (start-process "tramp-rpc-test-sentinel-conn"
+                                      conn-buffer "sleep" "60"))
+         (relay-process (start-process "tramp-rpc-test-sentinel-relay" nil
+                                       "cat"))
+         (sentinel-event nil)
+         (remote-kill-called nil))
+    (unwind-protect
+        (progn
+          (set-process-query-on-exit-flag conn-process nil)
+          (set-process-query-on-exit-flag relay-process nil)
+          (process-put conn-process :tramp-rpc-vec vec)
+          (process-put conn-process 'tramp-vector vec)
+          (set-process-sentinel conn-process #'tramp-rpc--connection-sentinel)
+          (tramp-rpc--set-connection vec conn-process conn-buffer)
+          (process-put relay-process :tramp-rpc-vec vec)
+          (process-put relay-process :tramp-rpc-pid 4243)
+          (process-put relay-process 'tramp-vector vec)
+          (set-process-sentinel
+           relay-process
+           (lambda (proc event)
+             (tramp-rpc--pipe-process-sentinel
+              proc event
+              (lambda (_proc user-event)
+                (setq sentinel-event user-event)))))
+          (puthash relay-process
+                   (list :vec vec :pid 4243)
+                   tramp-rpc--async-processes)
+
+          (cl-letf (((symbol-function 'tramp-rpc--kill-remote-process)
+                     (lambda (&rest _args)
+                       (setq remote-kill-called t))))
+            (delete-process conn-process)
+            (accept-process-output relay-process 0.1))
+
+          (should-not remote-kill-called)
+          (should-not (tramp-rpc--get-connection vec))
+          (should-not (gethash relay-process tramp-rpc--async-processes))
+          (should-not (process-live-p relay-process))
+          (should (equal sentinel-event "exited abnormally with code 255\n")))
+      (when (process-live-p conn-process)
+        (delete-process conn-process))
+      (when (process-live-p relay-process)
+        (delete-process relay-process))
+      (when (buffer-live-p conn-buffer)
+        (kill-buffer conn-buffer))
+      (remhash relay-process tramp-rpc--async-processes)
+      (tramp-rpc--remove-connection vec))))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-all-does-not-trigger-connection-lost ()
+  "Manual cleanup-all should not be mistaken for transport loss."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (make-tramp-file-name :method "rpc" :host "cleanup-all-host"
+                                    :localname "/tmp"))
+         (conn-buffer (generate-new-buffer " *tramp-rpc-test-cleanup-all*"))
+         (conn-process (start-process "tramp-rpc-test-cleanup-all"
+                                      conn-buffer "sleep" "60"))
+         (connection-lost-called nil))
+    (unwind-protect
+        (progn
+          (set-process-query-on-exit-flag conn-process nil)
+          (process-put conn-process :tramp-rpc-vec vec)
+          (process-put conn-process 'tramp-vector vec)
+          (set-process-sentinel conn-process #'tramp-rpc--connection-sentinel)
+          (tramp-rpc--set-connection vec conn-process conn-buffer)
+          (cl-letf (((symbol-function 'tramp-rpc--connection-lost)
+                     (lambda (&rest _args)
+                       (setq connection-lost-called t))))
+            (tramp-rpc-cleanup-all-connections))
+          (should-not connection-lost-called)
+          (should-not (tramp-rpc--get-connection vec)))
+      (when (process-live-p conn-process)
+        (delete-process conn-process))
+      (when (buffer-live-p conn-buffer)
+        (kill-buffer conn-buffer))
+      (tramp-rpc--remove-connection vec))))
+
+;;; ============================================================================
 ;;; Tilde Quoting Tests
 ;;; ============================================================================
 


### PR DESCRIPTION
## Summary
- detect lost/stale RPC transport processes and tear down dependent async/PTTY relays
- make send failures and RPC timeouts clean the whole stale RPC session, including batch and pipelined calls
- preserve manual cleanup semantics by marking intentional disconnects
- add mock regression coverage for connection-loss and cleanup-all behavior

Fixes #195.

## Validation
- `emacs -Q --batch --eval '(require (quote package))' --eval '(package-initialize)' -L ~/.emacs.d/.local/straight/build-30.2/tramp -L lisp --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/*.el`
- `emacs -Q --batch -L ~/.emacs.d/.local/straight/build-30.2/tramp -L lisp -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-mock-test-connection.*async-processes\\\\|tramp-rpc-mock-test-cleanup-all")'`
