### PR TITLE
feat: add structured watch events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "tramp-rpc-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["server"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 authors = ["Arthur Heymans <arthur@aheymans.xyz>"]

--- a/doc/TECHNICAL_COMPARISON.org
+++ b/doc/TECHNICAL_COMPARISON.org
@@ -217,13 +217,33 @@ TRAMP-RPC exposes these method categories:
 | ancestors.scan        | {path, markers}                 | {found: [{marker, directory}]} |
 
 **** Filesystem Watch Operations
-| Method       | Parameters     | Returns                   |
-|--------------+----------------+---------------------------|
-| watch.add    | path           | boolean                   |
-| watch.remove | path           | boolean                   |
-| watch.list   | (none)         | [string]                  |
+| Method       | Parameters                       | Returns                                      |
+|--------------+----------------------------------+----------------------------------------------|
+| watch.add    | ~{path: bin/string, recursive?}~ | ~{path: bin, recursive: bool}~               |
+| watch.remove | ~{path: bin/string}~             | ~true~                                       |
+| watch.list   | ~(none)~                         | ~[{path: bin, recursive: bool}]~             |
 
-The server also pushes ~fs.changed~ notifications (no id) when watched directories change.
+The server also pushes ~fs.events~ notifications (no id) when watched directories change:
+
+#+begin_src elisp
+((version . "2.0")
+ (method . "fs.events")
+ (params . ((events . [((action . "created") (path . PATH-BIN))
+                       ((action . "changed") (path . PATH-BIN))
+                       ((action . "attribute-changed") (path . PATH-BIN))
+                       ((action . "deleted") (path . PATH-BIN))
+                       ((action . "renamed")
+                        (path . OLD-PATH-BIN) (path1 . NEW-PATH-BIN))
+                       ((action . "renamed-from")
+                        (path . OLD-PATH-BIN) (cookie . COOKIE))
+                       ((action . "renamed-to")
+                        (path . NEW-PATH-BIN) (cookie . COOKIE))
+                       ((action . "rescan"))]))))
+#+end_src
+
+~watch.add~ defaults ~recursive~ to true when the field is omitted.  ~PATH-BIN~
+values are MessagePack ~bin~ payloads containing remote OS path bytes.  A
+~rescan~ event means the client should discard cached state for the connection.
 
 * Performance Analysis
 

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -58,7 +58,7 @@ straight/repos..., which contains Cargo.toml and the Rust server sources."
   "Deployment settings for TRAMP-RPC."
   :group 'tramp)
 
