### PR TITLE
Fix TRAMP RPC coding pairs and development reloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ This can include:
 
 # Testing updates
 
-NEVER use emacsclient. That will interfer with the users configuration
+NEVER use emacsclient, unless the user specifically request this to reload the configuration.
+That will interfer with the users configuration
 
 Always use `emacs -Q --batch --eval <lisp commands>`
 

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -595,20 +595,21 @@ Removes handler."
 
 (add-hook 'tramp-rpc-unload-hook
 	  (lambda ()
-	    ;; When Emacs is configured --with-native-compilation,
-	    ;; `load-history' contains `--anonymous-lambda' defun
-	    ;; entries for tramp-rpc-advice.el.  This raises an
-	    ;; `cl--assertion-failed' error when unloading.  Emacs
-	    ;; bug#80446.
-	    (dolist (entry load-history)
-	      (when (string-match-p
-		     (rx "tramp-rpc-advice" (| ".el" ".elc") eos) (car entry))
-		(setcdr entry
-			(seq-remove
-			 (lambda (item)
-			   (equal item '(defun . --anonymous-lambda)))
-			 (cdr entry)))))
-	    (unload-feature 'tramp-rpc-advice 'force)))
+	    (when (featurep 'tramp-rpc-advice)
+	      ;; When Emacs is configured --with-native-compilation,
+	      ;; `load-history' contains `--anonymous-lambda' defun
+	      ;; entries for tramp-rpc-advice.el.  This raises an
+	      ;; `cl--assertion-failed' error when unloading.  Emacs
+	      ;; bug#80446.
+	      (dolist (entry load-history)
+		(when (string-match-p
+		       (rx "tramp-rpc-advice" (| ".el" ".elc") eos) (car entry))
+		  (setcdr entry
+			  (seq-remove
+			   (lambda (item)
+			     (equal item '(defun . --anonymous-lambda)))
+			   (cdr entry)))))
+	      (unload-feature 'tramp-rpc-advice 'force))))
 
 (provide 'tramp-rpc-advice)
 ;;; tramp-rpc-advice.el ends here

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -1246,7 +1246,8 @@ This helps troubleshoot deployment issues."
 
 (add-hook 'tramp-rpc-unload-hook
 	  (lambda ()
-	    (unload-feature 'tramp-rpc-deploy 'force)))
+	    (when (featurep 'tramp-rpc-deploy)
+	      (unload-feature 'tramp-rpc-deploy 'force))))
 
 (provide 'tramp-rpc-deploy)
 ;;; tramp-rpc-deploy.el ends here

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -828,7 +828,8 @@ Removes handlers."
 
 (add-hook 'tramp-rpc-unload-hook
 	  (lambda ()
-	    (unload-feature 'tramp-rpc-magit 'force)))
+	    (when (featurep 'tramp-rpc-magit)
+	      (unload-feature 'tramp-rpc-magit 'force))))
 
 (provide 'tramp-rpc-magit)
 ;;; tramp-rpc-magit.el ends here

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -418,10 +418,30 @@ ENCODING).  When DECODING or ENCODING is nil inside a cons, it is
 replaced with the corresponding default from
 `default-process-coding-system', matching how native `make-process'
 handles nil :coding elements."
-  (if (consp coding)
-      (list (or (car coding) (car default-process-coding-system))
-            (or (cdr coding) (cdr default-process-coding-system)))
-    (list coding coding)))
+  (let ((coding (tramp-rpc--normalize-coding coding)))
+    (if (consp coding)
+        (list (car coding) (cdr coding))
+      (list coding coding))))
+
+(defun tramp-rpc--normalize-coding (coding)
+  "Normalize a `make-process' :coding value for internal use.
+
+CODING may be nil, a coding-system symbol, or a cons cell
+(DECODING . ENCODING).  Nil sides in a cons are replaced with the
+corresponding side of `default-process-coding-system', like native
+`make-process'.  When the resolved decoding and encoding coding systems
+are identical, return the single symbol form.  This preserves native
+semantics while avoiding fragile paths which assume a same-sided coding
+pair is a symbol."
+  (cond
+   ((null coding) nil)
+   ((consp coding)
+    (let ((decoding (or (car coding) (car default-process-coding-system)))
+          (encoding (or (cdr coding) (cdr default-process-coding-system))))
+      (if (eq decoding encoding)
+          decoding
+        (cons decoding encoding))))
+   (t coding)))
 
 ;; ============================================================================
 ;; make-process handler
