### PR TITLE
Add server-side recursive `copy-directory` handler for same-remote copies

### DIFF
--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -173,7 +173,8 @@ Returns a list where each element is either:
     (mapcar (lambda (result-obj)
               (if-let* ((error-obj (alist-get 'error result-obj)))
                   (list :error (alist-get 'code error-obj)
-                        :message (alist-get 'message error-obj))
+                        :message (alist-get 'message error-obj)
+                        :data (alist-get 'data error-obj))
                 (alist-get 'result result-obj)))
             results-array)))
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2756,17 +2756,14 @@ network round-trip."
     (dirname newname &optional keep-date parents copy-contents)
   "Like `copy-directory' for TRAMP-RPC files.
 
-For same-remote whole-directory copies, use the server-side recursive
-`file.copy' operation.  That keeps the number of RPC round-trips constant
-instead of walking the tree from Emacs and issuing one RPC per entry.  Fall
-back to the generic TRAMP handler for cross-remote copies, `copy-contents',
-and keep-date copies whose directory timestamp semantics must match Emacs
-exactly."
+For same-remote directory copies, use the server-side recursive `file.copy'
+operation.  That keeps the number of RPC round-trips constant instead of
+walking the tree from Emacs and issuing one RPC per entry.  Lisp computes the
+Emacs/TRAMP destination and policy details; the server only receives primitive
+copy options.  Fall back to the generic TRAMP handler for cross-remote copies."
   (setq dirname (expand-file-name dirname)
         newname (expand-file-name newname))
-  (if (and (not copy-contents)
-           (not keep-date)
-           (tramp-tramp-file-p dirname)
+  (if (and (tramp-tramp-file-p dirname)
            (tramp-tramp-file-p newname)
            (tramp-equal-remote dirname newname))
       (with-parsed-tramp-file-name dirname v1
@@ -2774,9 +2771,21 @@ exactly."
           (let* ((src-localname (file-name-unquote v1-localname))
                  (dest-localname (file-name-unquote v2-localname))
                  ;; Match `copy-directory': a directory-name NEWNAME means
-                 ;; copy into NEWNAME under DIRECTORY's basename; otherwise
-                 ;; NEWNAME is the exact destination directory.
+                 ;; copy into NEWNAME under DIRECTORY's basename, unless
+                 ;; COPY-CONTENTS requests copying DIRECTORY's entries directly
+                 ;; into NEWNAME.  Otherwise NEWNAME is the exact destination
+                 ;; directory.
                  (actual-dest-localname
+                  (if (and (directory-name-p newname)
+                           (not copy-contents))
+                      (expand-file-name
+                       (file-name-nondirectory (directory-file-name src-localname))
+                       dest-localname)
+                    dest-localname))
+                 ;; The source-symlink special case in `copy-directory' ignores
+                 ;; COPY-CONTENTS: a directory-name NEWNAME still receives a
+                 ;; symlink named after DIRECTORY.
+                 (symlink-dest-localname
                   (if (directory-name-p newname)
                       (expand-file-name
                        (file-name-nondirectory (directory-file-name src-localname))
@@ -2785,6 +2794,9 @@ exactly."
                  (actual-dest
                   (tramp-make-tramp-file-name
                    v2 (file-name-quote actual-dest-localname)))
+                 (symlink-dest
+                  (tramp-make-tramp-file-name
+                   v2 (file-name-quote symlink-dest-localname)))
                  (parent-localname
                   (file-name-directory (directory-file-name actual-dest-localname)))
                  (parent
@@ -2814,8 +2826,7 @@ exactly."
                      (equal source-lstat-type "symlink"))
                 (make-symbolic-link
                  (tramp-rpc--decode-string (alist-get 'link_target source-lstat))
-                 (tramp-make-tramp-file-name
-                  v2 (file-name-quote actual-dest-localname))
+                 symlink-dest
                  t)
               (let* ((source-stat (tramp-rpc--batch-result-or-signal
                                     "file.stat" dirname source-stat-result))
@@ -2861,17 +2872,31 @@ exactly."
                                  `((src . ,(tramp-rpc--path-to-bytes src-localname))
                                    (dest . ,(tramp-rpc--path-to-bytes actual-dest-localname))
                                    (preserve_permissions . t)
-                                   (preserve_times . :msgpack-false)
+                                   (preserve_times . ,(if keep-date t :msgpack-false))
                                    (overwrite . t)
                                    (exact_dest . t)
                                    (merge_existing_directories . ,(if parents
                                                                       t :msgpack-false))))))
             (tramp-flush-file-properties v1 v1-localname)
-            (tramp-flush-file-properties v2 actual-dest-localname)
-            (tramp-flush-directory-properties v2 parent-localname)
-            (tramp-rpc--invalidate-cache-for-path dirname)
-            (tramp-rpc--invalidate-cache-for-path
-             (tramp-make-tramp-file-name v2 (file-name-quote actual-dest-localname))))))
+            (let* ((copied-localname
+                    (if (and copy-directory-create-symlink
+                             (equal source-lstat-type "symlink"))
+                        symlink-dest-localname
+                      actual-dest-localname))
+                   (copied-parent-localname
+                    (file-name-directory (directory-file-name copied-localname))))
+              (tramp-flush-file-properties v2 copied-localname)
+              ;; Flush both the copied directory and its parent.  For
+              ;; COPY-CONTENTS, COPIED-LOCALNAME is the destination whose
+              ;; listing has changed; for whole-directory copies the parent
+              ;; listing has changed, and flushing the copied directory is
+              ;; harmless and clears any stale attributes created during
+              ;; preflight.
+              (tramp-flush-directory-properties v2 copied-localname)
+              (tramp-flush-directory-properties v2 copied-parent-localname)
+              (tramp-rpc--invalidate-cache-for-path dirname)
+              (tramp-rpc--invalidate-cache-for-path
+               (tramp-make-tramp-file-name v2 (file-name-quote copied-localname)))))))
     (tramp-handle-copy-directory dirname newname keep-date parents copy-contents)))
 
 (cl-defun tramp-rpc-handle-copy-file

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1761,31 +1761,7 @@ Returns the result or signals an error."
                   (os-errno (tramp-rpc-protocol-error-errno response)))
               (tramp-rpc--debug "ERROR id=%s code=%s msg=%s errno=%s"
                                expected-id code msg os-errno)
