### PR TITLE
Fix set-process-coding-system for cons pair :coding argument

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -412,11 +412,18 @@ update is still running."
 
 (defun tramp-rpc--coding-args (coding)
   "Return list of arguments for `set-process-coding-system' from CODING.
-CODING can be a symbol (used for both decoding and encoding) or a cons
-cell (DECODING . ENCODING)."
+CODING can be a symbol (used for both decoding and encoding), a cons
+cell (DECODING . ENCODING), or nil.  When DECODING or ENCODING is nil
+inside a cons, it is replaced with the corresponding default from
+`default-process-coding-system', matching how native `make-process'
+handles nil :coding elements."
   (if (consp coding)
-      (list (car coding) (cdr coding))
-    (list coding coding)))
+      (list (or (car coding) (car default-process-coding-system))
+            (or (cdr coding) (cdr default-process-coding-system)))
+    (if coding
+        (list coding coding)
+      (list (car default-process-coding-system)
+            (cdr default-process-coding-system)))))
 
 ;; ============================================================================
 ;; make-process handler

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -407,6 +407,18 @@ update is still running."
                                          (delete-process proc))))))))))
 
 ;; ============================================================================
+;; Coding helper
+;; ============================================================================
+
+(defun tramp-rpc--coding-args (coding)
+  "Return list of arguments for `set-process-coding-system' from CODING.
+CODING can be a symbol (used for both decoding and encoding) or a cons
+cell (DECODING . ENCODING)."
+  (if (consp coding)
+      (list (car coding) (cdr coding))
+    (list coding coding)))
+
+;; ============================================================================
 ;; make-process handler
 ;; ============================================================================
 
@@ -494,7 +506,8 @@ Resolves program path and loads direnv environment from working directory."
 
           ;; Configure the local relay process
           (when coding
-            (set-process-coding-system local-process coding coding))
+            (apply #'set-process-coding-system local-process
+                   (tramp-rpc--coding-args coding)))
           (set-process-query-on-exit-flag local-process (not noquery))
 
           (process-put local-process :tramp-rpc-vec v)
@@ -654,7 +667,8 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
 
     ;; Configure the process
     (when coding
-      (set-process-coding-system process coding coding))
+      (apply #'set-process-coding-system process
+             (tramp-rpc--coding-args coding)))
     (set-process-query-on-exit-flag process (not noquery))
 
     ;; Set up filter
@@ -725,7 +739,8 @@ DIRENV-ENV is an optional alist of environment variables for the process."
     (set-process-sentinel local-process #'tramp-rpc--pty-sentinel)
     (set-process-query-on-exit-flag local-process (not noquery))
     (when coding
-      (set-process-coding-system local-process coding coding))
+      (apply #'set-process-coding-system local-process
+             (tramp-rpc--coding-args coding)))
 
     ;; Store process info
     (process-put local-process :tramp-rpc-pty t)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1210,6 +1210,22 @@ This matches the upstream `tramp-test28-process-file' test."
       (should (>= (nth 1 info) 0)))))
 
 ;;; ============================================================================
+;;; Test 13b: Coding argument handling (unit test, no remote host needed)
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test13b-coding-args ()
+  "Test `tramp-rpc--coding-args' handles symbol and cons pair coding."
+  ;; Symbol case: same value used for both decoding and encoding
+  (should (equal '(utf-8-unix utf-8-unix)
+                 (tramp-rpc--coding-args 'utf-8-unix)))
+  ;; Cons pair case: (DECODING . ENCODING)
+  (should (equal '(undecided-unix utf-8-unix)
+                 (tramp-rpc--coding-args '(undecided-unix . utf-8-unix))))
+  ;; Nil case (not normally called, but be safe)
+  (should (equal '(nil nil)
+                 (tramp-rpc--coding-args nil))))
+
+;;; ============================================================================
 ;;; Test 14: Async Processes
 ;;; ============================================================================
 

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1215,15 +1215,23 @@ This matches the upstream `tramp-test28-process-file' test."
 
 (ert-deftest tramp-rpc-test13b-coding-args ()
   "Test `tramp-rpc--coding-args' handles symbol and cons pair coding."
-  ;; Symbol case: same value used for both decoding and encoding
-  (should (equal '(utf-8-unix utf-8-unix)
-                 (tramp-rpc--coding-args 'utf-8-unix)))
-  ;; Cons pair case: (DECODING . ENCODING)
-  (should (equal '(undecided-unix utf-8-unix)
-                 (tramp-rpc--coding-args '(undecided-unix . utf-8-unix))))
-  ;; Nil case (not normally called, but be safe)
-  (should (equal '(nil nil)
-                 (tramp-rpc--coding-args nil))))
+  (let ((default-dec (car default-process-coding-system))
+        (default-enc (cdr default-process-coding-system)))
+    ;; Symbol case: same value used for both decoding and encoding
+    (should (equal '(utf-8-unix utf-8-unix)
+                   (tramp-rpc--coding-args 'utf-8-unix)))
+    ;; Cons pair case: (DECODING . ENCODING)
+    (should (equal '(undecided-unix utf-8-unix)
+                   (tramp-rpc--coding-args '(undecided-unix . utf-8-unix))))
+    ;; Cons pair with nil decoding: nil replaced with default
+    (should (equal (list default-dec 'utf-8-unix)
+                   (tramp-rpc--coding-args '(nil . utf-8-unix))))
+    ;; Cons pair with nil encoding: nil replaced with default
+    (should (equal (list 'utf-8-unix default-enc)
+                   (tramp-rpc--coding-args '(utf-8-unix . nil))))
+    ;; Bare nil: both sides defaulted
+    (should (equal (list default-dec default-enc)
+                   (tramp-rpc--coding-args nil)))))
 
 ;;; ============================================================================
 ;;; Test 14: Async Processes


### PR DESCRIPTION
E.g. `magit-blame-addition` wasn't working.

`make-process`'s `:coding` can be a cons pair `(DECODING . ENCODING)`, but
`set-process-coding-system` expects individual symbol arguments.
When `:coding` is `(undecided-unix . utf-8-unix)`, passing it
directly causes `symbolp` to fail:

Wrong type argument: symbolp (undecided-unix . utf-8-unix)

This affected `tramp-rpc--make-direct-ssh-pty-process` and other
process starters.

## Changes

- Extract `tramp-rpc--coding-args` helper that unwraps a cons pair
  into proper `(decoding encoding)` args, or passes a symbol twice.
- Replace three duplicated inline `(if (consp coding) ...)` blocks
  with calls to the helper.
- Add `tramp-rpc-test13b-coding-args` unit test covering symbol,
  cons pair, and nil cases.

(disclosure: this one is fully AI generated, but it solves my problem fully - now I can use `magit-blame-addition`)