### PR TITLE
feat(watcher.rs): gitignore-aware watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,16 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bytes"
@@ -58,6 +77,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "equivalent"
@@ -220,6 +264,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +302,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -487,6 +560,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +776,7 @@ version = "0.9.1"
 dependencies = [
  "flate2",
  "futures",
+ "ignore",
  "libc",
  "nix",
  "notify",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,9 +28,7 @@ nix = { version = "0.29", features = ["term", "process", "signal", "fs"] }
 # For filesystem watching (inotify on Linux, kqueue on macOS)
 notify = "7.0"
 
-# For .gitignore-aware directory walking when registering recursive watches.
-# Without this, recursing into the worktree blows past the OS inotify limit
-# on projects with large gitignored trees (.venv, node_modules, ...).
+# For Git-aware recursive watch discovery.
 ignore = "0.4"
 
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,5 +28,10 @@ nix = { version = "0.29", features = ["term", "process", "signal", "fs"] }
 # For filesystem watching (inotify on Linux, kqueue on macOS)
 notify = "7.0"
 
+# For .gitignore-aware directory walking when registering recursive watches.
+# Without this, recursing into the worktree blows past the OS inotify limit
+# on projects with large gitignored trees (.venv, node_modules, ...).
+ignore = "0.4"
+
 [dev-dependencies]
 tempfile = "3"

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -1023,16 +1023,17 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    #[cfg(all(target_os = "linux", unix))]
+    #[cfg(all(target_os = "linux", target_arch = "x86_64", unix))]
     #[test]
     fn test_recursive_watch_follows_symlinked_directories_for_real_events() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path().canonicalize().unwrap();
         let real = root.join("real");
         let link = root.join("link");
+        let real_nested = real.join("nested");
         let linked_nested = link.join("nested");
         let linked_file = linked_nested.join("file");
-        fs::create_dir_all(real.join("nested")).unwrap();
+        fs::create_dir_all(&real_nested).unwrap();
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         let (tx, rx) = std_mpsc::channel();
@@ -1052,7 +1053,7 @@ mod tests {
             event
                 .paths
                 .iter()
-                .any(|path| path.starts_with(&linked_nested))
+                .any(|path| path.starts_with(&linked_nested) || path.starts_with(&real_nested))
         });
 
         watcher.unwatch(&root).unwrap();

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -158,12 +158,9 @@ impl FilteredWatcher {
     /// Reconcile a recursive root's watched-directory set to `next`, adding and
     /// removing per-directory watches to match.
     ///
-    /// The diff is by path string. A delete+recreate (or rename-into-place) of a
-    /// watched directory that coalesces inside one debounce window leaves
-    /// `current` and `next` byte-identical, so the diff is a no-op even though the
-    /// kernel watch now points at a stale inode. That case is handled out of band
-    /// by [`WatchManager::rearm_suspect_paths`], which force-rebinds paths that
-    /// saw a remove/rename event during the window.
+    /// The diff is by path string, so a coalesced delete+recreate (or
+    /// rename-into-place) within one debounce window is a no-op here and leaves the
+    /// watch on a stale inode; [`WatchManager::rearm_suspect_paths`] repairs that.
     fn apply_recursive_dirs(
         &mut self,
         root: &Path,
@@ -222,19 +219,11 @@ impl FilteredWatcher {
         Ok(())
     }
 
-    /// Re-arm the kernel watch for a path we already believe is watched,
-    /// rebinding it to whatever inode currently lives there. This is a REBIND,
-    /// not an add: it must NOT touch `path_watch_counts` or any ownership
-    /// bookkeeping (the shared watch's logical-owner count is unchanged).
-    ///
-    /// It recovers from inotify dropping a directory's watch on a delete+recreate
-    /// that coalesces inside one debounce window: the post-scan path set is
-    /// unchanged, so `apply_recursive_dirs` is a no-op and never re-issues the
-    /// watch for the new inode. The best-effort `unwatch` clears any stale
-    /// backend state that still refers to the old inode; the following `watch`
-    /// binds the current inode. The count check skips paths the scan already
-    /// pruned (genuine deletes / renames-away); callers gate on the path still
-    /// existing.
+    /// Re-arm the kernel watch for a path we already believe is watched, rebinding
+    /// it to whatever inode currently lives there. This is a REBIND, not an add: it
+    /// must NOT touch `path_watch_counts` (the shared watch's logical-owner count is
+    /// unchanged). No-ops for paths the scan already pruned; callers gate on the
+    /// path still existing. See [`WatchManager::rearm_suspect_paths`] for why.
     fn rearm_existing_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
         if !self.path_watch_counts.contains_key(path) {
             return Ok(());
@@ -294,10 +283,10 @@ impl FilteredWatcher {
 
     fn collect_recursive_dirs(root: &Path) -> HashSet<PathBuf> {
         // Git-aware only: honor .gitignore, .git/info/exclude, the global
-        // gitignore and parent-directory ignore files, but NOT generic
-        // `.ignore`/`.rgignore` files (`ignore(false)`). Those are not a Git
-        // ignore source, so honoring them would hide directories Git/Magit still
-        // track, and ignore-rule refresh detection only recognizes Git sources.
+        // gitignore and parent-directory ignore files, but NOT generic `.ignore`
+        // files (`ignore(false)`). `.ignore` is not a Git ignore source, so
+        // honoring it would hide directories Git/Magit still track, and the
+        // ignore-rule refresh detection only recognizes Git sources.
         // hidden(false): include .git/, magit cares about it.
         let walker = ignore::WalkBuilder::new(root)
             .standard_filters(true)
@@ -555,17 +544,25 @@ fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     paths.iter().filter(|path| path.is_dir()).cloned().collect()
 }
 
-/// Paths from events that drop or rebind a directory's kernel-watch inode:
-/// inotify frees a directory's watch descriptor on delete and rebinds the name
-/// to a new inode on rename. When a delete+recreate (or rename-into-place)
-/// coalesces inside one debounce window, the post-window path set is unchanged,
-/// so `apply_recursive_dirs`'s diff is a no-op and never re-arms the new inode;
-/// these paths are force-rebound afterward by `WatchManager::rearm_suspect_paths`.
+/// Paths from events that drop or rebind a directory's kernel-watch inode (a
+/// delete frees the watch descriptor; a rename rebinds the name to a new inode).
+/// Collected during the debounce window and force-rebound afterward by
+/// [`WatchManager::rearm_suspect_paths`].
+///
+/// inotify-only: macOS FSEvents is path-based and keeps delivering to the
+/// recreated path, so there is nothing to re-arm. Returning empty off Linux keeps
+/// `suspect_paths` empty and skips the unwatch/rewatch churn entirely.
+#[cfg(target_os = "linux")]
 fn inode_replacing_paths(event: &Event) -> Vec<PathBuf> {
     match event.kind {
         EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(_)) => event.paths.clone(),
         _ => Vec::new(),
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn inode_replacing_paths(_event: &Event) -> Vec<PathBuf> {
+    Vec::new()
 }
 
 fn ignore_rule_paths(event: &Event) -> Vec<PathBuf> {

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -158,12 +158,12 @@ impl FilteredWatcher {
     /// Reconcile a recursive root's watched-directory set to `next`, adding and
     /// removing per-directory watches to match.
     ///
-    /// Known limitation: the diff is by path string against the post-window
-    /// snapshot. If a watched directory is renamed out of the tree (or deleted)
-    /// and a same-named directory is recreated within the same debounce window,
-    /// `current` and `next` are byte-identical, so the recreated (new-inode)
-    /// directory is not re-watched. Fixing this needs inode/descriptor-level
-    /// tracking rather than path-set diffing.
+    /// The diff is by path string. A delete+recreate (or rename-into-place) of a
+    /// watched directory that coalesces inside one debounce window leaves
+    /// `current` and `next` byte-identical, so the diff is a no-op even though the
+    /// kernel watch now points at a stale inode. That case is handled out of band
+    /// by [`WatchManager::rearm_suspect_paths`], which force-rebinds paths that
+    /// saw a remove/rename event during the window.
     fn apply_recursive_dirs(
         &mut self,
         root: &Path,
@@ -222,6 +222,39 @@ impl FilteredWatcher {
         Ok(())
     }
 
+    /// Re-arm the kernel watch for a path we already believe is watched,
+    /// rebinding it to whatever inode currently lives there. This is a REBIND,
+    /// not an add: it must NOT touch `path_watch_counts` or any ownership
+    /// bookkeeping (the shared watch's logical-owner count is unchanged).
+    ///
+    /// It recovers from inotify dropping a directory's watch on a delete+recreate
+    /// that coalesces inside one debounce window: the post-scan path set is
+    /// unchanged, so `apply_recursive_dirs` is a no-op and never re-issues the
+    /// watch for the new inode. The best-effort `unwatch` clears any stale
+    /// backend state that still refers to the old inode; the following `watch`
+    /// binds the current inode. The count check skips paths the scan already
+    /// pruned (genuine deletes / renames-away); callers gate on the path still
+    /// existing.
+    fn rearm_existing_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        if !self.path_watch_counts.contains_key(path) {
+            return Ok(());
+        }
+        let _ = self.inner.unwatch(path);
+        self.inner.watch(path, RecursiveMode::NonRecursive)
+    }
+
+    fn watched_paths_under(&self, roots: &[PathBuf]) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = self
+            .path_watch_counts
+            .keys()
+            .filter(|path| roots.iter().any(|root| path.starts_with(root)))
+            .cloned()
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
     fn remove_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
         match self.path_watch_counts.get(path).copied() {
             Some(count) if count > 1 => {
@@ -260,11 +293,15 @@ impl FilteredWatcher {
     }
 
     fn collect_recursive_dirs(root: &Path) -> HashSet<PathBuf> {
+        // Git-aware only: honor .gitignore, .git/info/exclude, the global
+        // gitignore and parent-directory ignore files, but NOT generic
+        // `.ignore`/`.rgignore` files (`ignore(false)`). Those are not a Git
+        // ignore source, so honoring them would hide directories Git/Magit still
+        // track, and ignore-rule refresh detection only recognizes Git sources.
         // hidden(false): include .git/, magit cares about it.
-        // standard_filters honors .gitignore, .git/info/exclude, global ignore,
-        // including ignore files from parent directories.
         let walker = ignore::WalkBuilder::new(root)
             .standard_filters(true)
+            .ignore(false)
             .hidden(false)
             .build();
 
@@ -460,6 +497,45 @@ impl WatchManager {
             let _ = watcher.apply_recursive_dirs(&root, dirs);
         }
     }
+
+    /// Force-rebind watches for directories that saw a remove/rename event during
+    /// the debounce window and still exist. This recovers the coalesced
+    /// delete+recreate (or rename-into-place) case that `apply_recursive_dirs`'s
+    /// path-set diff misses (unchanged set -> no-op, leaving the watch on a stale
+    /// inode). A replaced directory invalidates watches for the whole subtree, so
+    /// every still-existing watched descendant is rebound. Must run AFTER
+    /// `refresh_recursive_roots`, so genuine deletes are already pruned from the
+    /// refcounts and thus skipped here.
+    fn rearm_suspect_paths(&self, suspect_paths: HashSet<PathBuf>) {
+        let existing_roots: Vec<PathBuf> = suspect_paths
+            .into_iter()
+            .filter(|path| path.is_dir())
+            .collect();
+        if existing_roots.is_empty() {
+            return;
+        }
+
+        let candidates = {
+            let watcher = lock_or_recover(&self.watcher);
+            watcher.watched_paths_under(&existing_roots)
+        };
+        let existing: Vec<PathBuf> = candidates
+            .into_iter()
+            .filter(|path| path.is_dir())
+            .collect();
+        if existing.is_empty() {
+            return;
+        }
+
+        let mut watcher = lock_or_recover(&self.watcher);
+        for path in &existing {
+            // Best effort repair path: if the directory disappears again or the
+            // backend refuses the watch, leave logical ownership intact. A later
+            // topology refresh can prune missing paths; watch-limit errors are
+            // equivalent to refresh add failures, which are also non-fatal here.
+            let _ = watcher.rearm_existing_watch(path);
+        }
+    }
 }
 
 fn directory_tree_refresh_paths(event: &Event) -> Vec<PathBuf> {
@@ -477,6 +553,19 @@ fn directory_tree_refresh_paths(event: &Event) -> Vec<PathBuf> {
 
 fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     paths.iter().filter(|path| path.is_dir()).cloned().collect()
+}
+
+/// Paths from events that drop or rebind a directory's kernel-watch inode:
+/// inotify frees a directory's watch descriptor on delete and rebinds the name
+/// to a new inode on rename. When a delete+recreate (or rename-into-place)
+/// coalesces inside one debounce window, the post-window path set is unchanged,
+/// so `apply_recursive_dirs`'s diff is a no-op and never re-arms the new inode;
+/// these paths are force-rebound afterward by `WatchManager::rearm_suspect_paths`.
+fn inode_replacing_paths(event: &Event) -> Vec<PathBuf> {
+    match event.kind {
+        EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(_)) => event.paths.clone(),
+        _ => Vec::new(),
+    }
 }
 
 fn ignore_rule_paths(event: &Event) -> Vec<PathBuf> {
@@ -551,7 +640,14 @@ async fn debounce_loop(
 
         let mut pending_paths: HashSet<PathBuf> = HashSet::new();
         let mut roots_to_refresh: HashSet<PathBuf> = HashSet::new();
-        collect_event(event, &manager, &mut pending_paths, &mut roots_to_refresh);
+        let mut suspect_paths: HashSet<PathBuf> = HashSet::new();
+        collect_event(
+            event,
+            &manager,
+            &mut pending_paths,
+            &mut roots_to_refresh,
+            &mut suspect_paths,
+        );
 
         // Phase 2: Collect more events during the debounce window
         let deadline = time::Instant::now() + DEBOUNCE_DURATION;
@@ -563,7 +659,13 @@ async fn debounce_loop(
                 event = rx.recv() => {
                     match event {
                         Some(e) => {
-                            collect_event(e, &manager, &mut pending_paths, &mut roots_to_refresh);
+                            collect_event(
+                                e,
+                                &manager,
+                                &mut pending_paths,
+                                &mut roots_to_refresh,
+                                &mut suspect_paths,
+                            );
                         }
                         None => return, // Channel closed
                     }
@@ -573,6 +675,7 @@ async fn debounce_loop(
 
         if let Some(manager) = manager.upgrade() {
             manager.refresh_recursive_roots(roots_to_refresh);
+            manager.rearm_suspect_paths(suspect_paths);
         }
 
         // Phase 3: Send notification with all collected paths
@@ -589,11 +692,13 @@ fn collect_event(
     manager: &Weak<WatchManager>,
     pending_paths: &mut HashSet<PathBuf>,
     roots_to_refresh: &mut HashSet<PathBuf>,
+    suspect_paths: &mut HashSet<PathBuf>,
 ) {
     if let Some(manager) = manager.upgrade() {
         roots_to_refresh.extend(manager.recursive_roots_for_event(&event));
     }
 
+    suspect_paths.extend(inode_replacing_paths(&event));
     pending_paths.extend(event.paths);
 }
 
@@ -784,6 +889,26 @@ mod tests {
         assert!(dirs.contains(&sub));
         assert!(dirs.contains(&sub.join("tracked")));
         assert!(!dirs.contains(&sub.join("ignored")));
+    }
+
+    /// Verify the scan is Git-aware only: a plain `.ignore` file does NOT exclude
+    /// directories (only Git ignore sources do), since Git/Magit still track them.
+    #[test]
+    fn test_recursive_scan_ignores_dot_ignore_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".ignore"), "build/\n").unwrap();
+        fs::write(root.join(".gitignore"), "gitignored/\n").unwrap();
+        fs::create_dir_all(root.join("build")).unwrap();
+        fs::create_dir_all(root.join("gitignored")).unwrap();
+
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+
+        // `.ignore` is not honored: build/ stays watched.
+        assert!(dirs.contains(&root.join("build")));
+        // `.gitignore` is still honored.
+        assert!(!dirs.contains(&root.join("gitignored")));
     }
 
     /// Verify a Create event for a new directory under a recursive root adds a watch.
@@ -1092,6 +1217,80 @@ mod tests {
         });
 
         let _ = watcher.unwatch(&root);
+    }
+
+    /// Verify a directory deleted and recreated within ONE debounce window is
+    /// re-armed and keeps delivering real events. This is the coalesced case the
+    /// production path actually hits: the post-window scan sees an unchanged path
+    /// set, so `apply_recursive_dirs` is a no-op and only the suspect-path re-arm
+    /// rebinds the new inode. (The overlap test above does two separate refreshes,
+    /// which masks this.)
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_coalesced_delete_recreate_within_window_rewatches_for_real_events() {
+        use notify::event::CreateKind;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        let nested = sub.join("nested");
+        let nested_file = nested.join("file");
+        fs::create_dir_all(&nested).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let manager = WatchManager {
+            watcher: Mutex::new(
+                FilteredWatcher::new(move |event: notify::Result<Event>| {
+                    if let Ok(event) = event {
+                        let _ = tx.send(event);
+                    }
+                })
+                .unwrap(),
+            ),
+            watched_paths: Mutex::new(HashMap::new()),
+        };
+        manager.watch(&root, true).unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        // Delete and recreate within one window: the kernel drops sub's whole
+        // watched subtree on delete; the recreated dirs have new inodes but the
+        // same paths.
+        fs::remove_dir_all(&sub).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+
+        // Drive debounce_loop's post-window block for the coalesced Remove+Create.
+        let remove_event = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(sub.clone());
+        let create_event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(sub.clone());
+        let mut roots: HashSet<PathBuf> = HashSet::new();
+        let mut suspects: HashSet<PathBuf> = HashSet::new();
+        for event in [&remove_event, &create_event] {
+            roots.extend(manager.recursive_roots_for_event(event));
+            suspects.extend(inode_replacing_paths(event));
+        }
+        manager.refresh_recursive_roots(roots);
+        manager.rearm_suspect_paths(suspects);
+
+        // The scan's diff was a no-op (sub still present at the same path), so
+        // without the suspect re-arm the watch would point at the deleted inode.
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&sub));
+            assert!(watcher.recursive_roots[&root].contains(&nested));
+            assert_eq!(watcher.path_watch_counts.get(&sub), Some(&1));
+            assert_eq!(watcher.path_watch_counts.get(&nested), Some(&1));
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&nested_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event.paths.iter().any(|path| path.starts_with(&nested))
+        });
+
+        manager.unwatch(&root).unwrap();
     }
 
     /// Verify repeated watch.add calls for the same canonical path are idempotent.

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -42,13 +42,9 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-/// Wraps a `RecommendedWatcher` with .gitignore-aware recursive watching.
+/// .gitignore-aware wrapper around `RecommendedWatcher`.
 ///
-/// This wrapper intercepts recursive watches: walks the tree honoring .gitignore and
-/// registers each non-ignored directory individually in NonRecursive mode.
-/// Unwatch then tears down all sub-watches owned by that recursive root.
-///
-/// To callers it looks just like a `notify::Watcher`.
+/// Recursive watches are registered as per-directory non-recursive watches.
 struct FilteredWatcher {
     inner: RecommendedWatcher,
     recursive_roots: HashMap<PathBuf, HashSet<PathBuf>>,
@@ -134,15 +130,7 @@ impl FilteredWatcher {
             .collect()
     }
 
-    /// Recursive roots whose watched set may change when the ignore file at
-    /// `path` changes.
-    ///
-    /// Known limitation: this only fires for ignore files inside a watched tree,
-    /// since events are only delivered for watched directories. When a subdirectory
-    /// is watched recursively without its repository root (e.g. a manual recursive
-    /// watch of `/repo/sub`), changes to an ignore file *above* the root such as
-    /// `/repo/.gitignore` are never observed, so ignore rules can go stale. The
-    /// common case (watching a git worktree root) is unaffected.
+    /// Recursive roots affected by an observed Git ignore-file change.
     fn recursive_roots_for_ignore_rule(&self, path: &Path) -> Vec<PathBuf> {
         let Some(scope) = ignore_rule_scope(path) else {
             return Vec::new();
@@ -155,12 +143,7 @@ impl FilteredWatcher {
             .collect()
     }
 
-    /// Reconcile a recursive root's watched-directory set to `next`, adding and
-    /// removing per-directory watches to match.
-    ///
-    /// The diff is by path string, so a coalesced delete+recreate (or
-    /// rename-into-place) within one debounce window is a no-op here and leaves the
-    /// watch on a stale inode; [`WatchManager::rearm_suspect_paths`] repairs that.
+    /// Reconcile one recursive root to a freshly scanned directory set.
     fn apply_recursive_dirs(
         &mut self,
         root: &Path,
@@ -175,10 +158,7 @@ impl FilteredWatcher {
         let mut applied = current;
         let mut added: Vec<PathBuf> = Vec::new();
 
-        // Apply removals before additions. For a rename old -> new this yields
-        // to_remove={old}, to_add={new}; removing first lets the backend release
-        // old's descriptor before new re-registers, so new cannot attach to a
-        // descriptor still bound to old's (now renamed) inode.
+        // Remove first so rename old -> new cannot reuse old's descriptor.
         for dir in &to_remove {
             self.remove_path_watch_best_effort(dir);
             applied.remove(dir);
@@ -202,15 +182,7 @@ impl FilteredWatcher {
     }
 
     fn add_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
-        // Always (re-)issue the OS watch, even when the refcount is already
-        // positive: a path's count can outlive its kernel watch. inotify drops a
-        // directory's watch when the directory is deleted, so after a
-        // delete+recreate under an overlapping watch the surviving count would
-        // otherwise skip re-arming and the recreated directory would go silent
-        // (see test_overlap_delete_recreate_rewatches_for_real_events). Re-adding
-        // is cheap and idempotent: inotify_add_watch returns the same descriptor
-        // and merges the mask; on macOS FSEvents the duplicate path is removed
-        // wholesale on unwatch.
+        // The logical refcount can outlive the backend watch after inode replacement.
         self.inner.watch(path, RecursiveMode::NonRecursive)?;
         *self
             .path_watch_counts
@@ -219,11 +191,7 @@ impl FilteredWatcher {
         Ok(())
     }
 
-    /// Re-arm the kernel watch for a path we already believe is watched, rebinding
-    /// it to whatever inode currently lives there. This is a REBIND, not an add: it
-    /// must NOT touch `path_watch_counts` (the shared watch's logical-owner count is
-    /// unchanged). No-ops for paths the scan already pruned; callers gate on the
-    /// path still existing. See [`WatchManager::rearm_suspect_paths`] for why.
+    /// Rebind an existing backend watch without changing logical ownership.
     fn rearm_existing_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
         if !self.path_watch_counts.contains_key(path) {
             return Ok(());
@@ -261,9 +229,7 @@ impl FilteredWatcher {
         }
     }
 
-    /// Like `remove_path_watch`, but for teardown: it drops the refcount even
-    /// when the backend unwatch fails (e.g. notify already forgot a deleted
-    /// directory), so a torn-down root never leaves a phantom count behind.
+    /// Teardown variant: drop logical ownership even if backend unwatch fails.
     fn remove_path_watch_best_effort(&mut self, path: &Path) {
         match self.path_watch_counts.get(path).copied() {
             Some(count) if count > 1 => {
@@ -282,12 +248,8 @@ impl FilteredWatcher {
     }
 
     fn collect_recursive_dirs(root: &Path) -> HashSet<PathBuf> {
-        // Git-aware only: honor .gitignore, .git/info/exclude, the global
-        // gitignore and parent-directory ignore files, but NOT generic `.ignore`
-        // files (`ignore(false)`). `.ignore` is not a Git ignore source, so
-        // honoring it would hide directories Git/Magit still track, and the
-        // ignore-rule refresh detection only recognizes Git sources.
-        // hidden(false): include .git/, magit cares about it.
+        // Git-aware only: ignore Git sources, not generic `.ignore` files.
+        // hidden(false): include .git/, which Magit cares about.
         let walker = ignore::WalkBuilder::new(root)
             .standard_filters(true)
             .ignore(false)
@@ -336,13 +298,8 @@ impl WatchManager {
                 // Only forward events that indicate filesystem mutations
                 match event.kind {
                     EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                        // These directory create/rename/remove events drive the recursive
-                        // watch topology, so they must not be dropped. The channel is
-                        // unbounded rather than bounded: this closure runs on notify's
-                        // single event-loop thread, which also services watch()/unwatch(),
-                        // so a bounded blocking_send would deadlock against a refresh's
-                        // inner.watch() (and try_send would drop topology events). send()
-                        // never blocks; the queue is drained once per debounce window.
+                        // Topology events cannot be dropped, and blocking here can
+                        // deadlock notify's watch/unwatch event loop.
                         let _ = tx.send(event);
                     }
                     _ => {} // Ignore Access, Other events
@@ -366,11 +323,7 @@ impl WatchManager {
     /// If `recursive` is true, all subdirectories are also watched.
     /// Returns an error if the path doesn't exist or watch limits are exceeded.
     ///
-    /// Idempotent: re-adding an already-watched path with the same mode is a
-    /// no-op success. A non-recursive watch is upgraded to recursive on request,
-    /// but an existing recursive watch is never downgraded to non-recursive (that
-    /// request is also a no-op success). It is not refcounted at this layer: one
-    /// `unwatch` removes the path regardless of how many times it was added.
+    /// Repeated watches are idempotent; non-recursive watches can be upgraded.
     pub fn watch(&self, path: &Path, recursive: bool) -> Result<(), notify::Error> {
         let mode = if recursive {
             RecursiveMode::Recursive
@@ -487,14 +440,10 @@ impl WatchManager {
         }
     }
 
-    /// Force-rebind watches for directories that saw a remove/rename event during
-    /// the debounce window and still exist. This recovers the coalesced
-    /// delete+recreate (or rename-into-place) case that `apply_recursive_dirs`'s
-    /// path-set diff misses (unchanged set -> no-op, leaving the watch on a stale
-    /// inode). A replaced directory invalidates watches for the whole subtree, so
-    /// every still-existing watched descendant is rebound. Must run AFTER
-    /// `refresh_recursive_roots`, so genuine deletes are already pruned from the
-    /// refcounts and thus skipped here.
+    /// Rebind still-existing watches after Linux/inotify inode replacement.
+    ///
+    /// Must run after `refresh_recursive_roots`, so genuine deletes are already
+    /// pruned and only path-identical replacements remain.
     fn rearm_suspect_paths(&self, suspect_paths: HashSet<PathBuf>) {
         let existing_roots: Vec<PathBuf> = suspect_paths
             .into_iter()
@@ -518,10 +467,7 @@ impl WatchManager {
 
         let mut watcher = lock_or_recover(&self.watcher);
         for path in &existing {
-            // Best effort repair path: if the directory disappears again or the
-            // backend refuses the watch, leave logical ownership intact. A later
-            // topology refresh can prune missing paths; watch-limit errors are
-            // equivalent to refresh add failures, which are also non-fatal here.
+            // Best effort: keep logical ownership even if the backend refuses.
             let _ = watcher.rearm_existing_watch(path);
         }
     }
@@ -544,14 +490,7 @@ fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     paths.iter().filter(|path| path.is_dir()).cloned().collect()
 }
 
-/// Paths from events that drop or rebind a directory's kernel-watch inode (a
-/// delete frees the watch descriptor; a rename rebinds the name to a new inode).
-/// Collected during the debounce window and force-rebound afterward by
-/// [`WatchManager::rearm_suspect_paths`].
-///
-/// inotify-only: macOS FSEvents is path-based and keeps delivering to the
-/// recreated path, so there is nothing to re-arm. Returning empty off Linux keeps
-/// `suspect_paths` empty and skips the unwatch/rewatch churn entirely.
+/// Linux/inotify inputs for [`WatchManager::rearm_suspect_paths`].
 #[cfg(target_os = "linux")]
 fn inode_replacing_paths(event: &Event) -> Vec<PathBuf> {
     match event.kind {
@@ -852,7 +791,6 @@ mod tests {
         }
     }
 
-    /// Verify .gitignore patterns exclude their target directories from a recursive scan.
     #[test]
     fn test_recursive_scan_skips_gitignored_directories() {
         let temp = tempfile::tempdir().unwrap();
@@ -870,7 +808,6 @@ mod tests {
         assert!(!dirs.contains(&root.join("ignored/nested")));
     }
 
-    /// Verify .gitignore files above the walk root still apply to descendant paths.
     #[test]
     fn test_recursive_scan_honors_parent_gitignore() {
         let temp = tempfile::tempdir().unwrap();
@@ -888,8 +825,6 @@ mod tests {
         assert!(!dirs.contains(&sub.join("ignored")));
     }
 
-    /// Verify the scan is Git-aware only: a plain `.ignore` file does NOT exclude
-    /// directories (only Git ignore sources do), since Git/Magit still track them.
     #[test]
     fn test_recursive_scan_ignores_dot_ignore_files() {
         let temp = tempfile::tempdir().unwrap();
@@ -902,13 +837,10 @@ mod tests {
 
         let dirs = FilteredWatcher::collect_recursive_dirs(&root);
 
-        // `.ignore` is not honored: build/ stays watched.
         assert!(dirs.contains(&root.join("build")));
-        // `.gitignore` is still honored.
         assert!(!dirs.contains(&root.join("gitignored")));
     }
 
-    /// Verify a Create event for a new directory under a recursive root adds a watch.
     #[test]
     fn test_refresh_adds_new_directory_under_recursive_root() {
         let temp = tempfile::tempdir().unwrap();
@@ -937,7 +869,6 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify a Create event for a gitignored directory does not add a watch.
     #[test]
     fn test_refresh_does_not_watch_new_gitignored_directory() {
         let temp = tempfile::tempdir().unwrap();
@@ -961,7 +892,6 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify ignore rule file changes refresh the filtered recursive watch set.
     #[test]
     fn test_refresh_handles_gitignore_change() {
         let temp = tempfile::tempdir().unwrap();
@@ -1001,7 +931,6 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify Remove events clear stale watch state so a same-name recreation can re-register.
     #[test]
     fn test_refresh_removes_deleted_directory_and_rewatches_recreated_path() {
         let temp = tempfile::tempdir().unwrap();
@@ -1040,7 +969,6 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify a Modify(Name) rename event moves the watch from the old path to the new path.
     #[test]
     fn test_refresh_handles_directory_rename() {
         let temp = tempfile::tempdir().unwrap();
@@ -1073,10 +1001,6 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify a renamed directory receives real inotify events after the refresh.
-    /// Linux-only: it guards inotify watch-descriptor reuse, which does not occur
-    /// on macOS FSEvents, and FSEvents delivery is too latency-dependent to assert
-    /// reliably in a unit test.
     #[cfg(target_os = "linux")]
     #[test]
     fn test_refresh_rewatches_renamed_directory_for_real_events() {
@@ -1113,11 +1037,6 @@ mod tests {
         watcher.unwatch(&root).unwrap();
     }
 
-    /// Verify two overlapping recursive roots keep delivering real events for a
-    /// shared subdirectory after it is renamed. Coverage for refcounted re-watch
-    /// of the renamed path across both roots' refreshes (the renamed dir's parent
-    /// is watched, so notify remaps it; this guards that the refresh bookkeeping
-    /// stays consistent and events keep flowing).
     #[cfg(target_os = "linux")]
     #[test]
     fn test_overlapping_roots_rewatch_renamed_dir_for_real_events() {
@@ -1137,7 +1056,6 @@ mod tests {
         })
         .unwrap();
 
-        // Two overlapping recursive roots; sub/old is shared (refcount 2).
         watcher.watch(&root, RecursiveMode::Recursive).unwrap();
         watcher.watch(&sub, RecursiveMode::Recursive).unwrap();
         assert_eq!(watcher.path_watch_counts.get(&old_dir), Some(&2));
@@ -1146,7 +1064,6 @@ mod tests {
         drain_events(&rx);
 
         fs::rename(&old_dir, &new_dir).unwrap();
-        // Refresh both roots, as refresh_recursive_roots does for a rename event.
         for r in [&root, &sub] {
             let dirs = FilteredWatcher::collect_recursive_dirs(r);
             watcher.apply_recursive_dirs(r, dirs).unwrap();
@@ -1166,10 +1083,6 @@ mod tests {
         watcher.unwatch(&sub).unwrap();
     }
 
-    /// Verify deleting then recreating a directory covered by two overlapping
-    /// watches re-arms a real OS watch. Regression test: the kernel drops a
-    /// deleted directory's watch on its own, so a count-trusting re-add would
-    /// never reinstall it, leaving the recreated directory silent.
     #[cfg(target_os = "linux")]
     #[test]
     fn test_overlap_delete_recreate_rewatches_for_real_events() {
@@ -1187,7 +1100,6 @@ mod tests {
         })
         .unwrap();
 
-        // Overlapping direct + recursive watch on sub -> refcount 2.
         watcher.watch(&sub, RecursiveMode::NonRecursive).unwrap();
         watcher.watch(&root, RecursiveMode::Recursive).unwrap();
         assert_eq!(watcher.path_watch_counts.get(&sub), Some(&2));
@@ -1195,12 +1107,10 @@ mod tests {
         std::thread::sleep(Duration::from_millis(100));
         drain_events(&rx);
 
-        // Delete sub (the kernel auto-drops its watch) then refresh root's set.
         fs::remove_dir_all(&sub).unwrap();
         let dirs = FilteredWatcher::collect_recursive_dirs(&root);
         watcher.apply_recursive_dirs(&root, dirs).unwrap();
 
-        // Recreate the same path (new inode, no kernel watch yet) and refresh.
         fs::create_dir(&sub).unwrap();
         let dirs = FilteredWatcher::collect_recursive_dirs(&root);
         watcher.apply_recursive_dirs(&root, dirs).unwrap();
@@ -1216,12 +1126,6 @@ mod tests {
         let _ = watcher.unwatch(&root);
     }
 
-    /// Verify a directory deleted and recreated within ONE debounce window is
-    /// re-armed and keeps delivering real events. This is the coalesced case the
-    /// production path actually hits: the post-window scan sees an unchanged path
-    /// set, so `apply_recursive_dirs` is a no-op and only the suspect-path re-arm
-    /// rebinds the new inode. (The overlap test above does two separate refreshes,
-    /// which masks this.)
     #[cfg(target_os = "linux")]
     #[test]
     fn test_coalesced_delete_recreate_within_window_rewatches_for_real_events() {
@@ -1251,13 +1155,10 @@ mod tests {
         std::thread::sleep(Duration::from_millis(100));
         drain_events(&rx);
 
-        // Delete and recreate within one window: the kernel drops sub's whole
-        // watched subtree on delete; the recreated dirs have new inodes but the
-        // same paths.
         fs::remove_dir_all(&sub).unwrap();
         fs::create_dir_all(&nested).unwrap();
 
-        // Drive debounce_loop's post-window block for the coalesced Remove+Create.
+        // Drive debounce_loop's post-window refresh for coalesced Remove+Create.
         let remove_event = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(sub.clone());
         let create_event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(sub.clone());
         let mut roots: HashSet<PathBuf> = HashSet::new();
@@ -1269,8 +1170,6 @@ mod tests {
         manager.refresh_recursive_roots(roots);
         manager.rearm_suspect_paths(suspects);
 
-        // The scan's diff was a no-op (sub still present at the same path), so
-        // without the suspect re-arm the watch would point at the deleted inode.
         {
             let watcher = lock_or_recover(&manager.watcher);
             assert!(watcher.recursive_roots[&root].contains(&sub));
@@ -1290,7 +1189,67 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify repeated watch.add calls for the same canonical path are idempotent.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_coalesced_rename_into_place_within_window_rewatches_for_real_events() {
+        use notify::event::RenameMode;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        let sub_file = sub.join("file");
+        fs::create_dir(&sub).unwrap();
+
+        let staging_temp = tempfile::tempdir().unwrap();
+        let staging = staging_temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let manager = WatchManager {
+            watcher: Mutex::new(
+                FilteredWatcher::new(move |event: notify::Result<Event>| {
+                    if let Ok(event) = event {
+                        let _ = tx.send(event);
+                    }
+                })
+                .unwrap(),
+            ),
+            watched_paths: Mutex::new(HashMap::new()),
+        };
+        manager.watch(&root, true).unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::rename(&staging, &sub).unwrap();
+
+        // Drive debounce_loop's post-window refresh for rename-into-place.
+        let rename_event =
+            Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To))).add_path(sub.clone());
+        let mut roots: HashSet<PathBuf> = HashSet::new();
+        let mut suspects: HashSet<PathBuf> = HashSet::new();
+        roots.extend(manager.recursive_roots_for_event(&rename_event));
+        suspects.extend(inode_replacing_paths(&rename_event));
+        manager.refresh_recursive_roots(roots);
+        manager.rearm_suspect_paths(suspects);
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&sub));
+            assert_eq!(watcher.path_watch_counts.get(&sub), Some(&1));
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&sub_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event.paths.iter().any(|path| path.starts_with(&sub))
+        });
+
+        manager.unwatch(&root).unwrap();
+    }
+
     #[test]
     fn test_watch_is_idempotent_for_same_path_and_upgrades_to_recursive() {
         let temp = tempfile::tempdir().unwrap();
@@ -1313,7 +1272,6 @@ mod tests {
         assert!(!watcher.path_watch_counts.contains_key(&root));
     }
 
-    /// Verify refcounting keeps a non-recursive watch alive when its recursive parent is unwatched.
     #[test]
     fn test_recursive_unwatch_preserves_overlapping_direct_watch() {
         let temp = tempfile::tempdir().unwrap();
@@ -1334,7 +1292,6 @@ mod tests {
         assert!(!watcher.path_watch_counts.contains_key(&sub));
     }
 
-    /// Verify refcounting keeps a nested recursive watch alive when the outer recursive watch is unwatched.
     #[test]
     fn test_recursive_unwatch_preserves_overlapping_recursive_watch() {
         let temp = tempfile::tempdir().unwrap();

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -41,12 +41,85 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// Wraps a `RecommendedWatcher` with .gitignore-aware recursive watching.
+///
+/// This wrapper intercepts recursive watches: walks the tree honoring .gitignore and
+/// registers each non-ignored directory individually in NonRecursive mode.
+/// Unwatch then tears down all sub-watches owned by that recursive root.
+///
+/// To callers it looks just like a `notify::Watcher`.
+struct FilteredWatcher {
+    inner: RecommendedWatcher,
+    recursive_subwatches: HashMap<PathBuf, Vec<PathBuf>>,
+}
+
+impl FilteredWatcher {
+    fn new<F>(handler: F) -> Result<Self, notify::Error>
+    where
+        F: notify::EventHandler,
+    {
+        Ok(Self {
+            inner: RecommendedWatcher::new(handler, Config::default())?,
+            recursive_subwatches: HashMap::new(),
+        })
+    }
+
+    fn watch(&mut self, path: &Path, mode: RecursiveMode) -> Result<(), notify::Error> {
+        match mode {
+            RecursiveMode::NonRecursive => self.inner.watch(path, mode),
+            RecursiveMode::Recursive => {
+                // hidden(false): include .git/, magit cares about it.
+                // standard_filters honors .gitignore, .git/info/exclude, global ignore.
+                // parents(false): only walk down from root.
+                let walker = ignore::WalkBuilder::new(path)
+                    .standard_filters(true)
+                    .hidden(false)
+                    .parents(false)
+                    .build();
+
+                let mut subs: Vec<PathBuf> = Vec::new();
+                for entry in walker {
+                    let entry = match entry {
+                        Ok(e) => e,
+                        Err(_) => continue, // skip unreadable, keep walking
+                    };
+                    if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                        continue;
+                    }
+                    let p = entry.path();
+                    if let Err(err) = self.inner.watch(p, RecursiveMode::NonRecursive) {
+                        for already in &subs {
+                            let _ = self.inner.unwatch(already);
+                        }
+                        return Err(err);
+                    }
+                    subs.push(p.to_path_buf());
+                }
+                self.recursive_subwatches.insert(path.to_path_buf(), subs);
+                Ok(())
+            }
+        }
+    }
+
+    fn unwatch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        if let Some(subs) = self.recursive_subwatches.remove(path) {
+            // Best-effort: a deleted subtree shouldn't block removing the rest.
+            for p in &subs {
+                let _ = self.inner.unwatch(p);
+            }
+            Ok(())
+        } else {
+            self.inner.unwatch(path)
+        }
+    }
+}
+
 /// Manages filesystem watchers and sends change notifications to the client.
 pub struct WatchManager {
     /// The underlying OS watcher (inotify/kqueue).
     /// Protected by std::sync::Mutex because notify's callback runs on its
     /// own thread, not a tokio thread.
-    watcher: Mutex<RecommendedWatcher>,
+    watcher: Mutex<FilteredWatcher>,
 
     /// Currently watched paths: maps the canonical path used for the watch
     /// to its recursive mode. We store the canonical path from watch() so
@@ -64,23 +137,20 @@ impl WatchManager {
     pub fn new(writer: WriterHandle) -> Result<Arc<Self>, notify::Error> {
         let (tx, rx) = mpsc::channel(10_000);
 
-        let watcher = RecommendedWatcher::new(
-            move |event: notify::Result<Event>| {
-                if let Ok(event) = event {
-                    // Only forward events that indicate filesystem mutations
-                    match event.kind {
-                        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                            // Use try_send to drop events on overflow rather than blocking.
-                            // The debounce window coalesces events anyway, so dropped events
-                            // during extremely high-frequency bursts are acceptable.
-                            let _ = tx.try_send(event);
-                        }
-                        _ => {} // Ignore Access, Other events
+        let watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
+            if let Ok(event) = event {
+                // Only forward events that indicate filesystem mutations
+                match event.kind {
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
+                        // Use try_send to drop events on overflow rather than blocking.
+                        // The debounce window coalesces events anyway, so dropped events
+                        // during extremely high-frequency bursts are acceptable.
+                        let _ = tx.try_send(event);
                     }
+                    _ => {} // Ignore Access, Other events
                 }
-            },
-            Config::default(),
-        )?;
+            }
+        })?;
 
         let manager = Arc::new(Self {
             watcher: Mutex::new(watcher),

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -79,11 +79,13 @@ impl FilteredWatcher {
     fn unwatch(&mut self, path: &Path) -> Result<(), notify::Error> {
         if let Some(dirs) = self.recursive_roots.remove(path) {
             for p in &dirs {
-                let _ = self.remove_path_watch(p);
+                self.remove_path_watch_best_effort(p);
             }
             Ok(())
-        } else if self.direct_watches.remove(path) {
-            self.remove_path_watch(path)
+        } else if self.direct_watches.contains(path) {
+            self.remove_path_watch(path)?;
+            self.direct_watches.remove(path);
+            Ok(())
         } else {
             self.inner.unwatch(path)
         }
@@ -132,31 +134,70 @@ impl FilteredWatcher {
             .collect()
     }
 
+    /// Recursive roots whose watched set may change when the ignore file at
+    /// `path` changes.
+    ///
+    /// Known limitation: this only fires for ignore files inside a watched tree,
+    /// since events are only delivered for watched directories. When a subdirectory
+    /// is watched recursively without its repository root (e.g. a manual recursive
+    /// watch of `/repo/sub`), changes to an ignore file *above* the root such as
+    /// `/repo/.gitignore` are never observed, so ignore rules can go stale. The
+    /// common case (watching a git worktree root) is unaffected.
+    fn recursive_roots_for_ignore_rule(&self, path: &Path) -> Vec<PathBuf> {
+        let Some(scope) = ignore_rule_scope(path) else {
+            return Vec::new();
+        };
+
+        self.recursive_roots
+            .keys()
+            .filter(|root| root.starts_with(&scope) || scope.starts_with(root))
+            .cloned()
+            .collect()
+    }
+
+    /// Reconcile a recursive root's watched-directory set to `next`, adding and
+    /// removing per-directory watches to match.
+    ///
+    /// Known limitation: the diff is by path string against the post-window
+    /// snapshot. If a watched directory is renamed out of the tree (or deleted)
+    /// and a same-named directory is recreated within the same debounce window,
+    /// `current` and `next` are byte-identical, so the recreated (new-inode)
+    /// directory is not re-watched. Fixing this needs inode/descriptor-level
+    /// tracking rather than path-set diffing.
     fn apply_recursive_dirs(
         &mut self,
         root: &Path,
         next: HashSet<PathBuf>,
     ) -> Result<(), notify::Error> {
-        let Some(current) = self.recursive_roots.get(root) else {
+        let Some(current) = self.recursive_roots.get(root).cloned() else {
             return Ok(());
         };
 
-        let to_add: Vec<_> = next.difference(current).cloned().collect();
         let to_remove: Vec<_> = current.difference(&next).cloned().collect();
+        let to_add: Vec<_> = next.difference(&current).cloned().collect();
+        let mut applied = current;
         let mut added: Vec<PathBuf> = Vec::new();
+
+        // Apply removals before additions. For a rename old -> new this yields
+        // to_remove={old}, to_add={new}; removing first lets the backend release
+        // old's descriptor before new re-registers, so new cannot attach to a
+        // descriptor still bound to old's (now renamed) inode.
+        for dir in &to_remove {
+            self.remove_path_watch_best_effort(dir);
+            applied.remove(dir);
+        }
 
         for dir in &to_add {
             if let Err(err) = self.add_path_watch(dir) {
                 for added_dir in &added {
-                    let _ = self.remove_path_watch(added_dir);
+                    self.remove_path_watch_best_effort(added_dir);
+                    applied.remove(added_dir);
                 }
+                self.recursive_roots.insert(root.to_path_buf(), applied);
                 return Err(err);
             }
             added.push(dir.clone());
-        }
-
-        for dir in &to_remove {
-            let _ = self.remove_path_watch(dir);
+            applied.insert(dir.clone());
         }
 
         self.recursive_roots.insert(root.to_path_buf(), next);
@@ -164,28 +205,57 @@ impl FilteredWatcher {
     }
 
     fn add_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
-        let path = path.to_path_buf();
-        if let Some(count) = self.path_watch_counts.get_mut(&path) {
-            *count += 1;
-            return Ok(());
-        }
-
-        self.inner.watch(&path, RecursiveMode::NonRecursive)?;
-        self.path_watch_counts.insert(path, 1);
+        // Always (re-)issue the OS watch, even when the refcount is already
+        // positive: a path's count can outlive its kernel watch. inotify drops a
+        // directory's watch when the directory is deleted, so after a
+        // delete+recreate under an overlapping watch the surviving count would
+        // otherwise skip re-arming and the recreated directory would go silent
+        // (see test_overlap_delete_recreate_rewatches_for_real_events). Re-adding
+        // is cheap and idempotent: inotify_add_watch returns the same descriptor
+        // and merges the mask; on macOS FSEvents the duplicate path is removed
+        // wholesale on unwatch.
+        self.inner.watch(path, RecursiveMode::NonRecursive)?;
+        *self
+            .path_watch_counts
+            .entry(path.to_path_buf())
+            .or_insert(0) += 1;
         Ok(())
     }
 
     fn remove_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
-        match self.path_watch_counts.get_mut(path) {
-            Some(count) if *count > 1 => {
-                *count -= 1;
+        match self.path_watch_counts.get(path).copied() {
+            Some(count) if count > 1 => {
+                if let Some(count) = self.path_watch_counts.get_mut(path) {
+                    *count -= 1;
+                }
                 Ok(())
             }
             Some(_) => {
+                self.inner.unwatch(path)?;
                 self.path_watch_counts.remove(path);
-                self.inner.unwatch(path)
+                Ok(())
             }
             None => self.inner.unwatch(path),
+        }
+    }
+
+    /// Like `remove_path_watch`, but for teardown: it drops the refcount even
+    /// when the backend unwatch fails (e.g. notify already forgot a deleted
+    /// directory), so a torn-down root never leaves a phantom count behind.
+    fn remove_path_watch_best_effort(&mut self, path: &Path) {
+        match self.path_watch_counts.get(path).copied() {
+            Some(count) if count > 1 => {
+                if let Some(count) = self.path_watch_counts.get_mut(path) {
+                    *count -= 1;
+                }
+            }
+            Some(_) => {
+                let _ = self.inner.unwatch(path);
+                self.path_watch_counts.remove(path);
+            }
+            None => {
+                let _ = self.inner.unwatch(path);
+            }
         }
     }
 
@@ -233,17 +303,21 @@ impl WatchManager {
     /// short window, and writes `fs.changed` notifications to the client
     /// via the shared stdout writer.
     pub fn new(writer: WriterHandle) -> Result<Arc<Self>, notify::Error> {
-        let (tx, rx) = mpsc::channel(10_000);
+        let (tx, rx) = mpsc::unbounded_channel();
 
         let watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
             if let Ok(event) = event {
                 // Only forward events that indicate filesystem mutations
                 match event.kind {
                     EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                        // Use try_send to drop events on overflow rather than blocking.
-                        // The debounce window coalesces events anyway, so dropped events
-                        // during extremely high-frequency bursts are acceptable.
-                        let _ = tx.try_send(event);
+                        // These directory create/rename/remove events drive the recursive
+                        // watch topology, so they must not be dropped. The channel is
+                        // unbounded rather than bounded: this closure runs on notify's
+                        // single event-loop thread, which also services watch()/unwatch(),
+                        // so a bounded blocking_send would deadlock against a refresh's
+                        // inner.watch() (and try_send would drop topology events). send()
+                        // never blocks; the queue is drained once per debounce window.
+                        let _ = tx.send(event);
                     }
                     _ => {} // Ignore Access, Other events
                 }
@@ -265,6 +339,12 @@ impl WatchManager {
     ///
     /// If `recursive` is true, all subdirectories are also watched.
     /// Returns an error if the path doesn't exist or watch limits are exceeded.
+    ///
+    /// Idempotent: re-adding an already-watched path with the same mode is a
+    /// no-op success. A non-recursive watch is upgraded to recursive on request,
+    /// but an existing recursive watch is never downgraded to non-recursive (that
+    /// request is also a no-op success). It is not refcounted at this layer: one
+    /// `unwatch` removes the path regardless of how many times it was added.
     pub fn watch(&self, path: &Path, recursive: bool) -> Result<(), notify::Error> {
         let mode = if recursive {
             RecursiveMode::Recursive
@@ -277,20 +357,29 @@ impl WatchManager {
         })?;
 
         let mut watcher = lock_or_recover(&self.watcher);
-        {
-            let paths = lock_or_recover(&self.watched_paths);
-            if paths.contains_key(&canonical) {
-                return Err(notify::Error::generic(&format!(
-                    "Path already being watched: {}",
-                    canonical.display()
-                )));
+        let mut paths = lock_or_recover(&self.watched_paths);
+
+        match paths.get(&canonical).copied() {
+            Some(existing) if existing == mode => return Ok(()),
+            Some(RecursiveMode::Recursive) => return Ok(()),
+            Some(RecursiveMode::NonRecursive) => {
+                watcher.unwatch(&canonical)?;
+                if let Err(err) = watcher.watch(&canonical, RecursiveMode::Recursive) {
+                    if watcher
+                        .watch(&canonical, RecursiveMode::NonRecursive)
+                        .is_err()
+                    {
+                        paths.remove(&canonical);
+                    }
+                    return Err(err);
+                }
+                paths.insert(canonical, RecursiveMode::Recursive);
+            }
+            None => {
+                watcher.watch(&canonical, mode)?;
+                paths.insert(canonical, mode);
             }
         }
-
-        watcher.watch(&canonical, mode)?;
-
-        let mut paths = lock_or_recover(&self.watched_paths);
-        paths.insert(canonical, mode);
 
         Ok(())
     }
@@ -333,17 +422,27 @@ impl WatchManager {
             .collect()
     }
 
-    fn refresh_recursive_watches_for_event(&self, event: &Event) {
+    fn recursive_roots_for_event(&self, event: &Event) -> HashSet<PathBuf> {
         let refresh_paths = directory_tree_refresh_paths(event);
-        if refresh_paths.is_empty() {
-            return;
+        let ignore_paths = ignore_rule_paths(event);
+        if refresh_paths.is_empty() && ignore_paths.is_empty() {
+            return HashSet::new();
         }
 
-        let roots_to_refresh = {
-            let watcher = lock_or_recover(&self.watcher);
-            watcher.recursive_roots_for_paths(&refresh_paths)
-        };
+        let watcher = lock_or_recover(&self.watcher);
+        let mut roots_to_refresh: HashSet<_> = watcher
+            .recursive_roots_for_paths(&refresh_paths)
+            .into_iter()
+            .collect();
 
+        for path in ignore_paths {
+            roots_to_refresh.extend(watcher.recursive_roots_for_ignore_rule(&path));
+        }
+
+        roots_to_refresh
+    }
+
+    fn refresh_recursive_roots(&self, roots_to_refresh: HashSet<PathBuf>) {
         if roots_to_refresh.is_empty() {
             return;
         }
@@ -380,6 +479,55 @@ fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     paths.iter().filter(|path| path.is_dir()).cloned().collect()
 }
 
+fn ignore_rule_paths(event: &Event) -> Vec<PathBuf> {
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) {
+        return Vec::new();
+    }
+
+    event
+        .paths
+        .iter()
+        .filter(|path| is_ignore_rule_path(path))
+        .cloned()
+        .collect()
+}
+
+fn is_ignore_rule_path(path: &Path) -> bool {
+    if path.file_name().is_some_and(|name| name == ".gitignore") {
+        return true;
+    }
+
+    path.file_name().is_some_and(|name| name == "exclude")
+        && path
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == "info")
+        && path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == ".git")
+}
+
+fn ignore_rule_scope(path: &Path) -> Option<PathBuf> {
+    if path.file_name().is_some_and(|name| name == ".gitignore") {
+        return path.parent().map(Path::to_path_buf);
+    }
+
+    if is_ignore_rule_path(path) {
+        return path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .map(Path::to_path_buf);
+    }
+
+    None
+}
+
 /// Background task: receives raw inotify events, debounces them, and sends
 /// batched `fs.changed` notifications to the Emacs client.
 ///
@@ -390,7 +538,7 @@ fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
 /// 4. When the timer fires, send one notification with all unique paths
 /// 5. Go back to step 1
 async fn debounce_loop(
-    mut rx: mpsc::Receiver<Event>,
+    mut rx: mpsc::UnboundedReceiver<Event>,
     writer: WriterHandle,
     manager: Weak<WatchManager>,
 ) {
@@ -400,14 +548,10 @@ async fn debounce_loop(
             Some(e) => e,
             None => break, // Channel closed, watcher dropped
         };
-        if let Some(manager) = manager.upgrade() {
-            manager.refresh_recursive_watches_for_event(&event);
-        }
 
         let mut pending_paths: HashSet<PathBuf> = HashSet::new();
-        for path in event.paths {
-            pending_paths.insert(path);
-        }
+        let mut roots_to_refresh: HashSet<PathBuf> = HashSet::new();
+        collect_event(event, &manager, &mut pending_paths, &mut roots_to_refresh);
 
         // Phase 2: Collect more events during the debounce window
         let deadline = time::Instant::now() + DEBOUNCE_DURATION;
@@ -419,17 +563,16 @@ async fn debounce_loop(
                 event = rx.recv() => {
                     match event {
                         Some(e) => {
-                            if let Some(manager) = manager.upgrade() {
-                                manager.refresh_recursive_watches_for_event(&e);
-                            }
-                            for path in e.paths {
-                                pending_paths.insert(path);
-                            }
+                            collect_event(e, &manager, &mut pending_paths, &mut roots_to_refresh);
                         }
                         None => return, // Channel closed
                     }
                 }
             }
+        }
+
+        if let Some(manager) = manager.upgrade() {
+            manager.refresh_recursive_roots(roots_to_refresh);
         }
 
         // Phase 3: Send notification with all collected paths
@@ -439,6 +582,19 @@ async fn debounce_loop(
             break;
         }
     }
+}
+
+fn collect_event(
+    event: Event,
+    manager: &Weak<WatchManager>,
+    pending_paths: &mut HashSet<PathBuf>,
+    roots_to_refresh: &mut HashSet<PathBuf>,
+) {
+    if let Some(manager) = manager.upgrade() {
+        roots_to_refresh.extend(manager.recursive_roots_for_event(&event));
+    }
+
+    pending_paths.extend(event.paths);
 }
 
 /// Serialize and send an `fs.changed` notification over the stdout writer.

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -6,11 +6,12 @@
 
 use crate::protocol::{Notification, RpcError};
 use crate::{msgpack_map, WriterHandle};
+use notify::event::{ModifyKind, RemoveKind};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rmpv::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration};
@@ -50,7 +51,9 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 /// To callers it looks just like a `notify::Watcher`.
 struct FilteredWatcher {
     inner: RecommendedWatcher,
-    recursive_subwatches: HashMap<PathBuf, Vec<PathBuf>>,
+    recursive_roots: HashMap<PathBuf, HashSet<PathBuf>>,
+    direct_watches: HashSet<PathBuf>,
+    path_watch_counts: HashMap<PathBuf, usize>,
 }
 
 impl FilteredWatcher {
@@ -60,57 +63,152 @@ impl FilteredWatcher {
     {
         Ok(Self {
             inner: RecommendedWatcher::new(handler, Config::default())?,
-            recursive_subwatches: HashMap::new(),
+            recursive_roots: HashMap::new(),
+            direct_watches: HashSet::new(),
+            path_watch_counts: HashMap::new(),
         })
     }
 
     fn watch(&mut self, path: &Path, mode: RecursiveMode) -> Result<(), notify::Error> {
         match mode {
-            RecursiveMode::NonRecursive => self.inner.watch(path, mode),
-            RecursiveMode::Recursive => {
-                // hidden(false): include .git/, magit cares about it.
-                // standard_filters honors .gitignore, .git/info/exclude, global ignore.
-                // parents(false): only walk down from root.
-                let walker = ignore::WalkBuilder::new(path)
-                    .standard_filters(true)
-                    .hidden(false)
-                    .parents(false)
-                    .build();
-
-                let mut subs: Vec<PathBuf> = Vec::new();
-                for entry in walker {
-                    let entry = match entry {
-                        Ok(e) => e,
-                        Err(_) => continue, // skip unreadable, keep walking
-                    };
-                    if !entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                        continue;
-                    }
-                    let p = entry.path();
-                    if let Err(err) = self.inner.watch(p, RecursiveMode::NonRecursive) {
-                        for already in &subs {
-                            let _ = self.inner.unwatch(already);
-                        }
-                        return Err(err);
-                    }
-                    subs.push(p.to_path_buf());
-                }
-                self.recursive_subwatches.insert(path.to_path_buf(), subs);
-                Ok(())
-            }
+            RecursiveMode::NonRecursive => self.watch_nonrecursive(path),
+            RecursiveMode::Recursive => self.watch_recursive(path),
         }
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<(), notify::Error> {
-        if let Some(subs) = self.recursive_subwatches.remove(path) {
-            // Best-effort: a deleted subtree shouldn't block removing the rest.
-            for p in &subs {
-                let _ = self.inner.unwatch(p);
+        if let Some(dirs) = self.recursive_roots.remove(path) {
+            for p in &dirs {
+                let _ = self.remove_path_watch(p);
             }
             Ok(())
+        } else if self.direct_watches.remove(path) {
+            self.remove_path_watch(path)
         } else {
             self.inner.unwatch(path)
         }
+    }
+
+    fn watch_nonrecursive(&mut self, path: &Path) -> Result<(), notify::Error> {
+        let path = path.to_path_buf();
+        if !self.direct_watches.insert(path.clone()) {
+            return Ok(());
+        }
+
+        if let Err(err) = self.add_path_watch(&path) {
+            self.direct_watches.remove(&path);
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn watch_recursive(&mut self, path: &Path) -> Result<(), notify::Error> {
+        let dirs = Self::collect_recursive_dirs(path);
+        if self.recursive_roots.contains_key(path) {
+            return self.apply_recursive_dirs(path, dirs);
+        }
+
+        // Seed the root with an empty set so initial registration can use the
+        // same diff-and-rollback path as later refreshes.
+        self.recursive_roots
+            .insert(path.to_path_buf(), HashSet::new());
+        if let Err(err) = self.apply_recursive_dirs(path, dirs) {
+            self.recursive_roots.remove(path);
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    fn recursive_roots_for_paths(&self, paths: &[PathBuf]) -> Vec<PathBuf> {
+        self.recursive_roots
+            .iter()
+            .filter(|(root, dirs)| {
+                paths
+                    .iter()
+                    .any(|path| path.starts_with(root) && (path.is_dir() || dirs.contains(path)))
+            })
+            .map(|(root, _)| root.clone())
+            .collect()
+    }
+
+    fn apply_recursive_dirs(
+        &mut self,
+        root: &Path,
+        next: HashSet<PathBuf>,
+    ) -> Result<(), notify::Error> {
+        let Some(current) = self.recursive_roots.get(root) else {
+            return Ok(());
+        };
+
+        let to_add: Vec<_> = next.difference(current).cloned().collect();
+        let to_remove: Vec<_> = current.difference(&next).cloned().collect();
+        let mut added: Vec<PathBuf> = Vec::new();
+
+        for dir in &to_add {
+            if let Err(err) = self.add_path_watch(dir) {
+                for added_dir in &added {
+                    let _ = self.remove_path_watch(added_dir);
+                }
+                return Err(err);
+            }
+            added.push(dir.clone());
+        }
+
+        for dir in &to_remove {
+            let _ = self.remove_path_watch(dir);
+        }
+
+        self.recursive_roots.insert(root.to_path_buf(), next);
+        Ok(())
+    }
+
+    fn add_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        let path = path.to_path_buf();
+        if let Some(count) = self.path_watch_counts.get_mut(&path) {
+            *count += 1;
+            return Ok(());
+        }
+
+        self.inner.watch(&path, RecursiveMode::NonRecursive)?;
+        self.path_watch_counts.insert(path, 1);
+        Ok(())
+    }
+
+    fn remove_path_watch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        match self.path_watch_counts.get_mut(path) {
+            Some(count) if *count > 1 => {
+                *count -= 1;
+                Ok(())
+            }
+            Some(_) => {
+                self.path_watch_counts.remove(path);
+                self.inner.unwatch(path)
+            }
+            None => self.inner.unwatch(path),
+        }
+    }
+
+    fn collect_recursive_dirs(root: &Path) -> HashSet<PathBuf> {
+        // hidden(false): include .git/, magit cares about it.
+        // standard_filters honors .gitignore, .git/info/exclude, global ignore,
+        // including ignore files from parent directories.
+        let walker = ignore::WalkBuilder::new(root)
+            .standard_filters(true)
+            .hidden(false)
+            .build();
+
+        let mut dirs = HashSet::new();
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue, // skip unreadable paths, keep walking
+            };
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                dirs.insert(entry.path().to_path_buf());
+            }
+        }
+        dirs
     }
 }
 
@@ -158,7 +256,7 @@ impl WatchManager {
         });
 
         // Spawn the debounce background task
-        tokio::spawn(debounce_loop(rx, writer));
+        tokio::spawn(debounce_loop(rx, writer, Arc::downgrade(&manager)));
 
         Ok(manager)
     }
@@ -179,6 +277,16 @@ impl WatchManager {
         })?;
 
         let mut watcher = lock_or_recover(&self.watcher);
+        {
+            let paths = lock_or_recover(&self.watched_paths);
+            if paths.contains_key(&canonical) {
+                return Err(notify::Error::generic(&format!(
+                    "Path already being watched: {}",
+                    canonical.display()
+                )));
+            }
+        }
+
         watcher.watch(&canonical, mode)?;
 
         let mut paths = lock_or_recover(&self.watched_paths);
@@ -224,6 +332,52 @@ impl WatchManager {
             .map(|(p, m)| (p.clone(), matches!(m, RecursiveMode::Recursive)))
             .collect()
     }
+
+    fn refresh_recursive_watches_for_event(&self, event: &Event) {
+        let refresh_paths = directory_tree_refresh_paths(event);
+        if refresh_paths.is_empty() {
+            return;
+        }
+
+        let roots_to_refresh = {
+            let watcher = lock_or_recover(&self.watcher);
+            watcher.recursive_roots_for_paths(&refresh_paths)
+        };
+
+        if roots_to_refresh.is_empty() {
+            return;
+        }
+
+        let refreshed_roots: Vec<_> = roots_to_refresh
+            .into_iter()
+            .map(|root| {
+                let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+                (root, dirs)
+            })
+            .collect();
+
+        let mut watcher = lock_or_recover(&self.watcher);
+        for (root, dirs) in refreshed_roots {
+            let _ = watcher.apply_recursive_dirs(&root, dirs);
+        }
+    }
+}
+
+fn directory_tree_refresh_paths(event: &Event) -> Vec<PathBuf> {
+    match event.kind {
+        EventKind::Create(_) | EventKind::Modify(ModifyKind::Any | ModifyKind::Other) => {
+            existing_directory_paths(&event.paths)
+        }
+        EventKind::Modify(ModifyKind::Name(_)) => event.paths.clone(),
+        EventKind::Remove(RemoveKind::Any | RemoveKind::Folder | RemoveKind::Other) => {
+            event.paths.clone()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn existing_directory_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
+    paths.iter().filter(|path| path.is_dir()).cloned().collect()
 }
 
 /// Background task: receives raw inotify events, debounces them, and sends
@@ -235,13 +389,20 @@ impl WatchManager {
 /// 3. Collect all events that arrive during the timer window
 /// 4. When the timer fires, send one notification with all unique paths
 /// 5. Go back to step 1
-async fn debounce_loop(mut rx: mpsc::Receiver<Event>, writer: WriterHandle) {
+async fn debounce_loop(
+    mut rx: mpsc::Receiver<Event>,
+    writer: WriterHandle,
+    manager: Weak<WatchManager>,
+) {
     loop {
         // Phase 1: Wait for the first event
         let event = match rx.recv().await {
             Some(e) => e,
             None => break, // Channel closed, watcher dropped
         };
+        if let Some(manager) = manager.upgrade() {
+            manager.refresh_recursive_watches_for_event(&event);
+        }
 
         let mut pending_paths: HashSet<PathBuf> = HashSet::new();
         for path in event.paths {
@@ -258,6 +419,9 @@ async fn debounce_loop(mut rx: mpsc::Receiver<Event>, writer: WriterHandle) {
                 event = rx.recv() => {
                     match event {
                         Some(e) => {
+                            if let Some(manager) = manager.upgrade() {
+                                manager.refresh_recursive_watches_for_event(&e);
+                            }
                             for path in e.paths {
                                 pending_paths.insert(path);
                             }
@@ -381,4 +545,243 @@ pub fn handle_list(_params: Value) -> HandlerResult {
         .collect();
 
     Ok(Value::Array(watches))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{CreateKind, RenameMode};
+    use std::fs;
+
+    fn test_manager() -> WatchManager {
+        WatchManager {
+            watcher: Mutex::new(FilteredWatcher::new(|_: notify::Result<Event>| {}).unwrap()),
+            watched_paths: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Verify .gitignore patterns exclude their target directories from a recursive scan.
+    #[test]
+    fn test_recursive_scan_skips_gitignored_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".gitignore"), "ignored/\n").unwrap();
+        fs::create_dir_all(root.join("ignored/nested")).unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+
+        assert!(dirs.contains(&root));
+        assert!(dirs.contains(&root.join("src")));
+        assert!(!dirs.contains(&root.join("ignored")));
+        assert!(!dirs.contains(&root.join("ignored/nested")));
+    }
+
+    /// Verify .gitignore files above the walk root still apply to descendant paths.
+    #[test]
+    fn test_recursive_scan_honors_parent_gitignore() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".gitignore"), "sub/ignored/\n").unwrap();
+        fs::create_dir_all(sub.join("ignored")).unwrap();
+        fs::create_dir_all(sub.join("tracked")).unwrap();
+
+        let dirs = FilteredWatcher::collect_recursive_dirs(&sub);
+
+        assert!(dirs.contains(&sub));
+        assert!(dirs.contains(&sub.join("tracked")));
+        assert!(!dirs.contains(&sub.join("ignored")));
+    }
+
+    /// Verify a Create event for a new directory under a recursive root adds a watch.
+    #[test]
+    fn test_refresh_adds_new_directory_under_recursive_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let src = root.join("src");
+        let new_dir = src.join("new");
+        fs::create_dir_all(&src).unwrap();
+
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&new_dir));
+        }
+
+        fs::create_dir_all(&new_dir).unwrap();
+        let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(new_dir.clone());
+        manager.refresh_recursive_watches_for_event(&event);
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&new_dir));
+            assert_eq!(watcher.path_watch_counts.get(&new_dir), Some(&1));
+        }
+        manager.unwatch(&root).unwrap();
+    }
+
+    /// Verify a Create event for a gitignored directory does not add a watch.
+    #[test]
+    fn test_refresh_does_not_watch_new_gitignored_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".gitignore"), "ignored/\n").unwrap();
+
+        let ignored_dir = root.join("ignored");
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+
+        fs::create_dir_all(&ignored_dir).unwrap();
+        let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(ignored_dir.clone());
+        manager.refresh_recursive_watches_for_event(&event);
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&ignored_dir));
+            assert!(!watcher.path_watch_counts.contains_key(&ignored_dir));
+        }
+        manager.unwatch(&root).unwrap();
+    }
+
+    /// Verify Remove events clear stale watch state so a same-name recreation can re-register.
+    #[test]
+    fn test_refresh_removes_deleted_directory_and_rewatches_recreated_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let removed_dir = root.join("removed");
+        fs::create_dir_all(&removed_dir).unwrap();
+
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&removed_dir));
+            assert_eq!(watcher.path_watch_counts.get(&removed_dir), Some(&1));
+        }
+
+        fs::remove_dir_all(&removed_dir).unwrap();
+        let remove_event =
+            Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(removed_dir.clone());
+        manager.refresh_recursive_watches_for_event(&remove_event);
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&removed_dir));
+            assert!(!watcher.path_watch_counts.contains_key(&removed_dir));
+        }
+
+        fs::create_dir_all(&removed_dir).unwrap();
+        let create_event =
+            Event::new(EventKind::Create(CreateKind::Folder)).add_path(removed_dir.clone());
+        manager.refresh_recursive_watches_for_event(&create_event);
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&removed_dir));
+            assert_eq!(watcher.path_watch_counts.get(&removed_dir), Some(&1));
+        }
+
+        manager.unwatch(&root).unwrap();
+    }
+
+    /// Verify a Modify(Name) rename event moves the watch from the old path to the new path.
+    #[test]
+    fn test_refresh_handles_directory_rename() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let old_dir = root.join("old");
+        let new_dir = root.join("new");
+        fs::create_dir_all(&old_dir).unwrap();
+
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&old_dir));
+            assert_eq!(watcher.path_watch_counts.get(&old_dir), Some(&1));
+        }
+
+        fs::rename(&old_dir, &new_dir).unwrap();
+        let event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+            .add_path(old_dir.clone())
+            .add_path(new_dir.clone());
+        manager.refresh_recursive_watches_for_event(&event);
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&old_dir));
+            assert!(watcher.recursive_roots[&root].contains(&new_dir));
+            assert!(!watcher.path_watch_counts.contains_key(&old_dir));
+            assert_eq!(watcher.path_watch_counts.get(&new_dir), Some(&1));
+        }
+        manager.unwatch(&root).unwrap();
+    }
+
+    /// Verify the API rejects a second watch on an already-watched canonical path.
+    #[test]
+    fn test_watch_rejects_same_path_registered_with_different_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+        assert!(manager.watch(&root, false).is_err());
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots.contains_key(&root));
+            assert!(!watcher.direct_watches.contains(&root));
+            assert_eq!(watcher.path_watch_counts.get(&root), Some(&1));
+        }
+
+        manager.unwatch(&root).unwrap();
+        let watcher = lock_or_recover(&manager.watcher);
+        assert!(!watcher.path_watch_counts.contains_key(&root));
+    }
+
+    /// Verify refcounting keeps a non-recursive watch alive when its recursive parent is unwatched.
+    #[test]
+    fn test_recursive_unwatch_preserves_overlapping_direct_watch() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+
+        let mut watcher = FilteredWatcher::new(|_: notify::Result<Event>| {}).unwrap();
+        watcher.watch(&sub, RecursiveMode::NonRecursive).unwrap();
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+
+        assert_eq!(watcher.path_watch_counts.get(&sub), Some(&2));
+        watcher.unwatch(&root).unwrap();
+        assert!(watcher.direct_watches.contains(&sub));
+        assert_eq!(watcher.path_watch_counts.get(&sub), Some(&1));
+
+        watcher.unwatch(&sub).unwrap();
+        assert!(!watcher.path_watch_counts.contains_key(&sub));
+    }
+
+    /// Verify refcounting keeps a nested recursive watch alive when the outer recursive watch is unwatched.
+    #[test]
+    fn test_recursive_unwatch_preserves_overlapping_recursive_watch() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+
+        let mut watcher = FilteredWatcher::new(|_: notify::Result<Event>| {}).unwrap();
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+        watcher.watch(&sub, RecursiveMode::Recursive).unwrap();
+
+        assert_eq!(watcher.path_watch_counts.get(&sub), Some(&2));
+        watcher.unwatch(&root).unwrap();
+        assert!(watcher.recursive_roots.contains_key(&sub));
+        assert_eq!(watcher.path_watch_counts.get(&sub), Some(&1));
+
+        watcher.unwatch(&sub).unwrap();
+        assert!(!watcher.path_watch_counts.contains_key(&sub));
+    }
 }

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -708,11 +708,45 @@ mod tests {
     use super::*;
     use notify::event::{CreateKind, RenameMode};
     use std::fs;
+    #[cfg(target_os = "linux")]
+    use std::sync::mpsc as std_mpsc;
+    #[cfg(target_os = "linux")]
+    use std::time::{Duration, Instant};
 
     fn test_manager() -> WatchManager {
         WatchManager {
             watcher: Mutex::new(FilteredWatcher::new(|_: notify::Result<Event>| {}).unwrap()),
             watched_paths: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn refresh_for_event(manager: &WatchManager, event: &Event) {
+        let roots = manager.recursive_roots_for_event(event);
+        manager.refresh_recursive_roots(roots);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn drain_events(rx: &std_mpsc::Receiver<Event>) {
+        while rx.try_recv().is_ok() {}
+    }
+
+    #[cfg(target_os = "linux")]
+    fn recv_event_matching<F>(rx: &std_mpsc::Receiver<Event>, timeout: Duration, mut matches: F)
+    where
+        F: FnMut(&Event) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                panic!("timed out waiting for matching notify event");
+            }
+
+            match rx.recv_timeout(remaining) {
+                Ok(event) if matches(&event) => return,
+                Ok(_) => {}
+                Err(err) => panic!("timed out waiting for notify event: {err}"),
+            }
         }
     }
 
@@ -771,7 +805,7 @@ mod tests {
 
         fs::create_dir_all(&new_dir).unwrap();
         let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(new_dir.clone());
-        manager.refresh_recursive_watches_for_event(&event);
+        refresh_for_event(&manager, &event);
 
         {
             let watcher = lock_or_recover(&manager.watcher);
@@ -795,8 +829,48 @@ mod tests {
 
         fs::create_dir_all(&ignored_dir).unwrap();
         let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(ignored_dir.clone());
-        manager.refresh_recursive_watches_for_event(&event);
+        refresh_for_event(&manager, &event);
 
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&ignored_dir));
+            assert!(!watcher.path_watch_counts.contains_key(&ignored_dir));
+        }
+        manager.unwatch(&root).unwrap();
+    }
+
+    /// Verify ignore rule file changes refresh the filtered recursive watch set.
+    #[test]
+    fn test_refresh_handles_gitignore_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let ignored_dir = root.join("ignored");
+        let gitignore = root.join(".gitignore");
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::create_dir_all(&ignored_dir).unwrap();
+        fs::write(&gitignore, "ignored/\n").unwrap();
+
+        let manager = test_manager();
+        manager.watch(&root, true).unwrap();
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(!watcher.recursive_roots[&root].contains(&ignored_dir));
+        }
+
+        fs::write(&gitignore, "").unwrap();
+        let unignore_event =
+            Event::new(EventKind::Modify(ModifyKind::Any)).add_path(gitignore.clone());
+        refresh_for_event(&manager, &unignore_event);
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root].contains(&ignored_dir));
+            assert_eq!(watcher.path_watch_counts.get(&ignored_dir), Some(&1));
+        }
+
+        fs::write(&gitignore, "ignored/\n").unwrap();
+        let ignore_event =
+            Event::new(EventKind::Modify(ModifyKind::Any)).add_path(gitignore.clone());
+        refresh_for_event(&manager, &ignore_event);
         {
             let watcher = lock_or_recover(&manager.watcher);
             assert!(!watcher.recursive_roots[&root].contains(&ignored_dir));
@@ -824,7 +898,7 @@ mod tests {
         fs::remove_dir_all(&removed_dir).unwrap();
         let remove_event =
             Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(removed_dir.clone());
-        manager.refresh_recursive_watches_for_event(&remove_event);
+        refresh_for_event(&manager, &remove_event);
         {
             let watcher = lock_or_recover(&manager.watcher);
             assert!(!watcher.recursive_roots[&root].contains(&removed_dir));
@@ -834,7 +908,7 @@ mod tests {
         fs::create_dir_all(&removed_dir).unwrap();
         let create_event =
             Event::new(EventKind::Create(CreateKind::Folder)).add_path(removed_dir.clone());
-        manager.refresh_recursive_watches_for_event(&create_event);
+        refresh_for_event(&manager, &create_event);
         {
             let watcher = lock_or_recover(&manager.watcher);
             assert!(watcher.recursive_roots[&root].contains(&removed_dir));
@@ -865,7 +939,7 @@ mod tests {
         let event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
             .add_path(old_dir.clone())
             .add_path(new_dir.clone());
-        manager.refresh_recursive_watches_for_event(&event);
+        refresh_for_event(&manager, &event);
 
         {
             let watcher = lock_or_recover(&manager.watcher);
@@ -877,15 +951,159 @@ mod tests {
         manager.unwatch(&root).unwrap();
     }
 
-    /// Verify the API rejects a second watch on an already-watched canonical path.
+    /// Verify a renamed directory receives real inotify events after the refresh.
+    /// Linux-only: it guards inotify watch-descriptor reuse, which does not occur
+    /// on macOS FSEvents, and FSEvents delivery is too latency-dependent to assert
+    /// reliably in a unit test.
+    #[cfg(target_os = "linux")]
     #[test]
-    fn test_watch_rejects_same_path_registered_with_different_mode() {
+    fn test_refresh_rewatches_renamed_directory_for_real_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let old_dir = root.join("old");
+        let new_dir = root.join("new");
+        let new_file = new_dir.join("file");
+        fs::create_dir_all(&old_dir).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let mut watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
+            if let Ok(event) = event {
+                let _ = tx.send(event);
+            }
+        })
+        .unwrap();
+
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::rename(&old_dir, &new_dir).unwrap();
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+        watcher.apply_recursive_dirs(&root, dirs).unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&new_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event.paths.iter().any(|path| path.starts_with(&new_dir))
+        });
+
+        watcher.unwatch(&root).unwrap();
+    }
+
+    /// Verify two overlapping recursive roots keep delivering real events for a
+    /// shared subdirectory after it is renamed. Coverage for refcounted re-watch
+    /// of the renamed path across both roots' refreshes (the renamed dir's parent
+    /// is watched, so notify remaps it; this guards that the refresh bookkeeping
+    /// stays consistent and events keep flowing).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_overlapping_roots_rewatch_renamed_dir_for_real_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        let old_dir = sub.join("old");
+        let new_dir = sub.join("new");
+        let new_file = new_dir.join("file");
+        fs::create_dir_all(&old_dir).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let mut watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
+            if let Ok(event) = event {
+                let _ = tx.send(event);
+            }
+        })
+        .unwrap();
+
+        // Two overlapping recursive roots; sub/old is shared (refcount 2).
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+        watcher.watch(&sub, RecursiveMode::Recursive).unwrap();
+        assert_eq!(watcher.path_watch_counts.get(&old_dir), Some(&2));
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::rename(&old_dir, &new_dir).unwrap();
+        // Refresh both roots, as refresh_recursive_roots does for a rename event.
+        for r in [&root, &sub] {
+            let dirs = FilteredWatcher::collect_recursive_dirs(r);
+            watcher.apply_recursive_dirs(r, dirs).unwrap();
+        }
+        assert_eq!(watcher.path_watch_counts.get(&new_dir), Some(&2));
+        assert!(!watcher.path_watch_counts.contains_key(&old_dir));
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&new_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event.paths.iter().any(|path| path.starts_with(&new_dir))
+        });
+
+        watcher.unwatch(&root).unwrap();
+        watcher.unwatch(&sub).unwrap();
+    }
+
+    /// Verify deleting then recreating a directory covered by two overlapping
+    /// watches re-arms a real OS watch. Regression test: the kernel drops a
+    /// deleted directory's watch on its own, so a count-trusting re-add would
+    /// never reinstall it, leaving the recreated directory silent.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_overlap_delete_recreate_rewatches_for_real_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let sub = root.join("sub");
+        let sub_file = sub.join("file");
+        fs::create_dir_all(&sub).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let mut watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
+            if let Ok(event) = event {
+                let _ = tx.send(event);
+            }
+        })
+        .unwrap();
+
+        // Overlapping direct + recursive watch on sub -> refcount 2.
+        watcher.watch(&sub, RecursiveMode::NonRecursive).unwrap();
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+        assert_eq!(watcher.path_watch_counts.get(&sub), Some(&2));
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        // Delete sub (the kernel auto-drops its watch) then refresh root's set.
+        fs::remove_dir_all(&sub).unwrap();
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+        watcher.apply_recursive_dirs(&root, dirs).unwrap();
+
+        // Recreate the same path (new inode, no kernel watch yet) and refresh.
+        fs::create_dir(&sub).unwrap();
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+        watcher.apply_recursive_dirs(&root, dirs).unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&sub_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event.paths.iter().any(|path| path.starts_with(&sub))
+        });
+
+        let _ = watcher.unwatch(&root);
+    }
+
+    /// Verify repeated watch.add calls for the same canonical path are idempotent.
+    #[test]
+    fn test_watch_is_idempotent_for_same_path_and_upgrades_to_recursive() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path().canonicalize().unwrap();
 
         let manager = test_manager();
