### PR TITLE
Support run-python on RPC connections

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -24,6 +24,7 @@
 ;; - process-command / process-tty-name (return stored metadata)
 ;; - vc-call-backend (ensure default-directory for remote VC files)
 ;; - vc-exec-after (handle native-compiled VC process state races)
+;; - python-shell--tramp-with-environment (avoid sending shell commands to the RPC server)
 ;; - eglot--cmd (bypass shell wrapping for RPC connections)
 ;; - magit-start-process (force pipe mode when INPUT will be piped to the process)
 ;; - vc-dir-refresh (clean up stale processes)
@@ -60,8 +61,12 @@
 (declare-function vc-set-mode-line-busy-indicator "vc-dispatcher")
 (declare-function vc--process-sentinel "vc-dispatcher")
 
-;; Variables from vc-dir.el (used in vc-dir-refresh handler)
+;; Functions from python.el (used by python-shell integration)
+(declare-function python-shell--tramp-with-environment "python")
+
+;; Variables from vc-dir.el / tramp.el (used in integration handlers)
 (defvar vc-dir-process-buffer)
+(defvar tramp-remote-process-environment)
 
 ;; ============================================================================
 ;; Process I/O handler
@@ -330,7 +335,28 @@ state."
   nil)
 
 ;; ============================================================================