@@ -441,7 +461,7 @@ Resolves program path and loads direnv environment from working directory."
          ;; Extract the actual buffer from the list.
          (buffer (if (consp buffer-arg) (car buffer-arg) buffer-arg))
          (command (plist-get args :command))
-         (coding (plist-get args :coding))
+         (coding (tramp-rpc--normalize-coding (plist-get args :coding)))
          (noquery (plist-get args :noquery))
          (filter (plist-get args :filter))
          (sentinel (plist-get args :sentinel))
@@ -736,8 +756,9 @@ DIRENV-ENV is an optional alist of environment variables for the process."
          (local-process (make-pipe-process
                          :name (or name "tramp-rpc-pty")
                          :buffer actual-buffer
-                          :coding (or coding 'utf-8-unix)
-                          :noquery t)))
+                         :coding (or (tramp-rpc--normalize-coding coding)
+                                     'utf-8-unix)
+                         :noquery t)))
 
     ;; Configure the local relay process
     (set-process-filter local-process (or filter #'tramp-rpc--pty-default-filter))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -1129,7 +1129,8 @@ Removes handlers and cleans up async processes."
 
 (add-hook 'tramp-rpc-unload-hook
 	  (lambda ()
-	    (unload-feature 'tramp-rpc-process 'force)))
+	    (when (featurep 'tramp-rpc-process)
+	      (unload-feature 'tramp-rpc-process 'force))))
 
 (provide 'tramp-rpc-process)
 ;;; tramp-rpc-process.el ends here

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -168,7 +168,8 @@ Returns a list where each element is either:
 
 (add-hook 'tramp-rpc-unload-hook
 	  (lambda ()
-	    (unload-feature 'tramp-rpc-protocol 'force)))
+	    (when (featurep 'tramp-rpc-protocol)
+	      (unload-feature 'tramp-rpc-protocol 'force))))
 
 (provide 'tramp-rpc-protocol)
 ;;; tramp-rpc-protocol.el ends here

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -47,6 +47,16 @@
 
 ;;; Code:
 
+(eval-and-compile
+  ;; When loading this file by absolute path during development, make sure the
+  ;; sibling modules required below are loaded from the same checkout rather
+  ;; than from an installed package earlier in `load-path'.
+  (when-let* ((dir (file-name-directory (or load-file-name
+                                            (and (boundp 'byte-compile-current-file)
+                                                 byte-compile-current-file)
+                                            buffer-file-name))))
+    (add-to-list 'load-path dir)))
+
 ;; Autoload support - these forms are extracted to tramp-rpc-autoloads.el
 ;; and run at package-initialize time, before the full file is loaded.
 
@@ -4192,6 +4202,9 @@ cleanup of all connections has run."
 ;; Unload support
 ;; ============================================================================
 
+(defvar tramp-rpc-unload-hook nil
+  "Hook run by `tramp-rpc-unload-function' to unload helper modules.")
+
 (defun tramp-rpc-unload-function ()
   "Unload function for tramp-rpc.
 Removes advice and cleans up async processes."
@@ -4200,16 +4213,17 @@ Removes advice and cleans up async processes."
   (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc)
   (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
   (tramp-remove-external-operation 'move-file-to-trash 'tramp-rpc)
-  ;; Remove all advice (from tramp-rpc-advice module).
-  ;; Not needed. This is called in `tramp-rpc-advice-unload-function'.
+  ;; Unload helper modules.  `tramp-rpc.el' requires these modules, so
+  ;; unloading only the top-level feature and loading it again would otherwise
+  ;; leave stale definitions in place (notably `tramp-rpc-process.el').  Helper
+  ;; unload functions also perform their own cleanup before removing symbols.
+  ;; Helper hook entries are idempotent because unloading one helper can unload
+  ;; another as a dependency before its hook entry is reached.
+  (run-hooks 'tramp-rpc-unload-hook)
   ;; Remove multi-hop hook and cleanup hooks.
   (remove-hook 'tramp-multi-hop-p-hook #'tramp-rpc-multi-hop-p)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
   (remove-hook 'tramp-cleanup-all-connections-hook #'tramp-rpc-cleanup-all-connections)
-  ;; Clean up all async processes (from tramp-rpc-process module)
-  (tramp-rpc--cleanup-async-processes)
-  ;; Clean up PTY processes (from tramp-rpc-process module)
-  (tramp-rpc--cleanup-pty-processes)
   ;; Remove method registrations.
   (setq tramp-methods (delete (assoc tramp-rpc-method tramp-methods) tramp-methods))
   (setq tramp-foreign-file-name-handler-alist

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1335,9 +1335,18 @@ This matches the upstream `tramp-test28-process-file' test."
 ;;; ============================================================================
 
 (ert-deftest tramp-rpc-test13b-coding-args ()
-  "Test `tramp-rpc--coding-args' handles symbol and cons pair coding."
+  "Test coding helpers handle symbol and cons pair coding."
   (let ((default-dec (car default-process-coding-system))
         (default-enc (cdr default-process-coding-system)))
+    ;; Same-sided cons pair is valid `make-process' input, but can be
+    ;; represented as a symbol internally.
+    (should (eq 'utf-8-unix
+                (tramp-rpc--normalize-coding
+                 '(utf-8-unix . utf-8-unix))))
+    ;; Different sides must remain a cons pair.
+    (should (equal '(undecided-unix . utf-8-unix)
+                   (tramp-rpc--normalize-coding
+                    '(undecided-unix . utf-8-unix))))
     ;; Symbol case: same value used for both decoding and encoding
     (should (equal '(utf-8-unix utf-8-unix)
                    (tramp-rpc--coding-args 'utf-8-unix)))
@@ -1350,6 +1359,41 @@ This matches the upstream `tramp-test28-process-file' test."
     ;; Cons pair with nil encoding: nil replaced with default
     (should (equal (list 'utf-8-unix default-enc)
                    (tramp-rpc--coding-args '(utf-8-unix . nil))))))
+
+(ert-deftest tramp-rpc-test13c-make-process-coding-pair ()
+  "Test `make-process' handler accepts same-sided cons pair :coding values."
+  (let ((default-directory "/rpc:mock:/tmp/")
+        (default-process-coding-system '(utf-8-unix . utf-8-unix))
+        proc)
+    (cl-letf (((symbol-function 'tramp-rpc--start-remote-process)
+               (lambda (&rest _args) 12345))
+              ((symbol-function 'tramp-rpc--start-async-read)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--kill-remote-process)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda (&rest _args) nil)))
+      (unwind-protect
+          (progn
+            (setq proc (tramp-rpc-handle-make-process
+                        :name "tramp-rpc-coding-pair-test"
+                        :buffer nil
+                        :command '("jj" "workspace" "root")
+                        :connection-type 'pipe
+                        :coding default-process-coding-system
+                        :noquery t
+                        :sentinel #'ignore))
+            (should (processp proc))
+            (should (equal (process-coding-system proc)
+                           '(utf-8-unix . utf-8-unix))))
+        (when (processp proc)
+          (ignore-errors (delete-process proc)))))))
 
 ;;; ============================================================================
 ;;; Test 14: Async Processes


### PR DESCRIPTION
## Summary
- Normalize same-sided `make-process` `:coding` pairs before TRAMP RPC process setup, fixing Majutsu's `(utf-8-unix . utf-8-unix)` invocation on `/rpc:` directories.
- Add regression coverage for the coding-pair process path.
- Make absolute-path development reloads load sibling TRAMP RPC modules from the checkout and unload helper modules correctly.
- Document the explicit emacsclient reload exception for development testing.

## Tests
- `emacs -Q --batch -L ~/.emacs.d/.local/straight/repos/tramp -l test/tramp-rpc-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-test13[bc]")'`
- `rm -f lisp/*.elc && emacs -Q --batch -L ~/.emacs.d/.local/straight/repos/tramp --eval "(require 'package)" --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" --eval "(package-initialize)" --eval "(setq byte-compile-error-on-warn t)" --eval "(push \"$(pwd)/lisp\" load-path)" -f batch-byte-compile lisp/*.el`
