### PR TITLE
fix: filter non-existing directories from remote-path

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3003,7 +3003,8 @@ A non-nil deprecated `tramp-rpc-remote-path' overrides
 `tramp-remote-path'.  Supports the standard TRAMP placeholders
 `tramp-default-remote-path' and `tramp-own-remote-path'.  The old
 `tramp-rpc-own-remote-path' placeholder is treated like
-`tramp-own-remote-path'.  Duplicate and unsupported entries are removed."
+`tramp-own-remote-path'.  Duplicate, unsupported, and nonexistent
+entries are removed."
   (let ((own-path nil)
         (default-path nil)
         (result nil))
@@ -3022,7 +3023,13 @@ A non-nil deprecated `tramp-rpc-remote-path' overrides
         (setq result (tramp-rpc--append-path-entries (list entry) result)))
        (t
         (tramp-rpc--debug "Ignoring unsupported remote PATH entry: %S" entry))))
-    result))
+    ;; Remove non-existing directories (matches tramp-sh behavior).
+    (delq nil (mapcar (lambda (x)
+                        (and (stringp x)
+                             (file-directory-p
+                              (tramp-make-tramp-file-name vec x))
+                             x))
+                      result)))
 
 (defun tramp-rpc--get-remote-login-shell (vec)
   "Return the login shell for the remote user on VEC.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3029,7 +3029,7 @@ entries are removed."
                              (file-directory-p
                               (tramp-make-tramp-file-name vec x))
                              x))
-                      result)))
+                      result))))
 
 (defun tramp-rpc--get-remote-login-shell (vec)
   "Return the login shell for the remote user on VEC.


### PR DESCRIPTION
From Michael Albinus' email (2026-05-15):

> tramp-rpc doesn't filter out non-existing directories from tramp-remote-path, contrary to what tramp-sh does. tramp-test35-exec-path fails for tramp-rpc because of this.

**Fix:** Add a non-existing directory filter at the end of `tramp-rpc--compute-remote-path`, matching tramp-sh's approach using `file-directory-p` + `tramp-make-tramp-file-name`.

See `tramp-get-remote-path` in tramp-sh.el for the equivalent logic.