-(defconst tramp-rpc-deploy-version "0.10.0"
+(defconst tramp-rpc-deploy-version "0.11.0"
   "Current version of tramp-rpc-server.")
 
 (defconst tramp-rpc-deploy-binary-name "tramp-rpc-server"

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -18,7 +18,7 @@
 ;; This file provides caching infrastructure, filesystem watching, and
 ;; magit/projectile integration for tramp-rpc.  It includes:
 ;; - TTL-based file-exists and file-truename caches
-;; - Cache invalidation via server push notifications (fs.changed)
+;; - Cache invalidation via server push notifications (fs.events)
 ;; - Watch management (add/remove/list watched directories)
 ;; - Notification dispatch for filesystem change events
 ;; - Parallel git command prefetch for fast magit-status
@@ -40,8 +40,12 @@
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
+(declare-function tramp-rpc--decode-string "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc--canonical-watch-active-p "tramp-rpc")
+(declare-function tramp-rpc--file-notify-alias-paths "tramp-rpc")
 (declare-function tramp-rpc--file-notify-dispatch "tramp-rpc")
+(declare-function tramp-rpc--watch-entry-canonical-directory "tramp-rpc")
 
 ;; Silence byte-compiler warnings for external functions
 (declare-function projectile-dir-files-alien "projectile")
@@ -157,7 +161,7 @@ Keys are \"conn-key:path\" strings, values are plists with watch metadata.")
 (defvar tramp-rpc--file-notify-watch-counts)
 
 (defvar tramp-rpc--suppress-fs-notifications nil
-  "When non-nil, suppress handling of fs.changed notifications.
+  "When non-nil, suppress cache handling of fs.events notifications.
 Used during operations that will invalidate caches themselves.")
 
 (defun tramp-rpc--connection-key-string (vec)
@@ -180,32 +184,90 @@ Used during operations that will invalidate caches themselves.")
 PROCESS is the connection, METHOD is the notification method,
 PARAMS is the notification parameters."
   (cond
-   ((string= method "fs.changed")
-    (tramp-rpc--handle-fs-changed process params))
+   ((string= method "fs.events")
+    (tramp-rpc--handle-fs-events process params))
    (t
     (tramp-rpc--debug "Unknown notification: %s" method))))
 
-(defun tramp-rpc--handle-fs-changed (process params)
-  "Handle an fs.changed notification from PROCESS with PARAMS.
-Invalidates caches for the changed paths."
-  (let ((paths (alist-get 'paths params)))
-    (when paths
-      (tramp-rpc--debug "fs.changed: %d paths changed" (length paths))
-      (unless tramp-rpc--suppress-fs-notifications
-        ;; Also clear the magit process-file cache since git state may have changed.
-        (tramp-rpc-magit--clear-status-cache))
-      (dolist (path paths)
-        (when (stringp path)
-          ;; Build the full tramp path for cache invalidation and file
-          ;; notification dispatch.  File notifications are deliberately not
-          ;; suppressed by `tramp-rpc--suppress-fs-notifications': that variable
-          ;; only suppresses cache/status work during operations that invalidate
-          ;; caches themselves.
-          (when-let* ((vec (process-get process :tramp-rpc-vec)))
-            (let ((full-path (tramp-make-tramp-file-name vec path)))
-              (unless tramp-rpc--suppress-fs-notifications
-                (tramp-rpc--invalidate-cache-for-path full-path))
-              (tramp-rpc--file-notify-dispatch full-path))))))))
+(defun tramp-rpc--fs-event-path (vec event key)
+  "Return EVENT's KEY path as a TRAMP file name on VEC, or nil."
+  (when-let* ((path (tramp-rpc--decode-string (alist-get key event)))
+              ((stringp path)))
+    (tramp-make-tramp-file-name vec path)))
+
+(defun tramp-rpc--watch-canonical-directory (vec result)
+  "Return canonical TRAMP directory from watch.add RESULT on VEC."
+  (when-let* ((canonical-localname (and (listp result)
+                                        (tramp-rpc--decode-string
+                                         (alist-get 'path result))))
+              ((stringp canonical-localname)))
+    (tramp-make-tramp-file-name vec canonical-localname)))
+
+(defun tramp-rpc--path-under-directory-relative (directory file-name)
+  "Return FILE-NAME relative to DIRECTORY, or nil.
+DIRECTORY itself returns the empty string.  Descendants can contain slashes."
+  (let* ((dir (file-name-as-directory (directory-file-name directory)))
+         (file (directory-file-name file-name)))
+    (cond
+     ((string= (directory-file-name dir) file) "")
+     ((string-prefix-p dir file)
+      (substring file (length dir))))))
+
+(defun tramp-rpc--watched-directory-alias-paths (path)
+  "Return explicit watch spellings equivalent to canonical PATH."
+  (let (aliases)
+    (when (hash-table-p tramp-rpc--watched-directories)
+      (maphash
+       (lambda (_key entry)
+         (let* ((canonical-directory (plist-get entry :canonical-directory))
+                (directory (plist-get entry :directory))
+                (relative (and canonical-directory directory
+                               (tramp-rpc--path-under-directory-relative
+                                canonical-directory path))))
+           (when relative
+             (let ((alias (if (string-empty-p relative)
+                              (directory-file-name directory)
+                            (expand-file-name relative directory))))
+               (unless (string= alias path)
+                 (cl-pushnew alias aliases :test #'string=))))))
+       tramp-rpc--watched-directories))
+    aliases))
+
+(defun tramp-rpc--invalidate-event-path (path)
+  "Invalidate caches for PATH and equivalent original watch spellings."
+  (dolist (candidate (append (list path)
+                             (tramp-rpc--watched-directory-alias-paths path)
+                             (tramp-rpc--file-notify-alias-paths path)))
+    (tramp-rpc--invalidate-cache-for-path candidate)))
+
+(defun tramp-rpc--handle-fs-events (process params)
+  "Handle an fs.events notification from PROCESS with PARAMS."
+  (let ((events (alist-get 'events params)))
+    (when events
+      (tramp-rpc--debug "fs.events: %d events" (length events))
+      (when-let* ((vec (process-get process :tramp-rpc-vec)))
+        (unless tramp-rpc--suppress-fs-notifications
+          ;; Also clear the magit process-file cache since git state may have changed.
+          (tramp-rpc-magit--clear-status-cache))
+        (dolist (event events)
+          (let* ((action (alist-get 'action event))
+                 (path (tramp-rpc--fs-event-path vec event 'path))
+                 (path1 (tramp-rpc--fs-event-path vec event 'path1))
+                 (cookie (alist-get 'cookie event)))
+            (when (stringp action)
+              (if (string= action "rescan")
+                  (unless tramp-rpc--suppress-fs-notifications
+                    (tramp-rpc--clear-file-caches-for-connection vec))
+                (when path
+                  ;; File notifications are deliberately not suppressed by
+                  ;; `tramp-rpc--suppress-fs-notifications': that variable only
+                  ;; suppresses cache/status work during operations that
+                  ;; invalidate caches themselves.
+                  (unless tramp-rpc--suppress-fs-notifications
+                    (tramp-rpc--invalidate-event-path path)
+                    (when path1
+                      (tramp-rpc--invalidate-event-path path1)))
+                  (tramp-rpc--file-notify-dispatch action path path1 cookie))))))))))
 
 (defun tramp-rpc-watch-directory (directory &optional recursive)
   "Start watching DIRECTORY for filesystem changes.
@@ -226,19 +288,29 @@ When RECURSIVE is non-nil, watch subdirectories too."
           ;; atomic non-recursive-to-recursive upgrade path.  Do not remove the
           ;; existing watch first; if the recursive add fails, the server rolls
           ;; back and our file-notify ownership state remains unchanged.
-          (progn
-            (tramp-rpc--call v "watch.add"
-                             `((path . ,localname) (recursive . t)))
+          (let* ((result (tramp-rpc--call
+                          v "watch.add"
+                          `((path . ,localname) (recursive . t))))
+                 (canonical-directory
+                  (tramp-rpc--watch-canonical-directory v result)))
             (plist-put file-notify-entry :owned nil)
-            (puthash watch-key '(:recursive t)
+            (puthash watch-key
+                     (list :recursive t
+                           :directory directory
+                           :canonical-directory canonical-directory)
                      tramp-rpc--watched-directories))
-        (tramp-rpc--call v "watch.add"
-                         `((path . ,localname)
-                           (recursive . ,(if recursive t :msgpack-false))))
-        (puthash watch-key
-                 (list :recursive (or recursive
-                                      (tramp-rpc--watch-entry-recursive-p entry)))
-                 tramp-rpc--watched-directories)))
+        (let* ((result (tramp-rpc--call
+                        v "watch.add"
+                        `((path . ,localname)
+                          (recursive . ,(if recursive t :msgpack-false)))))
+               (canonical-directory
+                (tramp-rpc--watch-canonical-directory v result)))
+          (puthash watch-key
+                   (list :recursive (or recursive
+                                        (tramp-rpc--watch-entry-recursive-p entry))
+                         :directory directory
+                         :canonical-directory canonical-directory)
+                   tramp-rpc--watched-directories))))
     (tramp-rpc--debug "Watching: %s (recursive=%s)" localname recursive)))
 
 (defun tramp-rpc-unwatch-directory (directory)
@@ -247,10 +319,12 @@ When RECURSIVE is non-nil, watch subdirectories too."
   (with-parsed-tramp-file-name directory nil
     (let* ((watch-key (format "%s:%s" (tramp-rpc--connection-key-string v)
                               localname))
+           (entry (gethash watch-key tramp-rpc--watched-directories))
+           (canonical-directory
+            (tramp-rpc--watch-entry-canonical-directory entry))
            (file-notify-entry (and (boundp 'tramp-rpc--file-notify-watch-counts)
                                    (gethash watch-key
                                             tramp-rpc--file-notify-watch-counts))))
-      (tramp-rpc--call v "watch.remove" `((path . ,localname)))
       (remhash watch-key tramp-rpc--watched-directories)
       ;; If file-notify was relying on the watch we just removed, restore its
       ;; direct non-recursive watch.  This applies to both recursive and
@@ -261,12 +335,17 @@ When RECURSIVE is non-nil, watch subdirectories too."
         (let ((result (tramp-rpc--call v "watch.add"
                                        `((path . ,localname)
                                          (recursive . :msgpack-false)))))
-          (when-let* ((canonical-localname (and (listp result)
-                                                (alist-get 'path result)))
-                      ((stringp canonical-localname)))
-            (plist-put file-notify-entry :canonical-directory
-                       (tramp-make-tramp-file-name v canonical-localname))))
-        (plist-put file-notify-entry :owned t)))
+          (when-let* ((restored-canonical-directory
+                       (tramp-rpc--watch-canonical-directory v result)))
+            (setq canonical-directory restored-canonical-directory)
+            (plist-put file-notify-entry :canonical-directory canonical-directory)))
+        (plist-put file-notify-entry :owned t))
+      (unless (tramp-rpc--canonical-watch-active-p canonical-directory)
+        (tramp-rpc--call
+         v "watch.remove"
+         `((path . ,(if (stringp canonical-directory)
+                        (tramp-file-local-name canonical-directory)
+                      localname))))))
     (tramp-rpc--debug "Unwatched: %s" localname)))
 
 (defun tramp-rpc--cleanup-watches-for-connection (vec)
@@ -521,9 +600,9 @@ commands.run_parallel RPC call, then stores the results directly
 as the process-file cache.  Also fetches ancestor markers."
   (when (and (file-remote-p directory)
              (tramp-rpc-file-name-p directory))
-    ;; Suppress fs.changed notifications during prefetch.
-    ;; The git commands we run on the server touch .git/index etc.,
-    ;; triggering inotify events that would clear the cache we're building.
+    ;; Suppress fs.events cache handling during prefetch.  The git commands
+    ;; we run on the server touch .git/index etc., triggering inotify events
+    ;; that would clear the cache we're building.
     (let ((tramp-rpc--suppress-fs-notifications t))
       ;; Remember the directory we prefetched for
       (setq tramp-rpc-magit--prefetch-directory (expand-file-name directory))
@@ -677,7 +756,7 @@ Only uses the cache if FILENAME is under the prefetched directory."
 
 (defun tramp-rpc-handle-magit-status-setup-buffer (&optional directory)
   "Handler for `magit-status-setup-buffer' to prefetch data.
-Suppresses fs.changed notifications during refresh to prevent
+Suppresses fs.events cache handling during refresh to prevent
 inotify events (from git commands touching .git/index etc.) from
 clearing caches mid-refresh."
   (let ((directory (or directory default-directory))
@@ -687,13 +766,13 @@ clearing caches mid-refresh."
         (tramp-run-real-handler 'magit-status-setup-buffer (list directory))
       ;; Clear process-file cache - ancestors/prefetch-dir stay for other packages
       (tramp-rpc-magit--clear-status-cache)
-      ;; Flush file caches since we suppressed fs.changed during the refresh
+      ;; Flush file caches since we suppressed fs.events during the refresh
       (clrhash tramp-rpc--file-exists-cache)
       (clrhash tramp-rpc--file-truename-cache))))
 
 (defun tramp-rpc-handle-magit-status-refresh-buffer ()
   "Handler for `magit-status-refresh-buffer' to prefetch data.
-Suppresses fs.changed notifications during refresh to prevent
+Suppresses fs.events cache handling during refresh to prevent
 inotify events from clearing caches mid-refresh."
   (when (null (tramp-rpc-magit--get-process-cache))
     (tramp-rpc-magit--prefetch default-directory))
@@ -702,7 +781,7 @@ inotify events from clearing caches mid-refresh."
         (tramp-run-real-handler 'magit-status-refresh-buffer nil)
       ;; Clear process-file cache - ancestors/prefetch-dir stay for other packages
       (tramp-rpc-magit--clear-status-cache)
-      ;; Flush file caches since we suppressed fs.changed during the refresh
+      ;; Flush file caches since we suppressed fs.events during the refresh
       (clrhash tramp-rpc--file-exists-cache)
       (clrhash tramp-rpc--file-truename-cache))))
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
-;; Version: 0.10.0
+;; Version: 0.11.0
 ;; Keywords: comm, processes, files
 ;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.4"))
 
@@ -3698,6 +3698,43 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(defun tramp-rpc--canonical-directory-equal-p (a b)
+  "Return non-nil if canonical directory names A and B are equal."
+  (and (stringp a)
+       (stringp b)
+       (string= (directory-file-name a) (directory-file-name b))))
+
+(defun tramp-rpc--watch-entry-canonical-directory (entry)
+  "Return canonical directory recorded in watch ENTRY."
+  (or (plist-get entry :canonical-directory)
+      (plist-get entry :directory)))
+
+(defun tramp-rpc--canonical-watch-active-p (canonical-directory)
+  "Return non-nil if CANONICAL-DIRECTORY still has a client-side owner.
+Both explicit watch entries and file-notify watch entries count as owners."
+  (let (active)
+    (when (and (stringp canonical-directory)
+               (hash-table-p tramp-rpc--watched-directories))
+      (maphash
+       (lambda (_key entry)
+         (when (tramp-rpc--canonical-directory-equal-p
+                canonical-directory
+                (tramp-rpc--watch-entry-canonical-directory entry))
+           (setq active t)))
+       tramp-rpc--watched-directories))
+    (when (and (not active)
+               (stringp canonical-directory)
+               (hash-table-p tramp-rpc--file-notify-watch-counts))
+      (maphash
+       (lambda (_key entry)
+         (when (and (plist-get entry :count)
+                    (tramp-rpc--canonical-directory-equal-p
+                     canonical-directory
+                     (tramp-rpc--watch-entry-canonical-directory entry)))
+           (setq active t)))
+       tramp-rpc--file-notify-watch-counts))
+    active))
+
 (defun tramp-rpc--cleanup-file-notify-for-connection (&optional vec)
   "Remove TRAMP-RPC file notification state for VEC.
 When VEC is nil, remove all TRAMP-RPC file notification state.  This also
@@ -3738,62 +3775,155 @@ descriptors after connection cleanup."
        (length watch-keys-to-remove)
        (if vec (format " for %s" prefix) "")))))
 
