### PR TITLE
Fix Emacs file notification compliance

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -193,7 +193,9 @@ PARAMS is the notification parameters."
   "Return EVENT's KEY path as a TRAMP file name on VEC, or nil."
   (when-let* ((path (tramp-rpc--decode-string (alist-get key event)))
               ((stringp path)))
-    (tramp-make-tramp-file-name vec path)))
+    (if (tramp-tramp-file-p path)
+        path
+      (tramp-make-tramp-file-name vec path))))
 
 (defun tramp-rpc--watch-canonical-directory (vec result)
   "Return canonical TRAMP directory from watch.add RESULT on VEC."
@@ -201,7 +203,9 @@ PARAMS is the notification parameters."
                                         (tramp-rpc--decode-string
                                          (alist-get 'path result))))
               ((stringp canonical-localname)))
-    (tramp-make-tramp-file-name vec canonical-localname)))
+    (if (tramp-tramp-file-p canonical-localname)
+        canonical-localname
+      (tramp-make-tramp-file-name vec canonical-localname))))
 
 (defun tramp-rpc--path-under-directory-relative (directory file-name)
   "Return FILE-NAME relative to DIRECTORY, or nil.
@@ -249,25 +253,45 @@ DIRECTORY itself returns the empty string.  Descendants can contain slashes."
         (unless tramp-rpc--suppress-fs-notifications
           ;; Also clear the magit process-file cache since git state may have changed.
           (tramp-rpc-magit--clear-status-cache))
-        (dolist (event events)
-          (let* ((action (alist-get 'action event))
-                 (path (tramp-rpc--fs-event-path vec event 'path))
-                 (path1 (tramp-rpc--fs-event-path vec event 'path1))
-                 (cookie (alist-get 'cookie event)))
-            (when (stringp action)
-              (if (string= action "rescan")
-                  (unless tramp-rpc--suppress-fs-notifications
-                    (tramp-rpc--clear-file-caches-for-connection vec))
-                (when path
-                  ;; File notifications are deliberately not suppressed by
-                  ;; `tramp-rpc--suppress-fs-notifications': that variable only
-                  ;; suppresses cache/status work during operations that
-                  ;; invalidate caches themselves.
-                  (unless tramp-rpc--suppress-fs-notifications
-                    (tramp-rpc--invalidate-event-path path)
-                    (when path1
-                      (tramp-rpc--invalidate-event-path path1)))
-                  (tramp-rpc--file-notify-dispatch action path path1 cookie))))))))))
+        (let (renamed-pairs)
+          ;; Linux/inotify can report the same rename as both a combined pair
+          ;; and as cookie-tracked from/to events in one debounce batch.  Emacs'
+          ;; filenotify tests expect one public `renamed' action, so suppress
+          ;; the from/to half when an equivalent combined event is present.
+          (dolist (event events)
+            (let ((action (alist-get 'action event)))
+              (when (string= action "renamed")
+                (when-let* ((path (tramp-rpc--fs-event-path vec event 'path))
+                            (path1 (tramp-rpc--fs-event-path vec event 'path1)))
+                  (push (cons path path1) renamed-pairs)))))
+          (dolist (event events)
+            (let* ((action (alist-get 'action event))
+                   (path (tramp-rpc--fs-event-path vec event 'path))
+                   (path1 (tramp-rpc--fs-event-path vec event 'path1))
+                   (cookie (alist-get 'cookie event))
+                   (duplicate-tracked-rename
+                    (and (member action '("renamed-from" "renamed-to"))
+                         path
+                         (cl-some
+                          (lambda (pair)
+                            (string= path (if (string= action "renamed-from")
+                                              (car pair)
+                                            (cdr pair))))
+                          renamed-pairs))))
+              (when (and (stringp action) (not duplicate-tracked-rename))
+                (if (string= action "rescan")
+                    (unless tramp-rpc--suppress-fs-notifications
+                      (tramp-rpc--clear-file-caches-for-connection vec))
+                  (when path
+                    ;; File notifications are deliberately not suppressed by
+                    ;; `tramp-rpc--suppress-fs-notifications': that variable only
+                    ;; suppresses cache/status work during operations that
+                    ;; invalidate caches themselves.
+                    (unless tramp-rpc--suppress-fs-notifications
+                      (tramp-rpc--invalidate-event-path path)
+                      (when path1
+                        (tramp-rpc--invalidate-event-path path1)))
+                    (tramp-rpc--file-notify-dispatch action path path1 cookie)))))))))))
 
 (defun tramp-rpc-watch-directory (directory &optional recursive)
   "Start watching DIRECTORY for filesystem changes.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2665,10 +2665,14 @@ network round-trip."
 
 (defun tramp-rpc-handle-delete-file (filename &optional trash)
   "Like `delete-file' for TRAMP-RPC files.
-Calls `file.delete' directly; the server's unlink error is sufficient for the
-missing-file check, so no separate preflight stat is needed."
+Calls `file.delete' directly.  Current Emacs `delete-file' treats missing files
+as a no-op, so ignore the server's ENOENT mapping as well."
   (tramp-skeleton-delete-file filename trash
-    (tramp-rpc--call v "file.delete" (tramp-rpc--encode-path localname)))
+    (condition-case err
+        (tramp-rpc--call v "file.delete" (tramp-rpc--encode-path localname))
+      (file-missing
+       (tramp-rpc--debug "delete-file ignored missing %s: %s"
+                         filename (error-message-string err)))))
   (tramp-rpc--invalidate-cache-for-path filename))
 
 (defun tramp-rpc--batch-error-p (value)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3683,23 +3683,22 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
     (unless (process-get descriptor 'tramp-rpc-file-notify-removing)
       (file-notify-rm-watch descriptor))))
 
-(defun tramp-rpc--make-file-notify-descriptor (vec directory localname)
+(defun tramp-rpc--make-file-notify-descriptor (vec _directory localname)
   "Create a TRAMP-style process descriptor for a file notification watch."
   (let* (;; Emacs' remote file notification tests use the process name to
          ;; identify the remote backend and inject synthetic backend events.
          ;; TRAMP-RPC's server uses the notify crate; on GNU/Linux its behavior
          ;; is closest to TRAMP's inotifywait backend.
          (name "inotifywait")
-         (buffer (generate-new-buffer
-                  (format " *%s file-notify %s*"
-                          (tramp-get-connection-name vec) name)))
+         ;; This synthetic process is only a watch descriptor; it never
+         ;; receives output.  Do not attach a buffer: `global-auto-revert-mode'
+         ;; iterates over `buffer-list' while removing file notification
+         ;; watches, and deleting descriptor buffers during that iteration can
+         ;; make Emacs select a just-deleted buffer.
          (descriptor (make-pipe-process
                       :name name
-                      :buffer buffer
                       :noquery t
                       :sentinel #'tramp-rpc--file-notify-process-sentinel)))
-    (with-current-buffer buffer
-      (setq default-directory directory))
     ;; These two properties are the ones TRAMP's generic file-notify routing and
     ;; validity helpers expect on watch descriptors.
     (process-put descriptor 'tramp-vector vec)
@@ -3710,14 +3709,11 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
     descriptor))
 
 (defun tramp-rpc--delete-file-notify-descriptor-process (descriptor)
-  "Delete DESCRIPTOR's synthetic process and hidden process buffer."
+  "Delete DESCRIPTOR's synthetic process."
   (when (processp descriptor)
     (process-put descriptor 'tramp-rpc-file-notify-removing t)
-    (let ((buffer (process-buffer descriptor)))
-      (when (process-live-p descriptor)
-        (delete-process descriptor))
-      (when (buffer-live-p buffer)
-        (kill-buffer buffer)))))
+    (when (process-live-p descriptor)
+      (delete-process descriptor))))
 
 (defun tramp-rpc--canonical-directory-equal-p (a b)
   "Return non-nil if canonical directory names A and B are equal."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1977,13 +1977,14 @@ errors instead of probing first."
                      (append (tramp-rpc--encode-path localname)
                              `((mode . ,mode))))))
 
-(defun tramp-rpc-handle-set-file-times (filename &optional timestamp _flag)
+(defun tramp-rpc-handle-set-file-times (filename &optional timestamp flag)
   "Like `set-file-times' for TRAMP-RPC files."
   (tramp-rpc--with-set-file-attributes-rpc filename
     (let ((mtime (floor (float-time (or timestamp (current-time))))))
       (tramp-rpc--call v "file.set_times"
                        (append (tramp-rpc--encode-path localname)
-                               `((mtime . ,mtime)))))))
+                               `((mtime . ,mtime)
+                                 (nofollow . ,(if flag t :msgpack-false))))))))
 
 
 ;; ============================================================================
@@ -3680,8 +3681,14 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
 
 (defun tramp-rpc--make-file-notify-descriptor (vec directory localname)
   "Create a TRAMP-style process descriptor for a file notification watch."
-  (let* ((name (format "%s file-notify" (tramp-get-connection-name vec)))
-         (buffer (generate-new-buffer (format " *%s*" name)))
+  (let* (;; Emacs' remote file notification tests use the process name to
+         ;; identify the remote backend and inject synthetic backend events.
+         ;; TRAMP-RPC's server uses the notify crate; on GNU/Linux its behavior
+         ;; is closest to TRAMP's inotifywait backend.
+         (name "inotifywait")
+         (buffer (generate-new-buffer
+                  (format " *%s file-notify %s*"
+                          (tramp-get-connection-name vec) name)))
          (descriptor (make-pipe-process
                       :name name
                       :buffer buffer
@@ -3877,6 +3884,25 @@ the empty string."
           (expand-file-name relative directory))
       file-name)))
 
+(defun tramp-rpc--file-notify-callback-name (data file-name)
+  "Return FILE-NAME in the form expected by `file-notify-callback'.
+`file-notify-callback' expands backend file names relative to the
+watch directory stored in `file-notify-descriptors'.  Passing an
+already expanded TRAMP name can therefore produce doubled remote
+prefixes on some TRAMP versions.  Prefer the name relative to the
+original watched directory, falling back to the original spelling when
+we cannot derive one."
+  (let* ((display-file-name
+          (tramp-rpc--file-notify-original-spelling data file-name))
+         (directory (plist-get data :directory))
+         (relative (and directory
+                        (tramp-rpc--file-notify-relative-name
+                         directory display-file-name))))
+    (cond
+     ((null relative) display-file-name)
+     ((string-empty-p relative) ".")
+     (t relative))))
+
 (defun tramp-rpc--file-notify-path-matches-p (data file-name)
   "Return non-nil if descriptor DATA covers FILE-NAME."
   (let ((canonical-directory
@@ -3919,10 +3945,10 @@ FILE-NAME1 is the destination for `renamed' events.  COOKIE pairs
         (let* ((descriptor (car descriptor-data))
                (data (cdr descriptor-data))
                (display-file-name
-                (tramp-rpc--file-notify-original-spelling data file-name))
+                (tramp-rpc--file-notify-callback-name data file-name))
                (display-file-name1
                 (and file-name1
-                     (tramp-rpc--file-notify-original-spelling data file-name1)))
+                     (tramp-rpc--file-notify-callback-name data file-name1)))
                (event-data (append (list descriptor (list callback-action)
                                          display-file-name)
                                    (cond
@@ -3961,6 +3987,9 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                (canonical-localname (and (listp result)
                                          (alist-get 'path result)))
                (canonical-directory (cond
+                                     ((and (stringp canonical-localname)
+                                           (tramp-tramp-file-p canonical-localname))
+                                      canonical-localname)
                                      ((stringp canonical-localname)
                                       (tramp-make-tramp-file-name
                                        v canonical-localname))

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -407,6 +407,9 @@ pub async fn set_times(params: Value) -> HandlerResult {
         /// Access time (seconds since epoch, defaults to mtime)
         #[serde(default)]
         atime: Option<i64>,
+        /// If true, update a symlink itself instead of following it.
+        #[serde(default)]
+        nofollow: bool,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -414,9 +417,10 @@ pub async fn set_times(params: Value) -> HandlerResult {
     let path = bytes_to_path(&params.path);
     let atime = params.atime.unwrap_or(params.mtime);
     let mtime = params.mtime;
+    let nofollow = params.nofollow;
 
     // Use spawn_blocking for the libc syscall
-    tokio::task::spawn_blocking(move || set_file_times_sync_path(&path, atime, mtime))
+    tokio::task::spawn_blocking(move || set_file_times_sync_path(&path, atime, mtime, nofollow))
         .await
         .map_err(|e| RpcError::internal_error(e.to_string()))??;
 
@@ -564,6 +568,7 @@ fn set_file_times_sync_path(
     path: &std::path::Path,
     atime: i64,
     mtime: i64,
+    nofollow: bool,
 ) -> Result<(), RpcError> {
     use std::os::unix::ffi::OsStrExt;
 
@@ -587,7 +592,11 @@ fn set_file_times_sync_path(
             libc::AT_FDCWD,
             path_cstr.as_ptr() as *const libc::c_char,
             times.as_ptr(),
-            0,
+            if nofollow {
+                libc::AT_SYMLINK_NOFOLLOW
+            } else {
+                0
+            },
         )
     };
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1700,6 +1700,20 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (equal moved "/rpc:mock:/tmp/file"))
       (should-not rpc-called))))
 
+(ert-deftest tramp-rpc-mock-test-delete-file-missing-is-noop ()
+  "Missing files are ignored like current Emacs `delete-file'."
+  :tags '(:delete)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let (invalidated)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method _params)
+                 (should (equal method "file.delete"))
+                 (signal 'file-missing '("RPC" "No such file" "/tmp/missing"))))
+              ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+               (lambda (filename) (setq invalidated filename))))
+      (tramp-rpc-handle-delete-file "/rpc:mock:/tmp/missing" nil)
+      (should (equal invalidated "/rpc:mock:/tmp/missing")))))
+
 (ert-deftest tramp-rpc-mock-test-move-file-to-trash-regular-file-local-trash ()
   "Test optimized `move-file-to-trash' copies a remote file to local trash."
   :tags '(:delete)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1063,16 +1063,14 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/real/changed")
           (should (equal events
                          `((file-notify
-                            (,descriptor (changed) "/rpc:mock:/tmp/link/changed")
+                            (,descriptor (changed) "changed")
                             file-notify-callback))))
           (setq events nil)
           (tramp-rpc--file-notify-dispatch
            "renamed" "/rpc:mock:/tmp/real/old" "/rpc:mock:/tmp/real/new")
           (should (equal events
                          `((file-notify
-                            (,descriptor (moved)
-                             "/rpc:mock:/tmp/link/old"
-                             "/rpc:mock:/tmp/link/new")
+                            (,descriptor (moved) "old" "new")
                             file-notify-callback))))
           ;; Dispatch uses the shared watch entry's canonical directory if it is
           ;; refreshed after the descriptor was created.
@@ -1084,9 +1082,43 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/new-real/changed")
           (should (equal events
                          `((file-notify
-                            (,descriptor (changed) "/rpc:mock:/tmp/link/changed")
+                            (,descriptor (changed) "changed")
                             file-notify-callback)))))
       (when descriptor
+        (remhash descriptor tramp-rpc--file-notify-descriptors)
+        (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-callback-expands-relative-event-name ()
+  "Dispatched relative backend names become absolute TRAMP callback names."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (directory "/rpc:mock:/tmp/link/")
+         (events nil)
+         descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params)
+                     (when (equal method "watch.add")
+                       '((path . "/tmp/real/")))))
+                  ((symbol-function 'insert-special-event)
+                   (lambda (event)
+                     (funcall (lookup-key special-event-map [file-notify]) event))))
+          (setq descriptor
+                (tramp-rpc-handle-file-notify-add-watch directory '(change) #'ignore))
+          (puthash descriptor
+                   (file-notify--watch-make
+                    (file-name-unquote (directory-file-name directory))
+                    nil
+                    (lambda (event) (push event events)))
+                   file-notify-descriptors)
+          (tramp-rpc--file-notify-dispatch "changed" "/rpc:mock:/tmp/real/changed")
+          (should (equal events
+                         `((,descriptor changed "/rpc:mock:/tmp/link/changed")))))
+      (when descriptor
+        (remhash descriptor file-notify-descriptors)
         (remhash descriptor tramp-rpc--file-notify-descriptors)
         (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
 
@@ -1118,16 +1150,16 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (tramp-rpc--file-notify-dispatch "deleted" "/rpc:mock:/tmp/repo/new")
           (should (equal (nreverse events)
                          `((file-notify
-                            (,descriptor (created) "/rpc:mock:/tmp/repo/new")
+                            (,descriptor (created) "new")
                             file-notify-callback)
                            (file-notify
-                            (,descriptor (attribute-changed) "/rpc:mock:/tmp/repo/new")
+                            (,descriptor (attribute-changed) "new")
                             file-notify-callback)
                            (file-notify
-                            (,descriptor (moved) "/rpc:mock:/tmp/repo/old" "/rpc:mock:/tmp/repo/new")
+                            (,descriptor (moved) "old" "new")
                             file-notify-callback)
                            (file-notify
-                            (,descriptor (deleted) "/rpc:mock:/tmp/repo/new")
+                            (,descriptor (deleted) "new")
                             file-notify-callback)))))
       (when descriptor
         (remhash descriptor tramp-rpc--file-notify-descriptors)
@@ -1161,10 +1193,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (tramp-rpc--file-notify-dispatch "attribute-changed" "/rpc:mock:/tmp/repo/file")
           (should (equal (nreverse events)
                          `((file-notify
-                            (,change-descriptor (changed) "/rpc:mock:/tmp/repo/file")
+                            (,change-descriptor (changed) "file")
                             file-notify-callback)
                            (file-notify
-                            (,attribute-descriptor (attribute-changed) "/rpc:mock:/tmp/repo/file")
+                            (,attribute-descriptor (attribute-changed) "file")
                             file-notify-callback)))))
       (dolist (descriptor (list change-descriptor attribute-descriptor))
         (when descriptor


### PR DESCRIPTION
## Summary

- Dispatch TRAMP-RPC file-notify events in the backend-relative form expected by Emacs' file-notify handler, avoiding doubled `/rpc:...:/rpc:...` paths.
- Make file-notify descriptors more compatible with Emacs' remote tests and avoid hidden descriptor buffers that could trip global-auto-revert buffer iteration.
- Align delete/set-time edge cases with current Emacs behavior, including missing `delete-file` targets and `set-file-times` `nofollow`.
- Suppress duplicate rename notifications when inotify reports both paired and tracked rename events.

## Validation

- `emacs -Q --batch -L ~/src/tramp/lisp -L lisp -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-mock-test-file-notify")'`
- `emacs -Q --batch -L ~/src/tramp/lisp -L lisp -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-mock-test-delete-file-missing-is-noop")'`
- `cargo test -p tramp-rpc-server`
- Byte-compile `lisp/*.el` with `byte-compile-error-on-warn`
- Emacs remote `filenotify-tests`: 12 passed, 1 skipped
- `auto-revert-test05-global-notify-remote`: passed

## Notes

The local Emacs checkout used for validation has source/binary mismatch warnings, so compatibility shims were used for missing test helpers in the Emacs batch test commands. The remaining skipped filenotify test is `file-notify-test10-sufficient-resources-remote`.