-;; Privilege elevation integration
+;; Python shell integration
+;; ============================================================================
+
+(defun tramp-rpc-handle-python-shell--tramp-with-environment
+    (orig-fun vec extraenv bodyfun)
+  "Run Python shell BODYFUN without tramp-sh environment refresh for RPC.
+
+`python-shell--tramp-with-environment' assumes that every TRAMP connection
+has an interactive shell and refreshes environment variables by calling
+`tramp-send-command'.  A tramp-rpc connection process is the MessagePack RPC
+server, not a shell, so sending shell snippets to it can block commands such as
+`run-python'.  For rpc connections, keep the requested environment in a
+dynamic `tramp-remote-process-environment' binding and let tramp-rpc's process
+handlers pass it directly to the server."
+  (if (tramp-rpc-file-name-p vec)
+      (let ((tramp-remote-process-environment
+             (append extraenv
+                     (and (boundp 'tramp-remote-process-environment)
+                          tramp-remote-process-environment))))
+        (funcall bodyfun))
+    (funcall orig-fun vec extraenv bodyfun)))
+
 ;; ============================================================================
 ;; Eglot integration
 ;; ============================================================================
@@ -462,6 +488,12 @@ exited (remote side finished), delete it so the refresh can proceed."
   ;; If eglot/magit-process is already loaded while `tramp-rpc' is being
   ;; required, defer registration until `tramp-rpc' is provided; otherwise
   ;; `tramp-add-external-operation' calls `(require 'tramp-rpc)' recursively.
+  (with-eval-after-load 'python
+    (unless (advice-member-p
+             #'tramp-rpc-handle-python-shell--tramp-with-environment
+             'python-shell--tramp-with-environment)
+      (advice-add 'python-shell--tramp-with-environment :around
+                  #'tramp-rpc-handle-python-shell--tramp-with-environment)))
   (with-eval-after-load 'eglot
     (with-eval-after-load 'tramp-rpc
       (tramp-add-external-operation
@@ -490,6 +522,9 @@ exited (remote side finished), delete it so the refresh can proceed."
   (tramp-remove-external-operation 'process-tty-name 'tramp-rpc)
   (tramp-remove-external-operation 'vc-call-backend 'tramp-rpc)
   (tramp-remove-external-operation 'vc-exec-after 'tramp-rpc)
+  (when (fboundp 'python-shell--tramp-with-environment)
+    (advice-remove 'python-shell--tramp-with-environment
+                   #'tramp-rpc-handle-python-shell--tramp-with-environment))
   (tramp-remove-external-operation 'eglot--cmd 'tramp-rpc)
   (tramp-remove-external-operation 'magit-start-process 'tramp-rpc)
   (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -53,6 +53,7 @@
 (declare-function tramp-rpc--ensure-inside-emacs-env "tramp-rpc")
 (declare-function tramp-rpc--merge-environments "tramp-rpc")
 (declare-function tramp-rpc--remote-path-environment "tramp-rpc")
+(declare-function tramp-rpc--tramp-remote-process-environment "tramp-rpc")
 (declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
@@ -454,6 +455,7 @@ Resolves program path and loads direnv environment from working directory."
       (let ((process-env (tramp-rpc--ensure-inside-emacs-env
                           (tramp-rpc--merge-environments
                            (tramp-rpc--remote-path-environment v)
+                           (tramp-rpc--tramp-remote-process-environment)
                            (tramp-rpc--get-direnv-environment v localname)
                            (tramp-rpc--caller-environment)))))
         (if use-pty

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -663,6 +663,36 @@ Uses `tramp-remote-path' by default.  A non-nil deprecated
     (when remote-path
       `(("PATH" . ,(mapconcat #'identity remote-path ":"))))))
 
+(defvar tramp-remote-process-environment)
+
+(defun tramp-rpc--environment-list-to-alist (environment)
+  "Convert ENVIRONMENT strings of the form NAME=VALUE to an alist.
+Entries without an equals sign are ignored because they request unsetting a
+variable in Emacs process APIs, while tramp-rpc sends an explicit environment
+map to the remote server."
+  (let (alist)
+    (dolist (elt environment)
+      (when (and (stringp elt)
+                 (string-match "\\`\\([^=]+\\)=\\(.*\\)\\'" elt))
+        (push (cons (match-string 1 elt) (match-string 2 elt)) alist)))
+    (nreverse alist)))
+
+(defun tramp-rpc--tramp-remote-process-environment ()
+  "Return dynamic `tramp-remote-process-environment' entries as an alist.
+This includes dynamic bindings made by packages such as python.el for remote
+processes.  The baseline `tramp-remote-process-environment' entries are shell
+setup snippets for tramp-sh (for example, LC_CTYPE set to two single quotes),
+not a direct exec environment.  Do not pass those defaults to RPC child
+processes, because they can leak shell-only quoting and produce warnings on
+stdout/stderr."
+  (when (boundp 'tramp-remote-process-environment)
+    (let ((baseline (default-toplevel-value 'tramp-remote-process-environment))
+          dynamic)
+      (dolist (elt tramp-remote-process-environment)
+        (unless (member elt baseline)
+          (push elt dynamic)))
+      (tramp-rpc--environment-list-to-alist (nreverse dynamic)))))
+
 (defun tramp-rpc--caller-environment ()
   "Extract environment variable overrides from `process-environment'.
 Emacs packages dynamically bind env vars via `with-environment-variables'
@@ -3125,6 +3155,7 @@ refresh), git commands are served from the prefetch cache when possible."
                (env (tramp-rpc--ensure-inside-emacs-env
                      (tramp-rpc--merge-environments
                       (tramp-rpc--remote-path-environment v)
+                      (tramp-rpc--tramp-remote-process-environment)
                       (tramp-rpc--get-direnv-environment v localname)
                       (tramp-rpc--caller-environment))))
                (stdin-content (when (and infile (not (eq infile t)))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -2056,6 +2056,42 @@ discard it for being unreadable."
                    ("B" . "direnv")
                    ("GIT_INDEX_FILE" . "/tmp/index")))))
 
+(ert-deftest tramp-rpc-mock-test-tramp-remote-process-environment-to-alist ()
+  "Test conversion of dynamic `tramp-remote-process-environment' entries."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-remote-process-environment
+         (append '("TERM=dumb" "PYTHONUNBUFFERED=1" "UNSET_ME" "EMPTY=")
+                 (default-toplevel-value 'tramp-remote-process-environment))))
+    (should (equal (tramp-rpc--tramp-remote-process-environment)
+                   '(("TERM" . "dumb")
+                     ("PYTHONUNBUFFERED" . "1")
+                     ("EMPTY" . ""))))))
+
+(ert-deftest tramp-rpc-mock-test-tramp-remote-process-environment-skips-baseline ()
+  "Test TRAMP shell setup defaults are not passed as RPC child env vars."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-remote-process-environment
+         (default-toplevel-value 'tramp-remote-process-environment)))
+    (should-not (tramp-rpc--tramp-remote-process-environment))))
+
+(ert-deftest tramp-rpc-mock-test-python-tramp-environment-advice ()
+  "Test python.el TRAMP environment advice avoids shell refresh for RPC."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((called-original nil)
+        (body-env nil)
+        (vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
+                                   :localname "/work/"))
+        (tramp-remote-process-environment '("EXISTING=yes")))
+    (tramp-rpc-handle-python-shell--tramp-with-environment
+     (lambda (&rest _args) (setq called-original t))
+     vec
+     '("TERM=dumb" "PYTHONUNBUFFERED=1")
+     (lambda ()
+       (setq body-env tramp-remote-process-environment)))
+    (should-not called-original)
+    (should (equal body-env
+                   '("TERM=dumb" "PYTHONUNBUFFERED=1" "EXISTING=yes")))))
+
 (ert-deftest tramp-rpc-mock-test-process-file-passes-path-and-unresolved-command ()
   "Test `process-file' searches commands with `tramp-remote-path' PATH."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
@@ -2082,6 +2118,32 @@ discard it for being unreadable."
       (should (equal (alist-get 'args captured-params) ["pattern"]))
       (should (equal (assoc "PATH" (alist-get 'env captured-params))
                      '("PATH" . "/home/user/.cargo/bin:/usr/bin:/bin"))))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-passes-tramp-remote-environment ()
+  "Test `process-file' forwards dynamic TRAMP remote process env vars."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/")
+        (captured-env nil)
+        (tramp-remote-process-environment '("TERM=dumb" "PYTHONUNBUFFERED=1")))
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (_vec) '("/usr/bin")))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--decode-output)
+               (lambda (output _encoding) output))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (equal method "process.run"))
+                 (setq captured-env (alist-get 'env params))
+                 '((exit_code . 0) (stdout . "") (stderr . "")))))
+      (should (= (tramp-rpc-handle-process-file "python3" nil nil nil "-c" "pass") 0))
+      (should (equal (assoc "TERM" captured-env) '("TERM" . "dumb")))
+      (should (equal (assoc "PYTHONUNBUFFERED" captured-env)
+                     '("PYTHONUNBUFFERED" . "1"))))))
 
 ;;; ============================================================================
 ;;; Direnv Cache Path Normalization Tests (No server or SSH required)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1255,6 +1255,52 @@ This matches the upstream `tramp-test28-process-file' test."
           (should (string-match-p "test-input" output)))
       (ignore-errors (delete-process proc)))))
 
+(ert-deftest tramp-rpc-test14-python-shell-make-comint ()
+  "Test `python-shell-make-comint' on an existing TRAMP RPC connection."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+  (require 'python)
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (python-shell-completion-native-enable nil)
+         (python-shell-font-lock-enable nil)
+         (buf nil)
+         proc)
+    (let* ((probe-buffer (generate-new-buffer "*tramp-rpc-python-probe*"))
+           (process-connection-type t)
+           (probe (start-file-process "tramp-rpc-python-probe" probe-buffer
+                                      "python3" "--version")))
+      (unwind-protect
+          (progn
+            (with-timeout (10 (error "Python probe timeout"))
+              (while (process-live-p probe)
+                (accept-process-output probe 0.1)))
+            (skip-unless (= 0 (process-exit-status probe))))
+        (ignore-errors (delete-process probe))
+        (kill-buffer probe-buffer)))
+    ;; Ensure the RPC connection exists before python.el tries to adjust its
+    ;; remote environment.  This used to hang because python.el sent shell
+    ;; snippets to the RPC server process via `tramp-send-command'.
+    (should (file-directory-p default-directory))
+    (unwind-protect
+        (with-timeout (15 (error "Python shell timeout"))
+          (setq buf (python-shell-make-comint "python3 -i" "Python-Test"))
+          (setq proc (get-buffer-process buf))
+          (while (and (process-live-p proc)
+                      (not (with-current-buffer buf
+                             (save-excursion
+                               (goto-char (point-min))
+                               (search-forward ">>>" nil t)))))
+            (accept-process-output proc 0.1))
+          (should (with-current-buffer buf
+                    (save-excursion
+                      (goto-char (point-min))
+                      (search-forward ">>>" nil t)))))
+      (when (processp proc)
+        (ignore-errors (delete-process proc)))
+      (when (and (bufferp buf) (buffer-live-p buf))
+        (kill-buffer buf)))))
+
 ;;; ============================================================================
 ;;; Test 15: Copy/Rename Between Local and Remote
 ;;; ============================================================================


### PR DESCRIPTION
## Summary

Fixes #209 by making `run-python` work on existing `tramp-rpc` connections.

`python.el` calls `python-shell--tramp-with-environment` before starting the
inferior Python process.  For already-open TRAMP connections, that helper tries
to refresh the remote shell environment by sending shell commands with
`tramp-send-command`.  A `tramp-rpc` connection process is the MessagePack RPC
server, not an interactive shell, so those shell snippets can hang.

This PR:

- advises `python-shell--tramp-with-environment` for `rpc` connections so it
  keeps Python's requested env vars in a dynamic
  `tramp-remote-process-environment` binding instead of refreshing a shell;
- forwards those dynamic remote process env vars through `process-file` and
  async `make-process` / `start-file-process` RPC launches;
- avoids forwarding TRAMP's baseline shell setup entries (for example
  `LC_CTYPE` with shell quoting), which are meant for `tramp-sh` and caused CI
  upstream process tests to see locale warnings in command output;
- adds mock env propagation coverage and a remote regression test for
  `python-shell-make-comint` on an existing RPC connection.

## Testing

- Mock env/advice tests pass locally.
- `run-python` on `/rpc:gmktec-k11:/tmp/` reaches the Python prompt locally.
- Remote ERT `tramp-rpc-test14-python-shell-make-comint` passes on
  `gmktec-k11` locally.
- Byte-compiled `lisp/*.el` with `byte-compile-error-on-warn`.