-(defun tramp-rpc--file-notify-direct-child-p (directory file)
-  "Return non-nil if FILE is an immediate child of DIRECTORY."
+(defun tramp-rpc--file-notify-relative-name (directory file)
+  "Return FILE's relative name under DIRECTORY, or nil.
+Only DIRECTORY itself and immediate children match.  DIRECTORY itself returns
+the empty string."
   (let* ((dir (file-name-as-directory (directory-file-name directory)))
          (file (directory-file-name file)))
-    (and (string-prefix-p dir file)
-         (let ((rest (substring file (length dir))))
-           (and (not (string-empty-p rest))
-                (not (string-match-p "/" rest)))))))
+    (cond
+     ((string= (directory-file-name dir) file) "")
+     ((string-prefix-p dir file)
+      (let ((rest (substring file (length dir))))
+        (and (not (string-empty-p rest))
+             (not (string-match-p "/" rest))
+             rest))))))
 
-(defun tramp-rpc--file-notify-dispatch (file-name)
-  "Dispatch a `file-notify' event for changed TRAMP FILE-NAME."
-  (when (and (hash-table-p tramp-rpc--file-notify-descriptors)
-             (> (hash-table-count tramp-rpc--file-notify-descriptors) 0))
-    ;; `file-notify-callback' and the special-event handler live in
-    ;; filenotify.el.  It is normally loaded before file notifications are
-    ;; registered, but require it defensively before constructing events.
-    (require 'filenotify)
-    (let ((descriptors nil))
+(defun tramp-rpc--file-notify-direct-child-p (directory file)
+  "Return non-nil if FILE is DIRECTORY or its immediate child."
+  (and (tramp-rpc--file-notify-relative-name directory file) t))
+
+(defun tramp-rpc--file-notify-action-enabled-p (action flags)
+  "Return non-nil when ACTION is enabled by file notification FLAGS."
+  (or (member action '("stopped"))
+      (and (memq 'change flags)
+           (member action '("created" "changed" "deleted"
+                            "renamed" "renamed-from" "renamed-to")))
+      (and (memq 'attribute-change flags)
+           (string= action "attribute-changed"))))
+
+(defun tramp-rpc--file-notify-callback-action (action)
+  "Map protocol ACTION to an action accepted by `file-notify-callback'."
+  (pcase action
+    ("created" 'created)
+    ("changed" 'changed)
+    ("attribute-changed" 'attribute-changed)
+    ("deleted" 'deleted)
+    ("renamed" 'moved)
+    ("renamed-from" 'moved-from)
+    ("renamed-to" 'moved-to)
+    ("stopped" 'unmounted)
+    (_ nil)))
+
+(defun tramp-rpc--file-notify-alias-paths (file-name)
+  "Return original watch spellings equivalent to canonical FILE-NAME."
+  (let (aliases)
+    (when (hash-table-p tramp-rpc--file-notify-descriptors)
       (maphash
-       (lambda (descriptor data)
+       (lambda (_descriptor data)
          (let* ((watch-key (plist-get data :watch-key))
                 (watch-entry (and watch-key
                                   (gethash watch-key
                                            tramp-rpc--file-notify-watch-counts)))
-                ;; Prefer the shared watch entry, because explicit unwatch can
-                ;; restore a file-notify-owned direct watch and learn a newer
-                ;; canonical path after descriptors were created.
                 (canonical-directory
                  (or (plist-get watch-entry :canonical-directory)
-                     (plist-get data :canonical-directory))))
-           (when (or (tramp-rpc--file-notify-direct-child-p
-                      (plist-get data :directory) file-name)
-                     ;; The server registers canonical watch paths and can
-                     ;; report events using that canonical spelling.  Keep the
-                     ;; original directory for Emacs' public descriptor table,
-                     ;; but also match against the canonical directory returned
-                     ;; by `watch.add' when it differs (for example, symlinked
-                     ;; watched directories).
-                     (and canonical-directory
-                          (tramp-rpc--file-notify-direct-child-p
-                           canonical-directory file-name)))
-             (push descriptor descriptors))))
+                     (plist-get data :canonical-directory)))
+                (directory (plist-get data :directory))
+                (relative (and canonical-directory directory
+                               (tramp-rpc--file-notify-relative-name
+                                canonical-directory file-name))))
+           (when relative
+             (let ((alias (if (string-empty-p relative)
+                              (directory-file-name directory)
+                            (expand-file-name relative directory))))
+               (unless (string= alias file-name)
+                 (cl-pushnew alias aliases :test #'string=))))))
+       tramp-rpc--file-notify-descriptors))
+    aliases))
+
+(defun tramp-rpc--file-notify-canonical-directory (data)
+  "Return the canonical directory associated with descriptor DATA."
+  (let* ((watch-key (plist-get data :watch-key))
+         (watch-entry (and watch-key
+                           (gethash watch-key
+                                    tramp-rpc--file-notify-watch-counts))))
+    ;; Prefer the shared watch entry, because explicit unwatch can restore a
+    ;; file-notify-owned direct watch and learn a newer canonical path after
+    ;; descriptors were created.
+    (or (plist-get watch-entry :canonical-directory)
+        (plist-get data :canonical-directory))))
+
+(defun tramp-rpc--file-notify-original-spelling (data file-name)
+  "Return FILE-NAME rewritten to descriptor DATA's original watch spelling."
+  (let* ((canonical-directory
+          (tramp-rpc--file-notify-canonical-directory data))
+         (directory (plist-get data :directory))
+         (relative (and canonical-directory directory
+                        (tramp-rpc--file-notify-relative-name
+                         canonical-directory file-name))))
+    (if relative
+        (if (string-empty-p relative)
+            (directory-file-name directory)
+          (expand-file-name relative directory))
+      file-name)))
+
+(defun tramp-rpc--file-notify-path-matches-p (data file-name)
+  "Return non-nil if descriptor DATA covers FILE-NAME."
+  (let ((canonical-directory
+         (tramp-rpc--file-notify-canonical-directory data)))
+    (or (tramp-rpc--file-notify-direct-child-p
+         (plist-get data :directory) file-name)
+        ;; The server registers canonical watch paths and can report events
+        ;; using that canonical spelling.  Keep the original directory for
+        ;; Emacs' public descriptor table, but also match against the
+        ;; canonical directory returned by `watch.add' when it differs (for
+        ;; example, symlinked watched directories).
+        (and canonical-directory
+             (tramp-rpc--file-notify-direct-child-p
+              canonical-directory file-name)))))
+
+(defun tramp-rpc--file-notify-dispatch (action file-name &optional file-name1 cookie)
+  "Dispatch a `file-notify' ACTION for TRAMP FILE-NAME.
+FILE-NAME1 is the destination for `renamed' events.  COOKIE pairs
+`renamed-from' and `renamed-to' events when the server provides one."
+  (when (and (hash-table-p tramp-rpc--file-notify-descriptors)
+             (> (hash-table-count tramp-rpc--file-notify-descriptors) 0)
+             (tramp-rpc--file-notify-callback-action action))
+    ;; `file-notify-callback' and the special-event handler live in
+    ;; filenotify.el.  It is normally loaded before file notifications are
+    ;; registered, but require it defensively before constructing events.
+    (require 'filenotify)
+    (let ((descriptors nil)
+          (callback-action (tramp-rpc--file-notify-callback-action action)))
+      (maphash
+       (lambda (descriptor data)
+         (when (and (tramp-rpc--file-notify-action-enabled-p
+                     action (plist-get data :flags))
+                    (or (tramp-rpc--file-notify-path-matches-p data file-name)
+                        (and file-name1
+                             (tramp-rpc--file-notify-path-matches-p
+                              data file-name1))))
+             (push (cons descriptor data) descriptors)))
        tramp-rpc--file-notify-descriptors)
-      (dolist (descriptor descriptors)
-        ;; `file-notify-callback' accepts inotify action names and maps
-        ;; `modify' to the public `changed' action.  The server currently
-        ;; reports only paths, not event kinds, so this is the best available
-        ;; approximation until the protocol carries create/delete/rename/etc.
-        (let ((event `(file-notify
-                       (,descriptor (modify) ,file-name)
-                       file-notify-callback)))
+      (dolist (descriptor-data descriptors)
+        (let* ((descriptor (car descriptor-data))
+               (data (cdr descriptor-data))
+               (display-file-name
+                (tramp-rpc--file-notify-original-spelling data file-name))
+               (display-file-name1
+                (and file-name1
+                     (tramp-rpc--file-notify-original-spelling data file-name1)))
+               (event-data (append (list descriptor (list callback-action)
+                                         display-file-name)
+                                   (cond
+                                    (display-file-name1 (list display-file-name1))
+                                    (cookie (list cookie)))))
+               (event `(file-notify ,event-data file-notify-callback)))
           (if (fboundp 'insert-special-event)
               (insert-special-event event)
             (funcall (lookup-key special-event-map [file-notify]) event)))))))
 
-(defun tramp-rpc-handle-file-notify-add-watch (directory _flags _callback)
+(defun tramp-rpc-handle-file-notify-add-watch (directory flags _callback)
   "Like `file-notify-add-watch' for TRAMP-RPC files.
 DIRECTORY is the remote directory passed by `file-notify-add-watch'."
   ;; `file-notify-add-watch' validates FLAGS and CALLBACK before invoking file
@@ -3843,6 +3973,7 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                  (list :directory directory
                        :canonical-directory (plist-get watch-entry
                                                        :canonical-directory)
+                       :flags flags
                        :localname localname
                        :watch-key watch-key)
                  tramp-rpc--file-notify-descriptors))
@@ -3853,6 +3984,8 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
   (when-let* ((data (gethash descriptor tramp-rpc--file-notify-descriptors)))
     (let* ((watch-key (plist-get data :watch-key))
            (entry (gethash watch-key tramp-rpc--file-notify-watch-counts))
+           (canonical-directory
+            (tramp-rpc--watch-entry-canonical-directory entry))
            (count (and entry (plist-get entry :count))))
       (cond
        ((and count (> count 1))
@@ -3861,9 +3994,10 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
         (remhash watch-key tramp-rpc--file-notify-watch-counts)
         (when (and (plist-get entry :owned)
                    ;; If a Magit/cache watch has been installed for the same
-                   ;; key while this file notification was live, do not remove
-                   ;; the server watch from underneath it.
-                   (not (gethash watch-key tramp-rpc--watched-directories)))
+                   ;; key or canonical path while this file notification was
+                   ;; live, do not remove the server watch from underneath it.
+                   (not (tramp-rpc--canonical-watch-active-p
+                         canonical-directory)))
           ;; Removing a file notification should not make
           ;; `file-notify-rm-watch' fail if the remote connection has already
           ;; gone away.

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -6,7 +6,7 @@
 
 use crate::protocol::{Notification, RpcError};
 use crate::{msgpack_map, WriterHandle};
-use notify::event::{ModifyKind, RemoveKind};
+use notify::event::{DataChange, MetadataKind, ModifyKind, RemoveKind, RenameMode};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rmpv::Value;
 use std::collections::{HashMap, HashSet};
@@ -116,6 +116,10 @@ impl FilteredWatcher {
         }
 
         Ok(())
+    }
+
+    fn recursive_roots(&self) -> Vec<PathBuf> {
+        self.recursive_roots.keys().cloned().collect()
     }
 
     fn recursive_roots_for_paths(&self, paths: &[PathBuf]) -> Vec<PathBuf> {
@@ -273,6 +277,75 @@ impl FilteredWatcher {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WatchEvent {
+    action: &'static str,
+    path: Option<PathBuf>,
+    path1: Option<PathBuf>,
+    cookie: Option<usize>,
+}
+
+impl WatchEvent {
+    fn path(action: &'static str, path: PathBuf) -> Self {
+        Self {
+            action,
+            path: Some(path),
+            path1: None,
+            cookie: None,
+        }
+    }
+
+    fn rename(path: PathBuf, path1: PathBuf) -> Self {
+        Self {
+            action: "renamed",
+            path: Some(path),
+            path1: Some(path1),
+            cookie: None,
+        }
+    }
+
+    fn tracked(action: &'static str, path: PathBuf, cookie: Option<usize>) -> Self {
+        Self {
+            action,
+            path: Some(path),
+            path1: None,
+            cookie,
+        }
+    }
+
+    fn rescan() -> Self {
+        Self {
+            action: "rescan",
+            path: None,
+            path1: None,
+            cookie: None,
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        let mut fields = vec![(
+            Value::String("action".into()),
+            Value::String(self.action.into()),
+        )];
+
+        if let Some(path) = &self.path {
+            fields.push((Value::String("path".into()), path_to_value(path)));
+        }
+        if let Some(path1) = &self.path1 {
+            fields.push((Value::String("path1".into()), path_to_value(path1)));
+        }
+        if let Some(cookie) = self.cookie {
+            fields.push((Value::String("cookie".into()), Value::from(cookie as u64)));
+        }
+
+        Value::Map(fields)
+    }
+}
+
+fn path_to_value(path: &Path) -> Value {
+    Value::String(path.to_string_lossy().into_owned().into())
+}
+
 /// Manages filesystem watchers and sends change notifications to the client.
 pub struct WatchManager {
     /// The underlying OS watcher (inotify/kqueue).
@@ -291,21 +364,21 @@ impl WatchManager {
     /// Create a new WatchManager and spawn the debounce background task.
     ///
     /// The debounce task receives raw inotify events, batches them over a
-    /// short window, and writes `fs.changed` notifications to the client
+    /// short window, and writes `fs.events` notifications to the client
     /// via the shared stdout writer.
     pub fn new(writer: WriterHandle) -> Result<Arc<Self>, notify::Error> {
         let (tx, rx) = mpsc::unbounded_channel();
 
         let watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
             if let Ok(event) = event {
-                // Only forward events that indicate filesystem mutations
-                match event.kind {
-                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                        // Topology events cannot be dropped, and blocking here can
-                        // deadlock notify's watch/unwatch event loop.
-                        let _ = tx.send(event);
-                    }
-                    _ => {} // Ignore Access, Other events
+                if matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                ) || event.need_rescan()
+                {
+                    // Topology events cannot be dropped, and blocking here can
+                    // deadlock notify's watch/unwatch event loop.
+                    let _ = tx.send(event);
                 }
             }
         })?;
@@ -408,15 +481,20 @@ impl WatchManager {
     fn recursive_roots_for_event(&self, event: &Event) -> HashSet<PathBuf> {
         let refresh_paths = directory_tree_refresh_paths(event);
         let ignore_paths = ignore_rule_paths(event);
-        if refresh_paths.is_empty() && ignore_paths.is_empty() {
+        let need_rescan = event.need_rescan();
+        if !need_rescan && refresh_paths.is_empty() && ignore_paths.is_empty() {
             return HashSet::new();
         }
 
         let watcher = lock_or_recover(&self.watcher);
-        let mut roots_to_refresh: HashSet<_> = watcher
-            .recursive_roots_for_paths(&refresh_paths)
-            .into_iter()
-            .collect();
+        let mut roots_to_refresh: HashSet<_> = if need_rescan {
+            watcher.recursive_roots().into_iter().collect()
+        } else {
+            watcher
+                .recursive_roots_for_paths(&refresh_paths)
+                .into_iter()
+                .collect()
+        };
 
         for path in ignore_paths {
             roots_to_refresh.extend(watcher.recursive_roots_for_ignore_rule(&path));
@@ -557,14 +635,93 @@ fn ignore_rule_scope(path: &Path) -> Option<PathBuf> {
     None
 }
 
+fn event_to_watch_events(event: &Event) -> Vec<WatchEvent> {
+    let mut events = Vec::new();
+
+    if event.need_rescan() {
+        events.push(WatchEvent::rescan());
+    }
+
+    match event.kind {
+        EventKind::Create(_) => {
+            events.extend(paths_as_events("created", &event.paths));
+        }
+        EventKind::Modify(ModifyKind::Data(
+            DataChange::Any | DataChange::Size | DataChange::Content | DataChange::Other,
+        ))
+        | EventKind::Modify(ModifyKind::Any | ModifyKind::Other) => {
+            events.extend(paths_as_events("changed", &event.paths));
+        }
+        EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::Any
+            | MetadataKind::AccessTime
+            | MetadataKind::WriteTime
+            | MetadataKind::Permissions
+            | MetadataKind::Ownership
+            | MetadataKind::Extended
+            | MetadataKind::Other,
+        )) => {
+            events.extend(paths_as_events("attribute-changed", &event.paths));
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
+            if event.paths.len() >= 2 {
+                if let (Some(from), Some(to)) = (event.paths.first(), event.paths.last()) {
+                    events.push(WatchEvent::rename(from.clone(), to.clone()));
+                }
+            } else {
+                events.extend(paths_as_events("renamed", &event.paths));
+            }
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+            let cookie = event.tracker();
+            events.extend(
+                event
+                    .paths
+                    .iter()
+                    .cloned()
+                    .map(|path| WatchEvent::tracked("renamed-from", path, cookie)),
+            );
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+            let cookie = event.tracker();
+            events.extend(
+                event
+                    .paths
+                    .iter()
+                    .cloned()
+                    .map(|path| WatchEvent::tracked("renamed-to", path, cookie)),
+            );
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::Any | RenameMode::Other)) => {
+            events.extend(paths_as_events("renamed", &event.paths));
+        }
+        EventKind::Remove(_) => {
+            events.extend(paths_as_events("deleted", &event.paths));
+        }
+        EventKind::Any | EventKind::Access(_) | EventKind::Other => {}
+    }
+
+    events
+}
+
+fn paths_as_events<'paths>(
+    action: &'static str,
+    paths: &'paths [PathBuf],
+) -> impl Iterator<Item = WatchEvent> + 'paths {
+    paths
+        .iter()
+        .cloned()
+        .map(move |path| WatchEvent::path(action, path))
+}
+
 /// Background task: receives raw inotify events, debounces them, and sends
-/// batched `fs.changed` notifications to the Emacs client.
+/// batched `fs.events` notifications to the Emacs client.
 ///
 /// Algorithm (fixed-window debounce):
 /// 1. Wait for the first event (blocks until something happens)
 /// 2. Start a 200ms timer
 /// 3. Collect all events that arrive during the timer window
-/// 4. When the timer fires, send one notification with all unique paths
+/// 4. When the timer fires, send one notification with all collected events
 /// 5. Go back to step 1
 async fn debounce_loop(
     mut rx: mpsc::UnboundedReceiver<Event>,
@@ -578,13 +735,13 @@ async fn debounce_loop(
             None => break, // Channel closed, watcher dropped
         };
 
-        let mut pending_paths: HashSet<PathBuf> = HashSet::new();
+        let mut pending_events: Vec<WatchEvent> = Vec::new();
         let mut roots_to_refresh: HashSet<PathBuf> = HashSet::new();
         let mut suspect_paths: HashSet<PathBuf> = HashSet::new();
         collect_event(
             event,
             &manager,
-            &mut pending_paths,
+            &mut pending_events,
             &mut roots_to_refresh,
             &mut suspect_paths,
         );
@@ -602,7 +759,7 @@ async fn debounce_loop(
                             collect_event(
                                 e,
                                 &manager,
-                                &mut pending_paths,
+                                &mut pending_events,
                                 &mut roots_to_refresh,
                                 &mut suspect_paths,
                             );
@@ -618,8 +775,9 @@ async fn debounce_loop(
             manager.rearm_suspect_paths(suspect_paths);
         }
 
-        // Phase 3: Send notification with all collected paths
-        if !pending_paths.is_empty() && send_notification(&writer, &pending_paths).await.is_err() {
+        // Phase 3: Send notification with all collected events
+        if !pending_events.is_empty() && send_notification(&writer, &pending_events).await.is_err()
+        {
             // Stdout is broken (Emacs disconnected), stop the loop.
             // Cannot use eprintln! as SSH merges stderr with stdout.
             break;
@@ -630,7 +788,7 @@ async fn debounce_loop(
 fn collect_event(
     event: Event,
     manager: &Weak<WatchManager>,
-    pending_paths: &mut HashSet<PathBuf>,
+    pending_events: &mut Vec<WatchEvent>,
     roots_to_refresh: &mut HashSet<PathBuf>,
     suspect_paths: &mut HashSet<PathBuf>,
 ) {
@@ -639,27 +797,28 @@ fn collect_event(
     }
 
     suspect_paths.extend(inode_replacing_paths(&event));
-    pending_paths.extend(event.paths);
+    pending_events.extend(event_to_watch_events(&event));
 }
 
-/// Serialize and send an `fs.changed` notification over the stdout writer.
+fn fs_events_notification(events: &[WatchEvent]) -> Notification {
+    let events_value: Vec<Value> = events.iter().map(WatchEvent::to_value).collect();
+
+    Notification::new(
+        "fs.events",
+        Value::Map(vec![(
+            Value::String("events".into()),
+            Value::Array(events_value),
+        )]),
+    )
+}
+
+/// Serialize and send an `fs.events` notification over the stdout writer.
 /// Returns an error if serialization or writing fails.
 async fn send_notification(
     writer: &WriterHandle,
-    paths: &HashSet<PathBuf>,
+    events: &[WatchEvent],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let paths_value: Vec<Value> = paths
-        .iter()
-        .map(|p| Value::String(p.to_string_lossy().into_owned().into()))
-        .collect();
-
-    let notification = Notification::new(
-        "fs.changed",
-        Value::Map(vec![(
-            Value::String("paths".into()),
-            Value::Array(paths_value),
-        )]),
-    );
+    let notification = fs_events_notification(events);
 
     let bytes = rmp_serde::to_vec_named(&notification)?;
     let mut w = writer.lock().await;
@@ -751,7 +910,7 @@ pub fn handle_list(_params: Value) -> HandlerResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::event::{CreateKind, RenameMode};
+    use notify::event::{CreateKind, Flag};
     use std::fs;
     #[cfg(target_os = "linux")]
     use std::sync::mpsc as std_mpsc;
@@ -765,9 +924,165 @@ mod tests {
         }
     }
 
+    fn map_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+        match value {
+            Value::Map(fields) => fields.iter().find_map(|(k, v)| match k {
+                Value::String(s) if s.as_str() == Some(key) => Some(v),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn test_watch_event_mapping_basic_actions() {
+        let path = PathBuf::from("/tmp/file");
+
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Create(CreateKind::File)).add_path(path.clone())
+            ),
+            vec![WatchEvent::path("created", path.clone())]
+        );
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
+                    .add_path(path.clone())
+            ),
+            vec![WatchEvent::path("changed", path.clone())]
+        );
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Modify(ModifyKind::Metadata(
+                    MetadataKind::Permissions,
+                )))
+                .add_path(path.clone())
+            ),
+            vec![WatchEvent::path("attribute-changed", path.clone())]
+        );
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Remove(RemoveKind::File)).add_path(path.clone())
+            ),
+            vec![WatchEvent::path("deleted", path)]
+        );
+    }
+
+    #[test]
+    fn test_watch_event_mapping_rename_actions() {
+        let old = PathBuf::from("/tmp/old");
+        let new = PathBuf::from("/tmp/new");
+
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+                    .add_path(old.clone())
+                    .add_path(new.clone())
+            ),
+            vec![WatchEvent::rename(old.clone(), new)]
+        );
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+                    .add_path(old.clone())
+                    .set_tracker(42)
+            ),
+            vec![WatchEvent::tracked("renamed-from", old.clone(), Some(42))]
+        );
+        assert_eq!(
+            event_to_watch_events(
+                &Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To)))
+                    .add_path(old.clone())
+                    .set_tracker(42)
+            ),
+            vec![WatchEvent::tracked("renamed-to", old, Some(42))]
+        );
+    }
+
+    #[test]
+    fn test_watch_event_serializes_paths_as_strings() {
+        let event = WatchEvent::rename(PathBuf::from("/tmp/old"), PathBuf::from("/tmp/new"));
+        let value = event.to_value();
+
+        assert_eq!(
+            map_value(&value, "action"),
+            Some(&Value::String("renamed".into()))
+        );
+        assert_eq!(
+            map_value(&value, "path"),
+            Some(&Value::String("/tmp/old".into()))
+        );
+        assert_eq!(
+            map_value(&value, "path1"),
+            Some(&Value::String("/tmp/new".into()))
+        );
+    }
+
+    #[test]
+    fn test_watch_event_mapping_includes_rescan() {
+        let events = event_to_watch_events(&Event::new(EventKind::Any).set_flag(Flag::Rescan));
+
+        assert_eq!(events, vec![WatchEvent::rescan()]);
+    }
+
+    #[test]
+    fn test_fs_events_notification_envelope() {
+        let notification = fs_events_notification(&[
+            WatchEvent::path("created", PathBuf::from("/tmp/new")),
+            WatchEvent::rescan(),
+        ]);
+
+        assert_eq!(notification.version, "2.0");
+        assert_eq!(notification.method, "fs.events");
+        let events = match map_value(&notification.params, "events") {
+            Some(Value::Array(events)) => events,
+            other => panic!("expected events array, got {other:?}"),
+        };
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            map_value(&events[0], "action"),
+            Some(&Value::String("created".into()))
+        );
+        assert_eq!(
+            map_value(&events[0], "path"),
+            Some(&Value::String("/tmp/new".into()))
+        );
+        assert_eq!(
+            map_value(&events[1], "action"),
+            Some(&Value::String("rescan".into()))
+        );
+    }
+
     fn refresh_for_event(manager: &WatchManager, event: &Event) {
         let roots = manager.recursive_roots_for_event(event);
         manager.refresh_recursive_roots(roots);
+    }
+
+    #[test]
+    fn test_rescan_refreshes_all_recursive_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let root1 = temp.path().join("root1");
+        let root2 = temp.path().join("root2");
+        fs::create_dir_all(&root1).unwrap();
+        fs::create_dir_all(&root2).unwrap();
+        let root1 = root1.canonicalize().unwrap();
+        let root2 = root2.canonicalize().unwrap();
+        let manager = test_manager();
+
+        manager.watch(&root1, true).unwrap();
+        manager.watch(&root2, true).unwrap();
+        fs::create_dir(root1.join("new1")).unwrap();
+        fs::create_dir(root2.join("new2")).unwrap();
+
+        refresh_for_event(&manager, &Event::new(EventKind::Any).set_flag(Flag::Rescan));
+
+        {
+            let watcher = lock_or_recover(&manager.watcher);
+            assert!(watcher.recursive_roots[&root1].contains(&root1.join("new1")));
+            assert!(watcher.recursive_roots[&root2].contains(&root2.join("new2")));
+        }
+        manager.unwatch(&root1).unwrap();
+        manager.unwatch(&root2).unwrap();
     }
 
     #[cfg(target_os = "linux")]

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -764,10 +764,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
        (fboundp 'tramp-file-name-with-sudo)))
 
 (ert-deftest tramp-rpc-mock-test-file-notify-suppression-still-dispatches ()
-  "fs.changed suppression skips cache work but still dispatches file notifications."
+  "fs.events suppression skips cache work but still dispatches file notifications."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let* ((vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
-         (proc (make-process :name "tramp-rpc-fs-changed-test"
+         (proc (make-process :name "tramp-rpc-fs-events-test"
                              :buffer nil
                              :command '("cat")
                              :connection-type 'pipe
@@ -784,14 +784,203 @@ This matches the behavior expected by `tramp-test28-process-file'."
                     ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
                      (lambda (path) (push path invalidations)))
                     ((symbol-function 'tramp-rpc--file-notify-dispatch)
-                     (lambda (path) (push path dispatches))))
+                     (lambda (action path &optional path1 cookie)
+                       (push (list action path path1 cookie) dispatches))))
             (tramp-rpc--handle-notification
-             proc "fs.changed" '((paths . ("/tmp/changed"))))
+             proc "fs.events"
+             '((events . (((action . "changed")
+                            (path . "/tmp/changed"))))))
             (should (= status-clears 0))
             (should-not invalidations)
-            (should (equal dispatches '("/rpc:mock:/tmp/changed")))))
+            (should (equal dispatches
+                           '(("changed" "/rpc:mock:/tmp/changed" nil nil))))))
       (when (process-live-p proc)
         (delete-process proc)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-unsuppressed-events-invalidate-caches ()
+  "Unsuppressed fs.events clear status/cache state and dispatch notifications."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
+         (proc (make-process :name "tramp-rpc-fs-events-unsuppressed-test"
+                             :buffer nil
+                             :command '("cat")
+                             :connection-type 'pipe
+                             :noquery t))
+         (status-clears 0)
+         (invalidations nil)
+         (connection-clears nil)
+         (dispatches nil)
+         (tramp-rpc--suppress-fs-notifications nil))
+    (unwind-protect
+        (progn
+          (process-put proc :tramp-rpc-vec vec)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache)
+                     (lambda () (cl-incf status-clears)))
+                    ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+                     (lambda (path) (push path invalidations)))
+                    ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
+                     (lambda (clear-vec) (push clear-vec connection-clears)))
+                    ((symbol-function 'tramp-rpc--file-notify-dispatch)
+                     (lambda (action path &optional path1 cookie)
+                       (push (list action path path1 cookie) dispatches))))
+            (tramp-rpc--handle-notification
+             proc "fs.events"
+             '((events . (((action . "changed")
+                            (path . "/tmp/changed"))
+                           ((action . "renamed")
+                            (path . "/tmp/old")
+                            (path1 . "/tmp/new"))
+                           ((action . "rescan"))))))
+            (should (= status-clears 1))
+            (should (member "/rpc:mock:/tmp/changed" invalidations))
+            (should (member "/rpc:mock:/tmp/old" invalidations))
+            (should (member "/rpc:mock:/tmp/new" invalidations))
+            (should (equal connection-clears (list vec)))
+            (should (equal (nreverse dispatches)
+                           '(("changed" "/rpc:mock:/tmp/changed" nil nil)
+                             ("renamed" "/rpc:mock:/tmp/old" "/rpc:mock:/tmp/new" nil))))))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-canonical-event-invalidates-original-watch-spelling ()
+  "Canonical fs.events paths also invalidate equivalent original watch paths."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
+         (proc (make-process :name "tramp-rpc-fs-events-canonical-test"
+                             :buffer nil
+                             :command '("cat")
+                             :connection-type 'pipe
+                             :noquery t))
+         (watch-key (format "%s:%s" (tramp-rpc--connection-key-string vec) "/tmp/link/"))
+         (descriptor (tramp-rpc--make-file-notify-descriptor
+                      vec "/rpc:mock:/tmp/link/" "/tmp/link/"))
+         (invalidations nil))
+    (unwind-protect
+        (progn
+          (process-put proc :tramp-rpc-vec vec)
+          (puthash descriptor
+                   (list :watch-key watch-key
+                         :directory "/rpc:mock:/tmp/link/"
+                         :canonical-directory "/rpc:mock:/tmp/real/"
+                         :flags '(change))
+                   tramp-rpc--file-notify-descriptors)
+          (puthash watch-key
+                   '(:count 1 :owned t
+                     :directory "/rpc:mock:/tmp/link/"
+                     :canonical-directory "/rpc:mock:/tmp/real/")
+                   tramp-rpc--file-notify-watch-counts)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache) #'ignore)
+                    ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+                     (lambda (path) (push path invalidations)))
+                    ((symbol-function 'tramp-rpc--file-notify-dispatch) #'ignore))
+            (tramp-rpc--handle-notification
+             proc "fs.events"
+             '((events . (((action . "changed")
+                            (path . "/tmp/real/changed"))))))
+            (should (member "/rpc:mock:/tmp/real/changed" invalidations))
+            (should (member "/rpc:mock:/tmp/link/changed" invalidations))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (tramp-rpc--delete-file-notify-descriptor-process descriptor))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-watch-directory-canonical-event-invalidates-original-spelling ()
+  "Explicit watch canonical fs.events paths invalidate original watched paths."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
+         (proc (make-process :name "tramp-rpc-watch-canonical-test"
+                             :buffer nil
+                             :command '("cat")
+                             :connection-type 'pipe
+                             :noquery t))
+         (directory "/rpc:mock:/tmp/link/")
+         (watch-key (format "%s:%s" (tramp-rpc--connection-key-string vec)
+                            "/tmp/link/"))
+         (invalidations nil))
+    (unwind-protect
+        (progn
+          (process-put proc :tramp-rpc-vec vec)
+          (cl-letf (((symbol-function 'tramp-rpc--call)
+                     (lambda (_vec method _params)
+                       (when (equal method "watch.add")
+                         '((path . "/tmp/real/")))))
+                    ((symbol-function 'tramp-rpc-magit--clear-status-cache) #'ignore)
+                    ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+                     (lambda (path) (push path invalidations)))
+                    ((symbol-function 'tramp-rpc--file-notify-dispatch) #'ignore))
+            (tramp-rpc-watch-directory directory t)
+            (should (equal (plist-get (gethash watch-key tramp-rpc--watched-directories)
+                                      :canonical-directory)
+                           "/rpc:mock:/tmp/real/"))
+            (tramp-rpc--handle-notification
+             proc "fs.events"
+             '((events . (((action . "changed")
+                            (path . "/tmp/real/sub/file"))))))
+            (should (member "/rpc:mock:/tmp/real/sub/file" invalidations))
+            (should (member "/rpc:mock:/tmp/link/sub/file" invalidations))))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(ert-deftest tramp-rpc-mock-test-watch-directory-canonical-aliases-share-server-watch ()
+  "Explicit watches with the same canonical path do not remove each other."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (link-directory "/rpc:mock:/tmp/link/")
+         (real-directory "/rpc:mock:/tmp/real/")
+         (calls nil))
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (push (list method params) calls)
+                 (when (equal method "watch.add")
+                   '((path . "/tmp/real/"))))))
+      (tramp-rpc-watch-directory link-directory t)
+      (tramp-rpc-watch-directory real-directory t)
+      (setq calls nil)
+      (tramp-rpc-unwatch-directory link-directory)
+      (should (equal (mapcar #'car (nreverse (copy-sequence calls))) nil))
+      (should (tramp-rpc--directory-watched-p "/tmp/real/" (tramp-dissect-file-name real-directory)))
+      (tramp-rpc-unwatch-directory real-directory)
+      (should (equal (mapcar #'car (nreverse (copy-sequence calls)))
+                     '("watch.remove"))))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-canonical-aliases-share-server-watch ()
+  "File notification watches with the same canonical path are refcounted."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (link-directory "/rpc:mock:/tmp/link/")
+         (real-directory "/rpc:mock:/tmp/real/")
+         (calls nil)
+         link-descriptor
+         real-descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method params)
+                     (push (list method params) calls)
+                     (when (equal method "watch.add")
+                       '((path . "/tmp/real/")))))
+                  ((symbol-function 'tramp-rpc-handle-file-directory-p)
+                   (lambda (_filename) t)))
+          (setq link-descriptor
+                (file-notify-add-watch link-directory '(change) #'ignore))
+          (setq real-descriptor
+                (file-notify-add-watch real-directory '(change) #'ignore))
+          (setq calls nil)
+          (file-notify-rm-watch link-descriptor)
+          (should (equal (mapcar #'car (nreverse (copy-sequence calls))) nil))
+          (should (file-notify-valid-p real-descriptor))
+          (file-notify-rm-watch real-descriptor)
+          (should (equal (mapcar #'car (nreverse (copy-sequence calls)))
+                         '("watch.remove"))))
+      (when (and link-descriptor (boundp 'file-notify-descriptors))
+        (remhash link-descriptor file-notify-descriptors))
+      (when (and real-descriptor (boundp 'file-notify-descriptors))
+        (remhash real-descriptor file-notify-descriptors)))))
 
 (ert-deftest tramp-rpc-mock-test-file-notify-cleanup-for-connection ()
   "Per-connection cleanup removes TRAMP-RPC and global file-notify descriptors."
@@ -871,10 +1060,19 @@ This matches the behavior expected by `tramp-test28-process-file'."
                                              tramp-rpc--file-notify-descriptors)
                                     :canonical-directory)
                          "/rpc:mock:/tmp/real/"))
-          (tramp-rpc--file-notify-dispatch "/rpc:mock:/tmp/real/changed")
+          (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/real/changed")
           (should (equal events
                          `((file-notify
-                            (,descriptor (modify) "/rpc:mock:/tmp/real/changed")
+                            (,descriptor (changed) "/rpc:mock:/tmp/link/changed")
+                            file-notify-callback))))
+          (setq events nil)
+          (tramp-rpc--file-notify-dispatch
+           "renamed" "/rpc:mock:/tmp/real/old" "/rpc:mock:/tmp/real/new")
+          (should (equal events
+                         `((file-notify
+                            (,descriptor (moved)
+                             "/rpc:mock:/tmp/link/old"
+                             "/rpc:mock:/tmp/link/new")
                             file-notify-callback))))
           ;; Dispatch uses the shared watch entry's canonical directory if it is
           ;; refreshed after the descriptor was created.
@@ -883,14 +1081,95 @@ This matches the behavior expected by `tramp-test28-process-file'."
                  (entry (gethash (plist-get data :watch-key)
                                  tramp-rpc--file-notify-watch-counts)))
             (plist-put entry :canonical-directory "/rpc:mock:/tmp/new-real/"))
-          (tramp-rpc--file-notify-dispatch "/rpc:mock:/tmp/new-real/changed")
+          (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/new-real/changed")
           (should (equal events
                          `((file-notify
-                            (,descriptor (modify) "/rpc:mock:/tmp/new-real/changed")
+                            (,descriptor (changed) "/rpc:mock:/tmp/link/changed")
                             file-notify-callback)))))
       (when descriptor
         (remhash descriptor tramp-rpc--file-notify-descriptors)
         (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-dispatches-structured-actions ()
+  "Structured server watch events dispatch the corresponding file-notify actions."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (directory "/rpc:mock:/tmp/repo/")
+         (events nil)
+         descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params)
+                     (when (equal method "watch.add")
+                       '((path . "/tmp/repo/")))))
+                  ((symbol-function 'insert-special-event)
+                   (lambda (event) (push event events))))
+          (setq descriptor
+                (tramp-rpc-handle-file-notify-add-watch
+                 directory '(change attribute-change) #'ignore))
+          (should (processp descriptor))
+          (tramp-rpc--file-notify-dispatch "created" "/rpc:mock:/tmp/repo/new")
+          (tramp-rpc--file-notify-dispatch "attribute-changed" "/rpc:mock:/tmp/repo/new")
+          (tramp-rpc--file-notify-dispatch
+           "renamed" "/rpc:mock:/tmp/repo/old" "/rpc:mock:/tmp/repo/new")
+          (tramp-rpc--file-notify-dispatch "deleted" "/rpc:mock:/tmp/repo/new")
+          (should (equal (nreverse events)
+                         `((file-notify
+                            (,descriptor (created) "/rpc:mock:/tmp/repo/new")
+                            file-notify-callback)
+                           (file-notify
+                            (,descriptor (attribute-changed) "/rpc:mock:/tmp/repo/new")
+                            file-notify-callback)
+                           (file-notify
+                            (,descriptor (moved) "/rpc:mock:/tmp/repo/old" "/rpc:mock:/tmp/repo/new")
+                            file-notify-callback)
+                           (file-notify
+                            (,descriptor (deleted) "/rpc:mock:/tmp/repo/new")
+                            file-notify-callback)))))
+      (when descriptor
+        (remhash descriptor tramp-rpc--file-notify-descriptors)
+        (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-dispatch-honors-flags ()
+  "TRAMP-RPC file notifications honor change vs attribute-change flags."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (directory "/rpc:mock:/tmp/repo/")
+         (events nil)
+         change-descriptor
+         attribute-descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params)
+                     (when (equal method "watch.add")
+                       '((path . "/tmp/repo/")))))
+                  ((symbol-function 'insert-special-event)
+                   (lambda (event) (push event events))))
+          (setq change-descriptor
+                (tramp-rpc-handle-file-notify-add-watch directory '(change) #'ignore))
+          (setq attribute-descriptor
+                (tramp-rpc-handle-file-notify-add-watch directory '(attribute-change) #'ignore))
+          (should (processp change-descriptor))
+          (should (processp attribute-descriptor))
+          (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/repo/file")
+          (tramp-rpc--file-notify-dispatch "attribute-changed" "/rpc:mock:/tmp/repo/file")
+          (should (equal (nreverse events)
+                         `((file-notify
+                            (,change-descriptor (changed) "/rpc:mock:/tmp/repo/file")
+                            file-notify-callback)
+                           (file-notify
+                            (,attribute-descriptor (attribute-changed) "/rpc:mock:/tmp/repo/file")
+                            file-notify-callback)))))
+      (dolist (descriptor (list change-descriptor attribute-descriptor))
+        (when descriptor
+          (remhash descriptor tramp-rpc--file-notify-descriptors)
+          (tramp-rpc--delete-file-notify-descriptor-process descriptor))))))
 
 (ert-deftest tramp-rpc-mock-test-file-notify-public-rm-and-valid-route ()
   "Public file-notify APIs route TRAMP-RPC descriptors to private state."
@@ -992,7 +1271,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (plist-get (gethash watch-key tramp-rpc--file-notify-watch-counts)
                          :owned))
       (should (equal (mapcar #'car (nreverse (copy-sequence calls)))
-                     '("watch.add" "watch.remove" "watch.add"))))))
+                     '("watch.add" "watch.add"))))))
 
 (ert-deftest tramp-rpc-mock-test-file-notify-watch-upgrade-failure-keeps-direct ()
   "A failed recursive upgrade does not remove a direct file-notify watch."


### PR DESCRIPTION
## Summary

- Replace the path-only `fs.changed` notification with structured `fs.events` records carrying `created`, `changed`, `attribute-changed`, `deleted`, rename, and `rescan` actions.
- Map Rust `notify` events into those protocol actions, including `path1` for paired renames and cookies for split rename events.
- Decode structured events on the Elisp side, invalidate caches for canonical/original watch aliases, and dispatch TRAMP-style `file-notify` callbacks while honoring `change` vs `attribute-change` watch flags.
- Track canonical watch paths returned by `watch.add` so symlink aliases share server watches and do not remove each other's underlying watch.
- Document the new protocol and bump the server/Lisp deploy version to `0.11.0`.

## Context

Upstream TRAMP's `inotifywait`/`gio monitor` handlers in `tramp` preserve native file-notify action distinctions. This change brings TRAMP-RPC's watcher protocol in line with that behavior instead of treating every server-side event as a generic `modify`.