-              (cond
-               ((= code tramp-rpc-protocol-error-file-not-found)
-                (signal 'file-missing (list "RPC" "No such file" msg)))
-               ((= code tramp-rpc-protocol-error-permission-denied)
-                (signal 'permission-denied (list "RPC" "Permission denied" msg)))
-               ;; Map OS errno values to appropriate Emacs error symbols.
-               ;; The server includes the raw errno in the error data field.
-               ((eql os-errno 2) ;; ENOENT
-                (signal 'file-missing (list "RPC" "No such file" msg)))
-               ((eql os-errno 17) ;; EEXIST
-                (signal 'file-already-exists (list "RPC" msg)))
-               ((eql os-errno 39) ;; ENOTEMPTY
-                (signal 'file-error (list "RPC" "Directory not empty" msg)))
-               ((eql os-errno 20) ;; ENOTDIR
-                (signal 'file-error (list "RPC" "Not a directory" msg)))
-               ((eql os-errno 21) ;; EISDIR
-                (signal 'file-error (list "RPC" "Is a directory" msg)))
-               ((eql os-errno 40) ;; ELOOP
-                (signal 'file-error (list "RPC" "Too many levels of symbolic links" msg)))
-               ;; All other IO errors also signal file-error so callers
-               ;; can catch them uniformly with condition-case.
-               ((= code tramp-rpc-protocol-error-io)
-                (signal 'remote-file-error (list "RPC" msg)))
-               (t
-                (signal 'remote-file-error (list "RPC error" msg)))))
+              (tramp-rpc--signal-rpc-error "RPC" msg code os-errno))
           (plist-get response :result))))))
 
 (defun tramp-rpc--call-batch (vec requests)
@@ -2655,6 +2631,73 @@ network round-trip."
   "Return file type string from STAT, or nil."
   (and stat (alist-get 'type stat)))
 
+(defun tramp-rpc--batch-error-p (value)
+  "Return non-nil when VALUE is an error object from `tramp-rpc--call-batch'."
+  (and (consp value) (plist-get value :error)))
+
+(defun tramp-rpc--batch-error-errno (error)
+  "Return OS errno from batched RPC ERROR, or nil."
+  (when-let* ((data (plist-get error :data)))
+    (alist-get 'os_errno data)))
+
+(defun tramp-rpc--error-args (operation detail message filename)
+  "Build signal args for OPERATION, DETAIL, MESSAGE, and optional FILENAME."
+  (cond
+   ((and filename detail) (list operation detail filename message))
+   (filename (list operation filename message))
+   (detail (list operation detail message))
+   (t (list operation message))))
+
+(defun tramp-rpc--signal-rpc-error (operation message code os-errno &optional filename)
+  "Signal RPC error CODE/OS-ERRNO for OPERATION and optional FILENAME."
+  (cond
+   ((= code tramp-rpc-protocol-error-file-not-found)
+    (signal 'file-missing
+            (tramp-rpc--error-args operation "No such file" message filename)))
+   ((= code tramp-rpc-protocol-error-permission-denied)
+    (signal 'permission-denied
+            (tramp-rpc--error-args operation "Permission denied" message filename)))
+   ((eql os-errno 2) ; ENOENT
+    (signal 'file-missing
+            (tramp-rpc--error-args operation "No such file" message filename)))
+   ((eql os-errno 17) ; EEXIST
+    (signal 'file-already-exists
+            (tramp-rpc--error-args operation nil message filename)))
+   ((eql os-errno 39) ; ENOTEMPTY
+    (signal 'file-error
+            (tramp-rpc--error-args operation "Directory not empty" message filename)))
+   ((eql os-errno 20) ; ENOTDIR
+    (signal 'file-error
+            (tramp-rpc--error-args operation "Not a directory" message filename)))
+   ((eql os-errno 21) ; EISDIR
+    (signal 'file-error
+            (tramp-rpc--error-args operation "Is a directory" message filename)))
+   ((eql os-errno 40) ; ELOOP
+    (signal 'file-error
+            (tramp-rpc--error-args
+             operation "Too many levels of symbolic links" message filename)))
+   ((= code tramp-rpc-protocol-error-io)
+    (signal 'remote-file-error
+            (tramp-rpc--error-args operation nil message filename)))
+   (t
+    (signal 'remote-file-error
+            (tramp-rpc--error-args operation nil message filename)))))
+
+(defun tramp-rpc--signal-batch-error (operation filename error)
+  "Signal ERROR returned by a batched RPC for OPERATION on FILENAME."
+  (tramp-rpc--signal-rpc-error
+   operation
+   (or (plist-get error :message) "RPC batch subrequest failed")
+   (plist-get error :error)
+   (tramp-rpc--batch-error-errno error)
+   filename))
+
+(defun tramp-rpc--batch-result-or-signal (operation filename result)
+  "Return batched RESULT, or signal its embedded error for FILENAME."
+  (if (tramp-rpc--batch-error-p result)
+      (tramp-rpc--signal-batch-error operation filename result)
+    result))
+
 (cl-defun tramp-rpc--copy-file-same-remote
     (filename newname ok-if-already-exists keep-time preserve-permissions)
   "Copy FILENAME to NEWNAME on one TRAMP-RPC remote with fewer round-trips."
@@ -2666,8 +2709,10 @@ network round-trip."
                                                 '((lstat . t))))
                        ("file.stat" . ,(append (tramp-rpc--encode-path v2-localname)
                                                 '((lstat . t)))))))
-             (source-stat (nth 0 stats))
-             (dest-stat (nth 1 stats))
+             (source-stat (tramp-rpc--batch-result-or-signal
+                           "file.stat" filename (nth 0 stats)))
+             (dest-stat (tramp-rpc--batch-result-or-signal
+                         "file.stat" newname (nth 1 stats)))
              (source-type (tramp-rpc--stat-type source-stat))
              (dest-type (tramp-rpc--stat-type dest-stat)))
         (unless source-stat
@@ -2706,6 +2751,128 @@ network round-trip."
         (tramp-flush-file-properties v2 v2-localname)
         (tramp-flush-directory-properties v2 v2-localname)
         (tramp-rpc--invalidate-cache-for-path newname)))))
+
+(cl-defun tramp-rpc-handle-copy-directory
+    (dirname newname &optional keep-date parents copy-contents)
+  "Like `copy-directory' for TRAMP-RPC files.
+
+For same-remote whole-directory copies, use the server-side recursive
+`file.copy' operation.  That keeps the number of RPC round-trips constant
+instead of walking the tree from Emacs and issuing one RPC per entry.  Fall
+back to the generic TRAMP handler for cross-remote copies, `copy-contents',
+and keep-date copies whose directory timestamp semantics must match Emacs
+exactly."
+  (setq dirname (expand-file-name dirname)
+        newname (expand-file-name newname))
+  (if (and (not copy-contents)
+           (not keep-date)
+           (tramp-tramp-file-p dirname)
+           (tramp-tramp-file-p newname)
+           (tramp-equal-remote dirname newname))
+      (with-parsed-tramp-file-name dirname v1
+        (with-parsed-tramp-file-name newname v2
+          (let* ((src-localname (file-name-unquote v1-localname))
+                 (dest-localname (file-name-unquote v2-localname))
+                 ;; Match `copy-directory': a directory-name NEWNAME means
+                 ;; copy into NEWNAME under DIRECTORY's basename; otherwise
+                 ;; NEWNAME is the exact destination directory.
+                 (actual-dest-localname
+                  (if (directory-name-p newname)
+                      (expand-file-name
+                       (file-name-nondirectory (directory-file-name src-localname))
+                       dest-localname)
+                    dest-localname))
+                 (actual-dest
+                  (tramp-make-tramp-file-name
+                   v2 (file-name-quote actual-dest-localname)))
+                 (parent-localname
+                  (file-name-directory (directory-file-name actual-dest-localname)))
+                 (parent
+                  (tramp-make-tramp-file-name v2 (file-name-quote parent-localname)))
+                 (stats (tramp-rpc--call-batch
+                         v1
+                         `(("file.stat" . ,(append (tramp-rpc--encode-path src-localname)
+                                                    '((lstat . t))))
+                           ("file.stat" . ,(tramp-rpc--encode-path src-localname))
+                           ("file.stat" . ,(append (tramp-rpc--encode-path actual-dest-localname)
+                                                    '((lstat . t))))
+                           ("file.stat" . ,(tramp-rpc--encode-path actual-dest-localname))
+                           ("file.stat" . ,(tramp-rpc--encode-path parent-localname)))))
+                 (source-lstat (tramp-rpc--batch-result-or-signal
+                                "file.stat" dirname (nth 0 stats)))
+                 ;; Keep following-stat results raw until after the
+                 ;; `copy-directory-create-symlink' branch.  Emacs copies a
+                 ;; source symlink as a symlink without following it, so a
+                 ;; dangling or looping symlink target must not make the fast
+                 ;; path fail before `make-symbolic-link' runs.
+                 (source-stat-result (nth 1 stats))
+                 (actual-dest-lstat-result (nth 2 stats))
+                 (actual-dest-stat-result (nth 3 stats))
+                 (parent-stat-result (nth 4 stats))
+                 (source-lstat-type (tramp-rpc--stat-type source-lstat)))
+            (if (and copy-directory-create-symlink
+                     (equal source-lstat-type "symlink"))
+                (make-symbolic-link
+                 (tramp-rpc--decode-string (alist-get 'link_target source-lstat))
+                 (tramp-make-tramp-file-name
+                  v2 (file-name-quote actual-dest-localname))
+                 t)
+              (let* ((source-stat (tramp-rpc--batch-result-or-signal
+                                    "file.stat" dirname source-stat-result))
+                     (actual-dest-lstat
+                      (tramp-rpc--batch-result-or-signal
+                       "file.stat" actual-dest actual-dest-lstat-result))
+                     (actual-dest-stat
+                      (tramp-rpc--batch-result-or-signal
+                       "file.stat" actual-dest actual-dest-stat-result))
+                     (parent-stat (tramp-rpc--batch-result-or-signal
+                                   "file.stat" parent parent-stat-result))
+                     (source-type (tramp-rpc--stat-type source-stat))
+                     (actual-dest-type (tramp-rpc--stat-type actual-dest-stat))
+                     (parent-type (tramp-rpc--stat-type parent-stat)))
+                (unless source-stat
+                  (signal 'file-missing (list "Opening input file" "No such file" dirname)))
+                (unless (equal source-type "directory")
+                  (signal 'file-error (list "Not a directory" dirname)))
+                ;; `copy-directory' allows an already existing destination
+                ;; directory when NEWNAME is a directory name, and also when
+                ;; PARENTS is non-nil (because `make-directory' with PARENTS
+                ;; accepts existing directories).  In all other cases, existing
+                ;; destination entries are errors.  Directory checks follow
+                ;; symlinks, so a symlink to a directory is accepted like TRAMP's
+                ;; generic handler accepts it.
+                (when (and actual-dest-lstat
+                           (not (equal actual-dest-type "directory")))
+                  (signal 'file-already-exists
+                          (list actual-dest)))
+                (when (and actual-dest-stat
+                           (not (directory-name-p newname))
+                           (not parents))
+                  (signal 'file-already-exists (list actual-dest)))
+                (when (and (not actual-dest-stat)
+                           (not parents))
+                  (unless parent-stat
+                    (signal 'file-missing
+                            (list "Creating directory" "No such file or directory"
+                                  actual-dest)))
+                  (unless (equal parent-type "directory")
+                    (signal 'file-error (list "Not a directory" parent))))
+                (tramp-rpc--call v1 "file.copy"
+                                 `((src . ,(tramp-rpc--path-to-bytes src-localname))
+                                   (dest . ,(tramp-rpc--path-to-bytes actual-dest-localname))
+                                   (preserve_permissions . t)
+                                   (preserve_times . :msgpack-false)
+                                   (overwrite . t)
+                                   (exact_dest . t)
+                                   (merge_existing_directories . ,(if parents
+                                                                      t :msgpack-false))))))
+            (tramp-flush-file-properties v1 v1-localname)
+            (tramp-flush-file-properties v2 actual-dest-localname)
+            (tramp-flush-directory-properties v2 parent-localname)
+            (tramp-rpc--invalidate-cache-for-path dirname)
+            (tramp-rpc--invalidate-cache-for-path
+             (tramp-make-tramp-file-name v2 (file-name-quote actual-dest-localname))))))
+    (tramp-handle-copy-directory dirname newname keep-date parents copy-contents)))
 
 (cl-defun tramp-rpc-handle-copy-file
     (filename newname &optional ok-if-already-exists keep-time
@@ -2747,18 +2914,6 @@ network round-trip."
       (make-symbolic-link
        (file-symlink-p filename) newname ok-if-already-exists))
 
-     ;; Both on same remote host using RPC - use server-side copy
-     ((and source-remote dest-remote
-           (tramp-equal-remote filename newname))
-      (with-parsed-tramp-file-name filename v1
-        (with-parsed-tramp-file-name newname v2
-          (tramp-rpc--call v1 "file.copy"
-                           `((src . ,(tramp-rpc--path-to-bin
-                                      (file-name-unquote v1-localname)))
-                             (dest . ,(tramp-rpc--path-to-bin
-                                       (file-name-unquote v2-localname)))
-                             (preserve . ,(if (or keep-time preserve-permissions) t :msgpack-false))
-                             (overwrite . ,(if ok-if-already-exists t :msgpack-false)))))))
      ;; Remote source, local dest - read via RPC, write locally
      ((and source-remote (not dest-remote))
       ;; Use file-local-copy to get a temp local copy, then rename
@@ -2932,15 +3087,6 @@ as a no-op, so ignore the server's ENOENT mapping as well."
        (tramp-rpc--debug "delete-file ignored missing %s: %s"
                          filename (error-message-string err)))))
   (tramp-rpc--invalidate-cache-for-path filename))
-
-(defun tramp-rpc--batch-error-p (value)
-  "Return non-nil when VALUE is an error object from `tramp-rpc--call-batch'."
-  (and (consp value) (plist-get value :error)))
-
-(defun tramp-rpc--signal-batch-error (operation filename error)
-  "Signal ERROR returned by a batched RPC for OPERATION on FILENAME."
-  (let ((message (or (plist-get error :message) "RPC batch subrequest failed")))
-    (signal 'remote-file-error (list operation filename message))))
 
 (defconst tramp-rpc--trash-read-batch-size 16
   "Maximum regular files to read in one optimized trash batch.")
@@ -4450,7 +4596,7 @@ Also controls process exit detection latency."
     (make-directory . tramp-rpc-handle-make-directory)
     (delete-directory . tramp-rpc-handle-delete-directory)
     (insert-directory . tramp-handle-insert-directory)
-    (copy-directory . tramp-handle-copy-directory)
+    (copy-directory . tramp-rpc-handle-copy-directory)
 
     ;; =========================================================================
     ;; RPC-based file I/O operations

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -268,6 +268,16 @@ pub fn map_io_error(err: std::io::Error, path: &str) -> RpcError {
     match err.kind() {
         ErrorKind::NotFound => RpcError::file_not_found(path),
         ErrorKind::PermissionDenied => RpcError::permission_denied(path),
+        ErrorKind::AlreadyExists => {
+            let mut rpc_error = RpcError::io_error(err);
+            if rpc_error.data.is_none() {
+                rpc_error.data = Some(Value::Map(vec![(
+                    Value::String("os_errno".into()),
+                    Value::Integer(libc::EEXIST.into()),
+                )]));
+            }
+            rpc_error
+        }
         _ => RpcError::io_error(err),
     }
 }

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -8,7 +8,7 @@ use rmpv::Value;
 use serde::Deserialize;
 use std::io::{SeekFrom, Write};
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
@@ -171,7 +171,7 @@ pub async fn write(params: Value) -> HandlerResult {
     })
 }
 
-/// Copy a file
+/// Copy a file or directory.
 pub async fn copy(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
@@ -179,21 +179,49 @@ pub async fn copy(params: Value) -> HandlerResult {
         src: Vec<u8>,
         #[serde(with = "path_or_bytes")]
         dest: Vec<u8>,
-        /// Preserve file attributes
+        /// Public protocol alias for preserving both permissions and timestamps.
         #[serde(default)]
         preserve: bool,
+        /// Preserve permission bits without forcing timestamp preservation.
+        #[serde(default)]
+        preserve_permissions: bool,
+        /// Preserve access and modification times.
+        #[serde(default)]
+        preserve_times: bool,
         /// Overwrite existing destination entries where possible.
         #[serde(default)]
         overwrite: bool,
+        /// Treat `dest` as the exact destination path, even when it names an
+        /// existing directory.  The default keeps the historical `file.copy`
+        /// behavior of copying into an existing destination directory.
+        #[serde(default)]
+        exact_dest: bool,
+        /// Allow recursive directory copies to merge into pre-existing child
+        /// directories.  This defaults to true as part of the public `file.copy`
+        /// protocol; callers that emulate Emacs `copy-directory` with nil
+        /// PARENTS set it to false.
+        #[serde(default = "default_true")]
+        merge_existing_directories: bool,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    let options = CopyOptions {
+        preserve_permissions: params.preserve || params.preserve_permissions,
+        preserve_times: params.preserve || params.preserve_times,
+        overwrite: params.overwrite,
+        merge_existing_directories: params.merge_existing_directories,
+    };
 
     let src_path = bytes_to_path(&params.src);
     let mut dest_path = bytes_to_path(&params.dest);
 
     // If destination is a directory, append the source filename
-    if dest_path.is_dir() {
+    if !params.exact_dest
+        && fs::metadata(&dest_path)
+            .await
+            .map(|meta| meta.is_dir())
+            .unwrap_or(false)
+    {
         if let Some(filename) = src_path.file_name() {
             dest_path.push(filename);
         }
@@ -206,30 +234,25 @@ pub async fn copy(params: Value) -> HandlerResult {
         .map_err(|e| map_io_error(e, &src_str))?;
 
     let bytes_copied = if src_metadata.is_dir() {
+        reject_recursive_self_copy(&src_path, &dest_path)
+            .await
+            .map_err(|e| map_io_error(e, &src_str))?;
         // Recursive directory copy
-        copy_dir_recursive(&src_path, &dest_path, params.preserve, params.overwrite)
+        copy_dir_recursive(&src_path, &dest_path, options, true)
             .await
             .map_err(|e| map_io_error(e, &src_str))?
     } else {
         // Copy regular file (or symlink target)
+        prepare_regular_destination(&dest_path, options.overwrite)
+            .await
+            .map_err(|e| map_io_error(e, &src_str))?;
         let n = fs::copy(&src_path, &dest_path)
             .await
             .map_err(|e| map_io_error(e, &src_str))?;
 
-        // Preserve attributes if requested
-        if params.preserve {
-            let _ = fs::set_permissions(&dest_path, src_metadata.permissions()).await;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::MetadataExt;
-                let atime = src_metadata.atime();
-                let mtime = src_metadata.mtime();
-                let dest = dest_path.to_string_lossy().into_owned();
-                let _ =
-                    tokio::task::spawn_blocking(move || set_file_times_sync(&dest, atime, mtime))
-                        .await;
-            }
-        }
+        apply_copied_metadata(&src_metadata, &dest_path, options)
+            .await
+            .map_err(|e| map_io_error(e, &src_str))?;
         n
     };
 
@@ -238,21 +261,26 @@ pub async fn copy(params: Value) -> HandlerResult {
     })
 }
 
+#[derive(Clone, Copy)]
+struct CopyOptions {
+    preserve_permissions: bool,
+    preserve_times: bool,
+    overwrite: bool,
+    merge_existing_directories: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 /// Recursively copy a directory and its contents.
 async fn copy_dir_recursive(
     src: &Path,
     dest: &Path,
-    preserve: bool,
-    overwrite: bool,
+    options: CopyOptions,
+    allow_existing_dest_dir: bool,
 ) -> std::io::Result<u64> {
-    // Create destination directory
-    fs::create_dir_all(dest).await?;
-
-    if preserve {
-        // Copy permissions from source dir
-        let src_meta = fs::metadata(src).await?;
-        let _ = fs::set_permissions(dest, src_meta.permissions()).await;
-    }
+    ensure_directory_destination(dest, allow_existing_dest_dir).await?;
 
     let mut total: u64 = 0;
     let mut entries = fs::read_dir(src).await?;
@@ -266,44 +294,151 @@ async fn copy_dir_recursive(
             total += Box::pin(copy_dir_recursive(
                 &entry_path,
                 &dest_child,
-                preserve,
-                overwrite,
+                options,
+                options.merge_existing_directories,
             ))
             .await?;
         } else if file_type.is_symlink() {
             // Preserve symlinks as symlinks
             let link_target = fs::read_link(&entry_path).await?;
-            if overwrite && fs::symlink_metadata(&dest_child).await.is_ok() {
-                remove_path_for_overwrite(&dest_child).await?;
-            }
+            prepare_symlink_destination(&dest_child, options.overwrite).await?;
             tokio::fs::symlink(&link_target, &dest_child).await?;
         } else {
-            if overwrite && fs::symlink_metadata(&dest_child).await.is_ok() {
-                remove_path_for_overwrite(&dest_child).await?;
-            }
+            prepare_regular_destination(&dest_child, options.overwrite).await?;
             let n = fs::copy(&entry_path, &dest_child).await?;
             total += n;
 
-            if preserve {
-                if let Ok(meta) = fs::metadata(&entry_path).await {
-                    let _ = fs::set_permissions(&dest_child, meta.permissions()).await;
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::MetadataExt;
-                        let atime = meta.atime();
-                        let mtime = meta.mtime();
-                        let dest_str = dest_child.to_string_lossy().into_owned();
-                        let _ = tokio::task::spawn_blocking(move || {
-                            set_file_times_sync(&dest_str, atime, mtime)
-                        })
-                        .await;
-                    }
-                }
-            }
+            let meta = fs::metadata(&entry_path).await?;
+            apply_copied_metadata(&meta, &dest_child, options).await?;
         }
     }
 
+    let src_meta = fs::metadata(src).await?;
+    apply_copied_metadata(&src_meta, dest, options).await?;
+
     Ok(total)
+}
+
+async fn ensure_directory_destination(path: &Path, allow_existing: bool) -> std::io::Result<()> {
+    match fs::symlink_metadata(path).await {
+        Ok(_) => {
+            if allow_existing
+                && fs::metadata(path)
+                    .await
+                    .map(|meta| meta.is_dir())
+                    .unwrap_or(false)
+            {
+                Ok(())
+            } else {
+                Err(already_exists(path))
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => fs::create_dir_all(path).await,
+        Err(e) => Err(e),
+    }
+}
+
+async fn reject_recursive_self_copy(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let src = fs::canonicalize(src).await?;
+    let dest = canonicalize_existing_ancestor(dest).await?;
+
+    if dest.starts_with(&src) {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "Cannot copy directory {} into its descendant {}",
+                src.display(),
+                dest.display()
+            ),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+async fn canonicalize_existing_ancestor(path: &Path) -> std::io::Result<PathBuf> {
+    let mut ancestor = path.to_path_buf();
+    let mut suffix = PathBuf::new();
+
+    loop {
+        match fs::symlink_metadata(&ancestor).await {
+            Ok(_) => return Ok(fs::canonicalize(&ancestor).await?.join(suffix)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = ancestor.file_name() else {
+                    return Err(e);
+                };
+                suffix = Path::new(name).join(suffix);
+                let Some(parent) = ancestor.parent() else {
+                    return Err(e);
+                };
+                ancestor = parent.to_path_buf();
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+async fn prepare_regular_destination(path: &Path, overwrite: bool) -> std::io::Result<()> {
+    if overwrite {
+        return Ok(());
+    }
+
+    match fs::symlink_metadata(path).await {
+        Ok(_) => Err(already_exists(path)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+async fn prepare_symlink_destination(path: &Path, overwrite: bool) -> std::io::Result<()> {
+    match fs::symlink_metadata(path).await {
+        Ok(meta) => {
+            if !overwrite {
+                return Err(already_exists(path));
+            }
+            if meta.is_dir() && !meta.file_type().is_symlink() {
+                return Err(already_exists(path));
+            }
+            remove_path_for_overwrite(path).await
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn already_exists(path: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!("Destination already exists: {}", path.display()),
+    )
+}
+
+async fn apply_copied_metadata(
+    src_meta: &std::fs::Metadata,
+    dest: &Path,
+    options: CopyOptions,
+) -> std::io::Result<()> {
+    if options.preserve_permissions {
+        fs::set_permissions(dest, src_meta.permissions()).await?;
+    }
+
+    if options.preserve_times {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            let atime = src_meta.atime();
+            let mtime = src_meta.mtime();
+            let dest = dest.to_path_buf();
+            tokio::task::spawn_blocking(move || {
+                set_file_times_sync_path_io(&dest, atime, mtime, false)
+            })
+            .await
+            .map_err(std::io::Error::other)??;
+        }
+    }
+
+    Ok(())
 }
 
 async fn remove_path_for_overwrite(path: &Path) -> std::io::Result<()> {
@@ -417,14 +552,16 @@ pub async fn set_times(params: Value) -> HandlerResult {
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     let path = bytes_to_path(&params.path);
+    let path_str = path.to_string_lossy().into_owned();
     let atime = params.atime.unwrap_or(params.mtime);
     let mtime = params.mtime;
     let nofollow = params.nofollow;
 
     // Use spawn_blocking for the libc syscall
-    tokio::task::spawn_blocking(move || set_file_times_sync_path(&path, atime, mtime, nofollow))
+    tokio::task::spawn_blocking(move || set_file_times_sync_path_io(&path, atime, mtime, nofollow))
         .await
-        .map_err(|e| RpcError::internal_error(e.to_string()))??;
+        .map_err(|e| RpcError::internal_error(e.to_string()))?
+        .map_err(|e| map_io_error(e, &path_str))?;
 
     Ok(Value::Boolean(true))
 }
@@ -540,38 +677,12 @@ pub async fn chown(params: Value) -> HandlerResult {
 // ============================================================================
 
 #[cfg(unix)]
-fn set_file_times_sync(path: &str, atime: i64, mtime: i64) -> Result<(), RpcError> {
-    use std::ffi::CString;
-
-    let path_cstr = CString::new(path).map_err(|_| RpcError::invalid_params("Invalid path"))?;
-
-    let times = [
-        libc::timespec {
-            tv_sec: atime as _,
-            tv_nsec: 0,
-        },
-        libc::timespec {
-            tv_sec: mtime as _,
-            tv_nsec: 0,
-        },
-    ];
-
-    let result = unsafe { libc::utimensat(libc::AT_FDCWD, path_cstr.as_ptr(), times.as_ptr(), 0) };
-
-    if result != 0 {
-        return Err(RpcError::io_error(std::io::Error::last_os_error()));
-    }
-
-    Ok(())
-}
-
-#[cfg(unix)]
-fn set_file_times_sync_path(
-    path: &std::path::Path,
+fn set_file_times_sync_path_io(
+    path: &Path,
     atime: i64,
     mtime: i64,
     nofollow: bool,
-) -> Result<(), RpcError> {
+) -> std::io::Result<()> {
     use std::os::unix::ffi::OsStrExt;
 
     let path_bytes = path.as_os_str().as_bytes();
@@ -603,7 +714,7 @@ fn set_file_times_sync_path(
     };
 
     if result != 0 {
-        return Err(RpcError::io_error(std::io::Error::last_os_error()));
+        return Err(std::io::Error::last_os_error());
     }
 
     Ok(())
@@ -696,5 +807,165 @@ mod tests {
         .expect_err("copy should fail without overwrite");
 
         assert!(err.message.contains("File exists") || err.message.contains("exists"));
+    }
+
+    #[tokio::test]
+    async fn copy_directory_exact_dest_merges_existing_directory() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest").join("src");
+
+        fs::create_dir_all(&src).await.unwrap();
+        fs::write(src.join("file.txt"), b"new").await.unwrap();
+
+        fs::create_dir_all(&dest).await.unwrap();
+        fs::write(dest.join("file.txt"), b"old").await.unwrap();
+
+        copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "overwrite" => true,
+            "exact_dest" => true,
+        })
+        .await
+        .expect("copy should merge into exact destination");
+
+        assert_eq!(fs::read(dest.join("file.txt")).await.unwrap(), b"new");
+        assert!(
+            !dest.join("src").exists(),
+            "exact_dest must not append basename"
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_directory_can_reject_existing_child_directories() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+
+        fs::create_dir_all(src.join("child")).await.unwrap();
+        fs::write(src.join("child/new.txt"), b"new").await.unwrap();
+
+        fs::create_dir_all(dest.join("child")).await.unwrap();
+        fs::write(dest.join("child/old.txt"), b"old").await.unwrap();
+
+        let err = copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "overwrite" => true,
+            "exact_dest" => true,
+            "merge_existing_directories" => false,
+        })
+        .await
+        .expect_err("copy should reject an existing child directory");
+
+        assert!(err.message.contains("exists"));
+        let errno = err
+            .data
+            .as_ref()
+            .and_then(|data| data.as_map())
+            .and_then(|data| data.iter().find(|(k, _)| k.as_str() == Some("os_errno")))
+            .and_then(|(_, v)| v.as_i64())
+            .expect("os_errno");
+        assert_eq!(errno, i64::from(libc::EEXIST));
+        assert_eq!(fs::read(dest.join("child/old.txt")).await.unwrap(), b"old");
+    }
+
+    #[tokio::test]
+    async fn copy_directory_rejects_recursive_self_copy() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = src.join("nested-copy");
+
+        fs::create_dir_all(&src).await.unwrap();
+        fs::write(src.join("file.txt"), b"payload").await.unwrap();
+
+        let err = copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "overwrite" => true,
+            "exact_dest" => true,
+        })
+        .await
+        .expect_err("copying a directory into itself must be rejected");
+
+        assert!(err.message.contains("Cannot copy directory"));
+    }
+
+    #[tokio::test]
+    async fn copy_regular_file_without_overwrite_rejects_existing_file() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src.txt");
+        let dest = tmp.path().join("dest.txt");
+
+        fs::write(&src, b"new").await.unwrap();
+        fs::write(&dest, b"old").await.unwrap();
+
+        let err = copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+        })
+        .await
+        .expect_err("copy should fail without overwrite");
+
+        assert!(err.message.contains("exists"));
+        assert_eq!(fs::read(&dest).await.unwrap(), b"old");
+    }
+
+    #[tokio::test]
+    async fn copy_directory_sets_permissions_after_children() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+
+        fs::create_dir_all(src.join("child")).await.unwrap();
+        fs::write(src.join("child/file.txt"), b"payload")
+            .await
+            .unwrap();
+
+        let readonly = std::fs::Permissions::from_mode(0o555);
+        fs::set_permissions(src.join("child"), readonly.clone())
+            .await
+            .unwrap();
+        fs::set_permissions(&src, readonly).await.unwrap();
+
+        copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "preserve_permissions" => true,
+        })
+        .await
+        .expect("copy should not chmod destination before copying children");
+
+        let copied = dest;
+        assert_eq!(
+            fs::read(copied.join("child/file.txt")).await.unwrap(),
+            b"payload"
+        );
+        assert_eq!(
+            fs::metadata(&copied).await.unwrap().permissions().mode() & 0o777,
+            0o555
+        );
+        assert_eq!(
+            fs::metadata(copied.join("child"))
+                .await
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+
+        let writable = std::fs::Permissions::from_mode(0o755);
+        fs::set_permissions(&src, writable.clone()).await.unwrap();
+        fs::set_permissions(src.join("child"), writable.clone())
+            .await
+            .unwrap();
+        fs::set_permissions(&copied, writable.clone())
+            .await
+            .unwrap();
+        fs::set_permissions(copied.join("child"), writable)
+            .await
+            .unwrap();
     }
 }

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -428,10 +428,12 @@ async fn apply_copied_metadata(
             use std::os::unix::fs::MetadataExt;
 
             let atime = src_meta.atime();
+            let atime_nsec = src_meta.atime_nsec();
             let mtime = src_meta.mtime();
+            let mtime_nsec = src_meta.mtime_nsec();
             let dest = dest.to_path_buf();
             tokio::task::spawn_blocking(move || {
-                set_file_times_sync_path_io(&dest, atime, mtime, false)
+                set_file_times_sync_path_io(&dest, atime, atime_nsec, mtime, mtime_nsec, false)
             })
             .await
             .map_err(std::io::Error::other)??;
@@ -558,10 +560,12 @@ pub async fn set_times(params: Value) -> HandlerResult {
     let nofollow = params.nofollow;
 
     // Use spawn_blocking for the libc syscall
-    tokio::task::spawn_blocking(move || set_file_times_sync_path_io(&path, atime, mtime, nofollow))
-        .await
-        .map_err(|e| RpcError::internal_error(e.to_string()))?
-        .map_err(|e| map_io_error(e, &path_str))?;
+    tokio::task::spawn_blocking(move || {
+        set_file_times_sync_path_io(&path, atime, 0, mtime, 0, nofollow)
+    })
+    .await
+    .map_err(|e| RpcError::internal_error(e.to_string()))?
+    .map_err(|e| map_io_error(e, &path_str))?;
 
     Ok(Value::Boolean(true))
 }
@@ -680,7 +684,9 @@ pub async fn chown(params: Value) -> HandlerResult {
 fn set_file_times_sync_path_io(
     path: &Path,
     atime: i64,
+    atime_nsec: i64,
     mtime: i64,
+    mtime_nsec: i64,
     nofollow: bool,
 ) -> std::io::Result<()> {
     use std::os::unix::ffi::OsStrExt;
@@ -692,11 +698,11 @@ fn set_file_times_sync_path_io(
     let times = [
         libc::timespec {
             tv_sec: atime as _,
-            tv_nsec: 0,
+            tv_nsec: atime_nsec as _,
         },
         libc::timespec {
             tv_sec: mtime as _,
-            tv_nsec: 0,
+            tv_nsec: mtime_nsec as _,
         },
     ];
 
@@ -725,6 +731,7 @@ mod tests {
     use super::*;
     use rmpv::Value;
     use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
 
     fn path_value(path: &Path) -> Value {
         Value::Binary(path.as_os_str().as_bytes().to_vec())
@@ -835,6 +842,51 @@ mod tests {
             !dest.join("src").exists(),
             "exact_dest must not append basename"
         );
+    }
+
+    #[tokio::test]
+    async fn copy_directory_preserves_file_and_directory_times() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let child = src.join("child");
+        let file = child.join("file.txt");
+        let dest = tmp.path().join("dest");
+
+        fs::create_dir_all(&child).await.unwrap();
+        fs::write(&file, b"payload").await.unwrap();
+
+        let src_time = 1_600_000_001;
+        let child_time = 1_600_000_002;
+        let file_time = 1_600_000_003;
+        let src_nsec = 101_000_001;
+        let child_nsec = 102_000_002;
+        let file_nsec = 103_000_003;
+        set_file_times_sync_path_io(&file, file_time, file_nsec, file_time, file_nsec, false)
+            .unwrap();
+        set_file_times_sync_path_io(
+            &child, child_time, child_nsec, child_time, child_nsec, false,
+        )
+        .unwrap();
+        set_file_times_sync_path_io(&src, src_time, src_nsec, src_time, src_nsec, false).unwrap();
+
+        copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "exact_dest" => true,
+            "preserve_times" => true,
+        })
+        .await
+        .expect("copy should preserve times");
+
+        let dest_meta = fs::metadata(&dest).await.unwrap();
+        assert_eq!(dest_meta.mtime(), src_time);
+        assert_eq!(dest_meta.mtime_nsec(), src_nsec);
+        let child_meta = fs::metadata(dest.join("child")).await.unwrap();
+        assert_eq!(child_meta.mtime(), child_time);
+        assert_eq!(child_meta.mtime_nsec(), child_nsec);
+        let file_meta = fs::metadata(dest.join("child/file.txt")).await.unwrap();
+        assert_eq!(file_meta.mtime(), file_time);
+        assert_eq!(file_meta.mtime_nsec(), file_nsec);
     }
 
     #[tokio::test]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -253,12 +253,24 @@ async fn batch_execute(params: Value) -> HandlerResult {
             // Convert Response to a result object
             match (response.result, response.error) {
                 (Some(result), None) => msgpack_map! { "result" => result },
-                (None, Some(error)) => msgpack_map! {
-                    "error" => msgpack_map! {
-                        "code" => error.code,
-                        "message" => error.message
+                (None, Some(error)) => {
+                    let mut error_fields = vec![
+                        (
+                            Value::String("code".into()),
+                            Value::Integer(error.code.into()),
+                        ),
+                        (
+                            Value::String("message".into()),
+                            Value::String(error.message.into()),
+                        ),
+                    ];
+                    if let Some(data) = error.data {
+                        error_fields.push((Value::String("data".into()), data));
                     }
-                },
+                    msgpack_map! {
+                        "error" => Value::Map(error_fields)
+                    }
+                }
                 _ => msgpack_map! { "result" => Value::Nil },
             }
         })
@@ -348,5 +360,54 @@ async fn dispatch_inner(request: Request) -> Response {
     match result {
         Ok(value) => Response::success(id, value),
         Err(error) => Response::error(Some(id), error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msgpack_map;
+    use std::os::unix::ffi::OsStrExt;
+
+    #[tokio::test]
+    async fn batch_errors_preserve_data() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let file = tmp.path().join("file");
+        tokio::fs::write(&file, b"payload").await.unwrap();
+        let not_a_dir = file.join("child");
+
+        let result = batch_execute(msgpack_map! {
+            "requests" => Value::Array(vec![msgpack_map! {
+                "method" => "file.stat",
+                "params" => msgpack_map! {
+                    "path" => Value::Binary(not_a_dir.as_os_str().as_bytes().to_vec()),
+                },
+            }]),
+        })
+        .await
+        .expect("batch should return per-request errors");
+
+        let results = result
+            .as_map()
+            .and_then(|m| m.iter().find(|(k, _)| k.as_str() == Some("results")))
+            .and_then(|(_, v)| v.as_array())
+            .expect("results array");
+        let error = results[0]
+            .as_map()
+            .and_then(|m| m.iter().find(|(k, _)| k.as_str() == Some("error")))
+            .and_then(|(_, v)| v.as_map())
+            .expect("error map");
+        let data = error
+            .iter()
+            .find(|(k, _)| k.as_str() == Some("data"))
+            .and_then(|(_, v)| v.as_map())
+            .expect("error data");
+        let errno = data
+            .iter()
+            .find(|(k, _)| k.as_str() == Some("os_errno"))
+            .and_then(|(_, v)| v.as_i64())
+            .expect("os_errno");
+
+        assert_eq!(errno, i64::from(libc::ENOTDIR));
     }
 }

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -157,15 +157,17 @@
   (skip-unless tramp-rpc-mock-test--msgpack-available)
   (let* ((response-plist '(:id 1
                            :result ((results . (((result . t))
-                                                ((error (code . -32001)
-                                                        (message . "Error"))))))))
+                                                ((error (code . -32003)
+                                                        (message . "Error")
+                                                        (data (os_errno . 20)))))))))
          (decoded (tramp-rpc-protocol-decode-batch-response response-plist)))
     (should (listp decoded))
     (should (= (length decoded) 2))
     ;; First result is success
     (should (eq (car decoded) t))
-    ;; Second is error
-    (should (plist-get (cadr decoded) :error))))
+    ;; Second is error, including structured errno data.
+    (should (plist-get (cadr decoded) :error))
+    (should (= 20 (alist-get 'os_errno (plist-get (cadr decoded) :data))))))
 
 (ert-deftest tramp-rpc-mock-test-protocol-length-framing ()
   "Test length-prefixed framing functions."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -868,6 +868,69 @@ signal `file-already-exists'.  With trailing slash (via
       (ignore-errors (delete-directory src t))
       (ignore-errors (delete-directory dest-parent t)))))
 
+(ert-deftest tramp-rpc-test06-copy-directory-copy-contents-roundtrips ()
+  "Same-remote `copy-directory' with COPY-CONTENTS is constant time."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (nested (expand-file-name "nested" src))
+         (dest (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (make-directory nested t)
+          (write-region "top" nil (expand-file-name "top.txt" src))
+          (write-region "child" nil (expand-file-name "child.txt" nested))
+          (make-directory dest)
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src (file-name-as-directory dest) nil nil t))
+          (should (file-exists-p (expand-file-name "top.txt" dest)))
+          (should (file-exists-p (expand-file-name "nested/child.txt" dest)))
+          (should-not (file-exists-p
+                       (expand-file-name (file-name-nondirectory src) dest))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-keep-date-roundtrips ()
+  "Same-remote `copy-directory' with KEEP-DATE is constant time."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (nested (expand-file-name "nested" src))
+         (file (expand-file-name "payload.txt" nested))
+         (dest (tramp-rpc-test--make-temp-name))
+         (src-time (seconds-to-time 1600000101))
+         (nested-time (seconds-to-time 1600000102))
+         (file-time (seconds-to-time 1600000103)))
+    (unwind-protect
+        (progn
+          (make-directory nested t)
+          (write-region "payload" nil file)
+          ;; Set parent directories after creating children so their mtimes are
+          ;; stable before copying.
+          (set-file-times file file-time)
+          (set-file-times nested nested-time)
+          (set-file-times src src-time)
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src dest t))
+          (should (= (truncate (float-time src-time))
+                     (truncate
+                      (float-time
+                       (file-attribute-modification-time
+                        (file-attributes dest))))))
+          (should (= (truncate (float-time nested-time))
+                     (truncate
+                      (float-time
+                       (file-attribute-modification-time
+                        (file-attributes (expand-file-name "nested" dest)))))))
+          (should (= (truncate (float-time file-time))
+                     (truncate
+                      (float-time
+                       (file-attribute-modification-time
+                        (file-attributes
+                         (expand-file-name "nested/payload.txt" dest))))))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest t)))))
+
 (ert-deftest tramp-rpc-test06-copy-directory-merges-existing-target-dir ()
   "Same-remote `copy-directory' merges into an existing DIRECTORY basename."
   (skip-unless (tramp-rpc-test-enabled))
@@ -1113,6 +1176,27 @@ signal `file-already-exists'.  With trailing slash (via
           (should (equal (file-symlink-p dest) target)))
       (ignore-errors (delete-file src-link))
       (ignore-errors (delete-file dest)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-create-symlink-ignores-copy-contents ()
+  "Source symlink copies into DIRECTORY even when COPY-CONTENTS is non-nil."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src-link (tramp-rpc-test--make-temp-name))
+         (dest-dir (tramp-rpc-test--make-temp-name))
+         (expected (expand-file-name (file-name-nondirectory src-link) dest-dir))
+         (target "missing-target")
+         (copy-directory-create-symlink t))
+    (unwind-protect
+        (progn
+          (condition-case nil
+              (make-symbolic-link target src-link)
+            (file-error (ert-skip "Symlinks not supported")))
+          (make-directory dest-dir)
+          (copy-directory src-link (file-name-as-directory dest-dir) nil nil t)
+          (should (equal (file-symlink-p expected) target)))
+      (ignore-errors (delete-file src-link))
+      (ignore-errors (delete-file expected))
+      (ignore-errors (delete-directory dest-dir t)))))
 
 (ert-deftest tramp-rpc-test06-rename-file ()
   "Test `rename-file' for TRAMP RPC files."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -816,6 +816,304 @@ signal `file-already-exists'.  With trailing slash (via
                                (buffer-string))))))
         (ignore-errors (delete-directory dest-dir t))))))
 
+(ert-deftest tramp-rpc-test06-copy-directory-roundtrips ()
+  "Same-remote `copy-directory' uses a constant number of RPC round-trips."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (nested (expand-file-name "nested" src))
+         (dest (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (make-directory nested t)
+          (write-region "top" nil (expand-file-name "top.txt" src))
+          (write-region "child" nil (expand-file-name "child.txt" nested))
+          ;; `copy-directory' itself calls `file-in-directory-p' before the
+          ;; file-name handler dispatches, so the end-to-end count includes
+          ;; that generic TRAMP safety check plus the backend's batch stat and
+          ;; single recursive `file.copy' RPC.  The important property is that
+          ;; this stays constant regardless of tree size.
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src dest))
+          (should (file-exists-p (expand-file-name "top.txt" dest)))
+          (should (file-exists-p (expand-file-name "nested/child.txt" dest)))
+          (should (equal "child"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "nested/child.txt" dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-to-existing-dir-roundtrips ()
+  "Same-remote `copy-directory' into an existing directory is constant time."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name (file-name-nondirectory src) dest-parent)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "payload" nil (expand-file-name "payload.txt" src))
+          (make-directory dest-parent)
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src (file-name-as-directory dest-parent)))
+          (should (file-exists-p (expand-file-name "payload.txt" expected-dest)))
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" expected-dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-merges-existing-target-dir ()
+  "Same-remote `copy-directory' merges into an existing DIRECTORY basename."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name (file-name-nondirectory src) dest-parent)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "new" nil (expand-file-name "payload.txt" src))
+          (make-directory expected-dest t)
+          (write-region "old" nil (expand-file-name "payload.txt" expected-dest))
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src (file-name-as-directory dest-parent)))
+          (should-not (file-exists-p (expand-file-name
+                                      (file-name-nondirectory src)
+                                      expected-dest)))
+          (should (equal "new"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" expected-dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-rejects-existing-child-dir ()
+  "With nil PARENTS, existing nested directories match Emacs semantics."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name (file-name-nondirectory src) dest-parent))
+         (existing-child (expand-file-name "child" expected-dest)))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name "child" src) t)
+          (write-region "new" nil (expand-file-name "child/new.txt" src))
+          (make-directory existing-child t)
+          (write-region "old" nil (expand-file-name "old.txt" existing-child))
+          (should-error
+           (copy-directory src (file-name-as-directory dest-parent))
+           :type 'file-already-exists)
+          (should (equal "old"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "old.txt" existing-child))
+                           (buffer-string))))
+          (should-not (file-exists-p (expand-file-name "new.txt" existing-child))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-parents-merges-existing-child-dir ()
+  "With non-nil PARENTS, existing nested directories are accepted."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name (file-name-nondirectory src) dest-parent))
+         (existing-child (expand-file-name "child" expected-dest)))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name "child" src) t)
+          (write-region "new" nil (expand-file-name "child/new.txt" src))
+          (make-directory existing-child t)
+          (write-region "old" nil (expand-file-name "old.txt" existing-child))
+          (copy-directory src (file-name-as-directory dest-parent) nil t)
+          (should (file-exists-p (expand-file-name "old.txt" existing-child)))
+          (should (equal "new"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "new.txt" existing-child))
+                           (buffer-string)))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-parents-allows-existing-dir-newname ()
+  "A non-directory-name NEWNAME may be an existing directory when PARENTS is t."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "payload" nil (expand-file-name "payload.txt" src))
+          (make-directory dest)
+          (copy-directory src dest nil t)
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-preserves-nonwritable-modes ()
+  "Mode preservation happens after child entries are copied."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (child (expand-file-name "child" src))
+         (dest (tramp-rpc-test--make-temp-name))
+         (copied-child (expand-file-name "child" dest)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (write-region "payload" nil (expand-file-name "payload.txt" child))
+          (set-file-modes child #o555)
+          (set-file-modes src #o555)
+          (copy-directory src dest)
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" copied-child))
+                           (buffer-string))))
+          (should (= (logand (file-modes dest) #o777) #o555))
+          (should (= (logand (file-modes copied-child) #o777) #o555)))
+      (ignore-errors (set-file-modes child #o755))
+      (ignore-errors (set-file-modes src #o755))
+      (ignore-errors (set-file-modes copied-child #o755))
+      (ignore-errors (set-file-modes dest #o755))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-merges-through-symlinked-target-dir ()
+  "Existing DIRECTORY basename may be a symlink to a directory."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (dest-parent (tramp-rpc-test--make-temp-name))
+         (real-target (tramp-rpc-test--make-temp-name))
+         (expected-link (expand-file-name (file-name-nondirectory src) dest-parent)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "payload" nil (expand-file-name "payload.txt" src))
+          (make-directory dest-parent)
+          (make-directory real-target)
+          (condition-case nil
+              (make-symbolic-link real-target expected-link)
+            (file-error (ert-skip "Symlinks not supported")))
+          (tramp-rpc-test--with-call-count 7
+            (copy-directory src (file-name-as-directory dest-parent)))
+          (should (file-symlink-p expected-link))
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" real-target))
+                           (buffer-string)))))
+      (ignore-errors (delete-file expected-link))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory dest-parent t))
+      (ignore-errors (delete-directory real-target t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-follows-symlinked-newname-parent ()
+  "A symlink to a directory may be the NEWNAME parent."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (link-parent (tramp-rpc-test--make-temp-name))
+         (real-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name (file-name-nondirectory src) real-parent)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "payload" nil (expand-file-name "payload.txt" src))
+          (make-directory real-parent)
+          (condition-case nil
+              (make-symbolic-link real-parent link-parent)
+            (file-error (ert-skip "Symlinks not supported")))
+          (copy-directory src (file-name-as-directory link-parent))
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" expected-dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-file link-parent))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory real-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-follows-symlinked-newname-parent-file ()
+  "A symlink to a directory may be the parent of a non-directory-name NEWNAME."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src (tramp-rpc-test--make-temp-name))
+         (link-parent (tramp-rpc-test--make-temp-name))
+         (real-parent (tramp-rpc-test--make-temp-name))
+         (expected-dest (expand-file-name "copied" real-parent)))
+    (unwind-protect
+        (progn
+          (make-directory src)
+          (write-region "payload" nil (expand-file-name "payload.txt" src))
+          (make-directory real-parent)
+          (condition-case nil
+              (make-symbolic-link real-parent link-parent)
+            (file-error (ert-skip "Symlinks not supported")))
+          (copy-directory src (expand-file-name "copied" link-parent))
+          (should (equal "payload"
+                         (with-temp-buffer
+                           (insert-file-contents
+                            (expand-file-name "payload.txt" expected-dest))
+                           (buffer-string)))))
+      (ignore-errors (delete-file link-parent))
+      (ignore-errors (delete-directory src t))
+      (ignore-errors (delete-directory real-parent t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-create-symlink-overwrites-file ()
+  "`copy-directory-create-symlink' follows Emacs overwrite behavior."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((target (tramp-rpc-test--make-temp-name))
+         (src-link (tramp-rpc-test--make-temp-name))
+         (dest (tramp-rpc-test--make-temp-name))
+         (copy-directory-create-symlink t))
+    (unwind-protect
+        (progn
+          (make-directory target)
+          (condition-case nil
+              (make-symbolic-link target src-link)
+            (file-error (ert-skip "Symlinks not supported")))
+          (write-region "old" nil dest)
+          (copy-directory src-link dest)
+          (should (equal (file-symlink-p dest) (file-local-name target))))
+      (ignore-errors (delete-file src-link))
+      (ignore-errors (delete-file dest))
+      (ignore-errors (delete-directory target t)))))
+
+(ert-deftest tramp-rpc-test06-copy-directory-create-symlink-dangling-source ()
+  "`copy-directory-create-symlink' must not follow SOURCE's target."
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((src-link (tramp-rpc-test--make-temp-name))
+         (dest (tramp-rpc-test--make-temp-name))
+         (target "missing-target")
+         (copy-directory-create-symlink t))
+    (unwind-protect
+        (progn
+          (condition-case nil
+              (make-symbolic-link target src-link)
+            (file-error (ert-skip "Symlinks not supported")))
+          (copy-directory src-link dest)
+          (should (equal (file-symlink-p dest) target)))
+      (ignore-errors (delete-file src-link))
+      (ignore-errors (delete-file dest)))))
+
 (ert-deftest tramp-rpc-test06-rename-file ()
   "Test `rename-file' for TRAMP RPC files."
   (skip-unless (tramp-rpc-test-enabled))


### PR DESCRIPTION
Previously, `copy-directory` on same-remote TRAMP-RPC paths fell through to the generic TRAMP handler, which would walk the directory tree from Emacs and issue one RPC per entry. This change implements a dedicated `tramp-rpc-handle-copy-directory` that performs a single server-side `file.copy` RPC for same-remote whole-directory copies, keeping the round-trip count constant regardless of tree size.

Key changes:

- **New Elisp handler** (`tramp-rpc-handle-copy-directory`): Validates source/destination pre-conditions via a single batch `file.stat` RPC, then dispatches one recursive `file.copy` RPC for same-remote copies. Falls back to `tramp-handle-copy-directory` for cross-remote, `copy-contents`, or `keep-date` cases where exact Emacs semantics are required.

- **New `exact_dest` parameter** for `file.copy`: Treats `dest` as the literal destination path rather than copying into an existing destination directory. This lets the Elisp layer control basename resolution and avoid double-nesting.

- **Granular `preserve_permissions` / `preserve_times` fields**: Replaces the single `preserve` flag with separate controls, while keeping `preserve` as a backward-compatible alias. The recursive copy now applies metadata (permissions and timestamps) to each entry *after* its children are written, fixing a bug where setting a read-only mode on a directory before copying its contents would cause failures.

- **Refactored Rust copy helpers**: Extracted `CopyOptions`, `apply_copied_metadata`, `prepare_regular_destination`, `prepare_symlink_destination`, and `ensure_directory_destination` to reduce duplication and make overwrite/metadata semantics consistent between file and directory copies.

- **Fix for `prepare_regular_destination`**: Non-overwrite copies now correctly return `AlreadyExists` instead of silently clobbering existing files.

- **Unified `set_file_times_sync_path_io`**: Merged two near-duplicate `set_file_times_sync*` helpers into one that returns `std::io::Result`, enabling consistent `map_io_error` propagation at call sites.

- **Cross-architecture fix** in `extract_stat_fields`: Uses conditional compilation to avoid a lossy `into()` cast on 32-bit targets where `st_atime` is already `i32`.

- **New tests**: Rust unit tests for `exact_dest` merging, non-overwrite rejection, and permission-ordering correctness; ERT integration tests covering round-trip counts, merging into existing directories, symlinked targets, and `copy-directory-create-symlink` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced remote directory copy behavior for `copy-directory`, including controlled merging, `PARENTS` handling, and correct symlink/overwrite semantics.
  * Added finer-grained timestamp preservation (nanosecond precision) during remote copy and time-setting.

* **Bug Fixes**
  * Remote batch RPC errors now preserve structured `error.data` (including `os_errno`) for clearer diagnostics.
  * Improved mapping of I/O errors such as “already exists” to consistent, information-rich remote error reports.

* **Tests**
  * Added/expanded coverage for remote `copy-directory` semantics, constant-time round-trips, and error-data preservation in batch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->