### PR TITLE
Fix a recently added test when running it on NixOS / in nix sandbox

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -168,10 +168,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_write_not_blocked_by_long_poll_read() {
         let start_params = Value::Map(vec![
-            (
-                Value::String("cmd".into()),
-                Value::String("/bin/cat".into()),
-            ),
+            (Value::String("cmd".into()), Value::String("cat".into())),
             (Value::String("cwd".into()), Value::String("/tmp".into())),
         ]);
         let start_payload = make_request("process.start", start_params);


### PR DESCRIPTION
Use bare `cat` instead of a hardcoded path so the binary is found via `PATH`. This way test will be passing in NixOS / nix build sandbox, where there is no global `/bin/cat` available.

According to https://docs.rs/tokio/latest/tokio/process/struct.Command.html, `Command::new()` will do the `PATH` lookup automatically for non-absolute `program`'s.

As a side-note, `/bin/sh` is working because it's 1 of the 2 binaries NixOS/nix sandbox provide (the other being `/usr/bin/env`). Maybe `/bin/sh` in tests is also worth cleaning, but not strictly necessary.