+        manager.watch(&root, false).unwrap();
         manager.watch(&root, true).unwrap();
-        assert!(manager.watch(&root, false).is_err());
+        manager.watch(&root, false).unwrap();
 
         {
             let watcher = lock_or_recover(&manager.watcher);

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -254,6 +254,9 @@ impl FilteredWatcher {
             .standard_filters(true)
             .ignore(false)
             .hidden(false)
+            // Match notify's recursive watcher behavior: recursive watches
+            // follow symlinked directories and install watches below them.
+            .follow_links(true)
             .build();
 
         let mut dirs = HashSet::new();
@@ -841,6 +844,25 @@ mod tests {
         assert!(!dirs.contains(&root.join("gitignored")));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_recursive_scan_follows_symlinked_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let real = root.join("real");
+        let link = root.join("link");
+        fs::create_dir_all(real.join("nested")).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let dirs = FilteredWatcher::collect_recursive_dirs(&root);
+
+        assert!(dirs.contains(&root));
+        assert!(dirs.contains(&real));
+        assert!(dirs.contains(&real.join("nested")));
+        assert!(dirs.contains(&link));
+        assert!(dirs.contains(&link.join("nested")));
+    }
+
     #[test]
     fn test_refresh_adds_new_directory_under_recursive_root() {
         let temp = tempfile::tempdir().unwrap();
@@ -999,6 +1021,41 @@ mod tests {
             assert_eq!(watcher.path_watch_counts.get(&new_dir), Some(&1));
         }
         manager.unwatch(&root).unwrap();
+    }
+
+    #[cfg(all(target_os = "linux", unix))]
+    #[test]
+    fn test_recursive_watch_follows_symlinked_directories_for_real_events() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let real = root.join("real");
+        let link = root.join("link");
+        let linked_nested = link.join("nested");
+        let linked_file = linked_nested.join("file");
+        fs::create_dir_all(real.join("nested")).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let (tx, rx) = std_mpsc::channel();
+        let mut watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
+            if let Ok(event) = event {
+                let _ = tx.send(event);
+            }
+        })
+        .unwrap();
+
+        watcher.watch(&root, RecursiveMode::Recursive).unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        drain_events(&rx);
+
+        fs::write(&linked_file, "changed").unwrap();
+        recv_event_matching(&rx, Duration::from_secs(2), |event| {
+            event
+                .paths
+                .iter()
+                .any(|path| path.starts_with(&linked_nested))
+        });
+
+        watcher.unwatch(&root).unwrap();
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Recursive `watch.add` blindly walks every subdirectory and exhausts the OS inotify limit on projects with large gitignored trees (`.venv`, `node_modules`, `target`, ...).
In magit this surfaces as a 30 s timeout on `watch.add` followed by `OS file watch limit reached`.
<img width="834" height="89" alt="image" src="https://github.com/user-attachments/assets/75cda17f-b82d-485c-a510-d8b3a9592529" />
This pr warps `RecommendedWatcher` in a `FilteredWatcher` that intercepts recursive watches while honoring `.gitignore`. The public API keeps unchanged.
