### PR TITLE
fix: run Eshell sudo through tramp-rpc

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -29,6 +29,11 @@
 (declare-function tramp-send-command-and-check "tramp-sh")
 (declare-function tramp-send-command-and-read "tramp-sh")
 
+;; Functions from tramp-rpc.el.  `tramp-rpc-deploy' is loaded by
+;; tramp-rpc.el after these helpers have been defined.
+(declare-function tramp-rpc--proxy-hop-string "tramp-rpc")
+(declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
+
 ;;; ============================================================================
 ;;; Customization
 ;;; ============================================================================
@@ -275,19 +280,32 @@ Methods like \"scp\" and \"rsync\" use out-of-band transfer for `copy-file',
 while \"ssh\" and \"sshx\" use inline encoding (base64 through the shell).
 Any \"rpc:\" hops in the hop chain are normalized to \"ssh:\" so that
 standard TRAMP can traverse them."
-  (let ((method (tramp-file-name-method vec)))
-    (if (member method '("ssh" "sshx" "scp" "scpx" "rsync"))
+  (let ((method (tramp-file-name-method vec))
+        (sudo-hop (and (fboundp 'tramp-rpc--sudo-rpc-hop-vec)
+                       (tramp-rpc--sudo-rpc-hop-vec vec))))
+    (if (and (not sudo-hop)
+             (member method '("ssh" "sshx" "scp" "scpx" "rsync")))
         vec  ; Already a TRAMP method that supports shell commands and file transfer
-      ;; Convert to bootstrap method - create a new tramp-file-name struct
+      ;; Convert to bootstrap method - create a new tramp-file-name struct.
+      ;; For /rpc:user@host|sudo:root@host: paths, deployment must still happen
+      ;; over the SSH user from the rpc hop.  The root RPC server is started via
+      ;; sudo later; using root here makes TRAMP try an unrelated scpx root
+      ;; login and fails before sudo authentication can help.
       (make-tramp-file-name
        :method tramp-rpc-deploy-bootstrap-method
-       :user (tramp-file-name-user vec)
+       :user (or (and sudo-hop
+                      (or (tramp-file-name-user sudo-hop) (user-login-name)))
+                 (tramp-file-name-user vec))
        :domain (tramp-file-name-domain vec)
        :host (tramp-file-name-host vec)
-       :port (tramp-file-name-port vec)
+       :port (if sudo-hop
+                 (tramp-file-name-port sudo-hop)
+               (tramp-file-name-port vec))
        :localname (tramp-file-name-localname vec)
        :hop (tramp-rpc-deploy--normalize-hops
-             (tramp-file-name-hop vec))))))
+             (if sudo-hop
+                 (tramp-rpc--proxy-hop-string vec)
+               (tramp-file-name-hop vec)))))))
 
 (defun tramp-rpc-deploy--detect-remote-arch (vec)
   "Detect the architecture of remote host specified by VEC.

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -388,26 +388,30 @@ before the cat relay drains its pipe causes a stale FD that makes
 
 (defun tramp-rpc--install-process-cleanup (process)
   "Add sentinel cleanup to PROCESS so it is deleted after exit.
-Uses `add-function' to append after whatever sentinel the caller has
-already installed (e.g. `vc-do-command' sets #\\='ignore then adds
-via `add-function').  When the sentinel fires for exit/signal, we
-schedule a deferred `delete-process' that removes the process from
-Emacs's `Vprocess_alist'.  Without this, `get-buffer-process' keeps
-returning the dead cat relay, which makes `vc-dir-busy' think an
+Wrap the caller's current sentinel and invoke it at event time before
+scheduling cleanup.  Keep symbol sentinels as symbols when calling them
+so dynamic rebinding, such as TRAMP's `shell-command-sentinel' test
+rebinding, is still honored.  Without cleanup, `get-buffer-process'
+keeps returning the dead cat relay, which makes `vc-dir-busy' think an
 update is still running."
   (when (process-live-p process)
-    (add-function :after (process-sentinel process)
-                  (lambda (proc _event)
-                    (when (memq (process-status proc) '(exit signal))
-                      ;; Defer the deletion so the full sentinel chain
-                      ;; (including vc-exec-after stages) completes first.
-                      (run-at-time 0 nil
-                                   (lambda ()
-                                     (when (and (processp proc)
-                                                (not (process-live-p proc)))
-                                       (remhash proc tramp-rpc--async-processes)
-                                       (ignore-errors
-                                         (delete-process proc))))))))))
+    (let ((sentinel (process-sentinel process)))
+      (unless (process-get process :tramp-rpc-cleanup-sentinel-installed)
+        (process-put process :tramp-rpc-cleanup-sentinel-installed t)
+        (set-process-sentinel
+         process
+         (lambda (proc event)
+           (when sentinel
+             (funcall sentinel proc event))
+           (when (memq (process-status proc) '(exit signal))
+             ;; Defer deletion so the full sentinel chain completes first.
+             (run-at-time 0 nil
+                          (lambda ()
+                            (when (and (processp proc)
+                                       (not (process-live-p proc)))
+                              (remhash proc tramp-rpc--async-processes)
+                              (ignore-errors
+                                (delete-process proc))))))))))))
 
 ;; ============================================================================
 ;; Coding helper

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -469,11 +469,19 @@ pair is a symbol."
 TRAMP's skeleton uses `or' when resolving `:connection-type', which would
 turn an explicit nil into the dynamic `process-connection-type'.  Native
 `make-process' treats explicit nil as a pipe, so pass `pipe' to the skeleton
-for that one case."
+for that one case.
+
+The skeleton also treats string `:stderr' as a remote stderr file.  Preserve
+tramp-rpc's existing compatibility behavior where non-remote strings name
+stderr buffers."
   (let ((args (copy-sequence args)))
     (when (and (plist-member args :connection-type)
                (null (plist-get args :connection-type)))
       (setq args (plist-put args :connection-type 'pipe)))
+    (when-let* ((stderr (plist-get args :stderr)))
+      (when (and (stringp stderr)
+                 (not (tramp-tramp-file-p stderr)))
+        (setq args (plist-put args :stderr (get-buffer-create stderr)))))
     args))
 
 (defun tramp-rpc-handle-make-process (&rest args)

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -58,6 +58,7 @@
 (declare-function tramp-rpc--tramp-remote-process-environment "tramp-rpc")
 (declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc--ssh-detail-user "tramp-rpc")
+(declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el
@@ -394,24 +395,33 @@ so dynamic rebinding, such as TRAMP's `shell-command-sentinel' test
 rebinding, is still honored.  Without cleanup, `get-buffer-process'
 keeps returning the dead cat relay, which makes `vc-dir-busy' think an
 update is still running."
-  (when (process-live-p process)
-    (let ((sentinel (process-sentinel process)))
-      (unless (process-get process :tramp-rpc-cleanup-sentinel-installed)
-        (process-put process :tramp-rpc-cleanup-sentinel-installed t)
-        (set-process-sentinel
-         process
-         (lambda (proc event)
-           (when sentinel
-             (funcall sentinel proc event))
-           (when (memq (process-status proc) '(exit signal))
-             ;; Defer deletion so the full sentinel chain completes first.
-             (run-at-time 0 nil
-                          (lambda ()
-                            (when (and (processp proc)
-                                       (not (process-live-p proc)))
-                              (remhash proc tramp-rpc--async-processes)
-                              (ignore-errors
-                                (delete-process proc))))))))))))
+  (cl-labels ((cleanup
+               (proc)
+               (run-at-time
+                0 nil
+                (lambda ()
+                  (when (processp proc)
+                    (remhash proc tramp-rpc--async-processes)
+                    (unless (process-live-p proc)
+                      (ignore-errors
+                        (delete-process proc))))))))
+    (cond
+     ((process-live-p process)
+      (let ((sentinel (process-sentinel process)))
+        (unless (process-get process :tramp-rpc-cleanup-sentinel-installed)
+          (process-put process :tramp-rpc-cleanup-sentinel-installed t)
+          (set-process-sentinel
+           process
+           (lambda (proc event)
+             (when sentinel
+               (funcall sentinel proc event))
+             (when (memq (process-status proc) '(exit signal))
+               ;; Defer deletion so the full sentinel chain completes first.
+               (cleanup proc)))))))
+     ((processp process)
+      ;; The relay can finish before the deferred installer runs.  Its original
+      ;; sentinel has already fired in that case, so just remove stale tracking.
+      (cleanup process)))))
 
 ;; ============================================================================
 ;; Coding helper
@@ -648,7 +658,11 @@ DIRENV-ENV is an optional alist of environment variables from direnv.
 When `tramp-rpc-use-direct-ssh-pty' is non-nil (the default), this uses
 a direct SSH connection for the PTY, providing much lower latency for
 interactive terminal use.  Otherwise, uses the RPC-based PTY implementation."
-  (if tramp-rpc-use-direct-ssh-pty
+  (if (and tramp-rpc-use-direct-ssh-pty
+           ;; Sudo-via-RPC paths must not use the final sudo vec for direct SSH,
+           ;; because that would attempt to SSH as root instead of using the rpc
+           ;; hop's identity and elevated RPC server.
+           (not (tramp-rpc--sudo-rpc-hop-vec vec)))
       ;; Use direct SSH for low-latency PTY
       (tramp-rpc--make-direct-ssh-pty-process
        vec name buffer command coding noquery filter sentinel localname direnv-env)

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -464,6 +464,18 @@ pair is a symbol."
 ;; make-process handler
 ;; ============================================================================
 
+(defun tramp-rpc--make-process-skeleton-args (args)
+  "Return ARGS adjusted for `tramp-skeleton-make-process'.
+TRAMP's skeleton uses `or' when resolving `:connection-type', which would
+turn an explicit nil into the dynamic `process-connection-type'.  Native
+`make-process' treats explicit nil as a pipe, so pass `pipe' to the skeleton
+for that one case."
+  (let ((args (copy-sequence args)))
+    (when (and (plist-member args :connection-type)
+               (null (plist-get args :connection-type)))
+      (setq args (plist-put args :connection-type 'pipe)))
+    args))
+
 (defun tramp-rpc-handle-make-process (&rest args)
   "Create an async process on the remote host.
 ARGS are keyword arguments as per `make-process'.
@@ -471,168 +483,142 @@ Supports PTY allocation when :connection-type is \='pty or t,
 or when `process-connection-type' is t.
 For pipe mode, uses async polling for long-running processes.
 Resolves program path and loads direnv environment from working directory."
-  (let* ((name (plist-get args :name))
-         (buffer-arg (plist-get args :buffer))
-         ;; tramp-handle-shell-command passes (output-buffer error-file)
-         ;; as the buffer argument for async commands with stderr.
-         ;; Extract the actual buffer from the list.
-         (buffer (if (consp buffer-arg) (car buffer-arg) buffer-arg))
-         (raw-command (plist-get args :command))
-         (sudo-command (and (car raw-command)
-                            (string= (file-name-nondirectory (car raw-command))
-                                     "sudo")))
-         ;; Check both :connection-type arg and process-connection-type variable.
-         ;; `:connection-type nil' explicitly requests a pipe, so use
-         ;; `plist-member' instead of `or' to preserve that nil value.
-         (connection-type (if (plist-member args :connection-type)
-                              (plist-get args :connection-type)
-                            (when (boundp 'process-connection-type)
-                              process-connection-type)))
-         ;; Determine if PTY is requested.  Only non-PTY literal sudo commands
-         ;; are wrapped for non-interactive stdin authentication; PTY sudo
-         ;; commands stay untouched so sudo can interact with the terminal
-         ;; normally.  For /rpc|sudo paths we follow
-         ;; TRAMP's sudo design and run inside the elevated RPC connection.
-         (use-pty (memq connection-type '(pty t)))
-         (pipe-sudo (and sudo-command (not use-pty)))
-         (command raw-command)
-         (sudo-password nil)
-         (coding (tramp-rpc--normalize-coding (plist-get args :coding)))
-         (noquery (plist-get args :noquery))
-         (filter (plist-get args :filter))
-         (sentinel (plist-get args :sentinel))
-         (stderr (plist-get args :stderr))
-         ;; file-handler is accepted but not used (we ARE the file handler)
-         (_file-handler (plist-get args :file-handler)))
-
-    ;; Ensure we're in a remote directory
-    (unless (tramp-tramp-file-p default-directory)
-      (signal
-       'remote-file-error
-       (list "tramp-rpc-handle-make-process called without remote default-directory")))
-
-    (with-parsed-tramp-file-name default-directory nil
+  (let ((args (tramp-rpc--make-process-skeleton-args args)))
+    ;; Reuse TRAMP's make-process skeleton for type checks, unique process names,
+    ;; buffer setup, stderr validation, and TRAMP file-name parsing.  The body
+    ;; below is only the RPC-specific process creation path.
+    (tramp-skeleton-make-process args nil t
       ;; Unquote localname in case of file-name-quoted paths (e.g. /: prefix).
       (setq localname (file-name-unquote localname))
-      ;; For non-PTY literal sudo commands, validate sudo in the same RPC pipe
-      ;; execution context that will run the command.  If a password is needed,
-      ;; use sudo's stdin wrapper; a separate PTY preauth can miss tty-scoped
-      ;; sudo timestamps and leave the pipe-mode command unauthenticated.
-      (when pipe-sudo
-        (let ((ssh-user (or (tramp-rpc--ssh-detail-user v) (user-login-name))))
-          (if (tramp-rpc--sudo-password-required-p v)
-              (setq sudo-password (tramp-rpc--sudo-read-password v ssh-user)
-                    ;; This RPC path invokes sudo directly, so unlike the SSH
-                    ;; server-start path the empty prompt argument is preserved.
-                    ;; Suppress prompt text so it does not pollute the async
-                    ;; process' stdout/stderr.
-                    command (append (list (car raw-command)
-                                          "-k" "-S" "-p" "")
-                                    (cdr raw-command)))
-            (setq command (append (list (car raw-command) "-n")
-                                  (cdr raw-command))))))
-      ;; Get the remote process environment: PATH from `tramp-remote-path'
-      ;; (or deprecated `tramp-rpc-remote-path'), direnv for this directory,
-      ;; INSIDE_EMACS, and caller-set env vars (e.g. GIT_INDEX_FILE from magit).
-      (let ((process-env (tramp-rpc--ensure-inside-emacs-env
-                          (tramp-rpc--merge-environments
-                           (tramp-rpc--remote-path-environment v)
-                           (tramp-rpc--tramp-remote-process-environment)
-                           (tramp-rpc--get-direnv-environment v localname)
-                           (tramp-rpc--caller-environment)))))
-        (if use-pty
-            ;; PTY mode - start async process with PTY.  Do not add -n or
-            ;; pre-authenticate here; sudo owns the terminal prompt.
-            (tramp-rpc--make-pty-process
-             v name buffer command coding noquery
-             filter sentinel localname process-env)
-          ;; Pipe mode - use a local cat process as relay for proper I/O events
-          ;; This is needed because accept-process-output waits for actual I/O,
-          ;; not just filter calls
-          ;; Leave relative PROGRAM names unresolved so the server's process
-          ;; launcher searches the PATH we pass in PROCESS-ENV.
-          (let* ((program (car command))
-                 (program-args (cdr command))
-                 (remote-pid (tramp-rpc--start-remote-process
-                              v program program-args localname process-env))
-                 ;; Use a local cat process as relay - we write output to its stdin
-                 ;; and it echoes to stdout, triggering proper I/O events
-                 (local-process (let ((process-connection-type nil)) ; Use pipes, not PTY
-                                  (start-process (or name "tramp-rpc-async")
-                                                 buffer
-                                                 "cat")))
-                 (stderr-buffer (cond
-                                 ((bufferp stderr) stderr)
-                                 ((stringp stderr) (get-buffer-create stderr))
-                                 (t nil)))
-                 ;; Create a stderr cat relay so that
-                 ;; (get-buffer-process stderr-buffer) returns a process,
-                 ;; matching the contract of native `make-process' with :stderr.
-                 (stderr-process
-                  (when stderr-buffer
-                    (let* ((process-connection-type nil)
-                           (proc (start-process
-                                  (format "%s-stderr" (or name "tramp-rpc-async"))
-                                  stderr-buffer
-                                  "cat")))
-                      (set-process-query-on-exit-flag proc nil)
-                      proc))))
+      (let* ((sudo-command (and (car command)
+                                (string= (file-name-nondirectory (car command))
+                                         "sudo")))
+             ;; The skeleton normalizes t to `pty'.  `pipe' and nil are both
+             ;; non-PTY from the RPC process launcher's perspective.
+             (use-pty (eq connection-type 'pty))
+             (pipe-sudo (and sudo-command (not use-pty)))
+             (sudo-password nil)
+             (coding (tramp-rpc--normalize-coding coding)))
+        ;; For non-PTY literal sudo commands, validate sudo in the same RPC pipe
+        ;; execution context that will run the command.  If a password is needed,
+        ;; use sudo's stdin wrapper; a separate PTY preauth can miss tty-scoped
+        ;; sudo timestamps and leave the pipe-mode command unauthenticated.
+        (when pipe-sudo
+          (let ((ssh-user (or (tramp-rpc--ssh-detail-user v) (user-login-name))))
+            (if (tramp-rpc--sudo-password-required-p v)
+                (setq sudo-password (tramp-rpc--sudo-read-password v ssh-user)
+                      ;; This RPC path invokes sudo directly, so unlike the SSH
+                      ;; server-start path the empty prompt argument is preserved.
+                      ;; Suppress prompt text so it does not pollute the async
+                      ;; process' stdout/stderr.
+                      command (append (list (car command) "-k" "-S" "-p" "")
+                                      (cdr command)))
+              (setq command (append (list (car command) "-n")
+                                    (cdr command))))))
+        ;; Get the remote process environment: PATH from `tramp-remote-path'
+        ;; (or deprecated `tramp-rpc-remote-path'), direnv for this directory,
+        ;; INSIDE_EMACS, and caller-set env vars (e.g. GIT_INDEX_FILE from magit).
+        (let ((process-env (tramp-rpc--ensure-inside-emacs-env
+                            (tramp-rpc--merge-environments
+                             (tramp-rpc--remote-path-environment v)
+                             (tramp-rpc--tramp-remote-process-environment)
+                             (tramp-rpc--get-direnv-environment v localname)
+                             (tramp-rpc--caller-environment)))))
+          (if use-pty
+              ;; PTY mode - start async process with PTY.  Do not add -n or
+              ;; pre-authenticate here; sudo owns the terminal prompt.
+              (tramp-rpc--make-pty-process
+               v name buffer command coding noquery
+               filter sentinel localname process-env)
+            ;; Pipe mode - use a local cat process as relay for proper I/O events.
+            ;; This is needed because accept-process-output waits for actual I/O,
+            ;; not just filter calls.  Leave relative PROGRAM names unresolved so
+            ;; the server's process launcher searches the PATH we pass in
+            ;; PROCESS-ENV.
+            (let* ((program (car command))
+                   (program-args (cdr command))
+                   (remote-pid (tramp-rpc--start-remote-process
+                                v program program-args localname process-env))
+                   ;; Use a local cat process as relay: we write output to its
+                   ;; stdin and it echoes to stdout, triggering proper I/O events.
+                   (local-process (let ((process-connection-type nil))
+                                    (start-process (or name "tramp-rpc-async")
+                                                   buffer
+                                                   "cat")))
+                   (stderr-buffer (cond
+                                   ((bufferp stderr) stderr)
+                                   ((stringp stderr) (get-buffer-create stderr))
+                                   (t nil)))
+                   ;; Create a stderr cat relay so that
+                   ;; (get-buffer-process stderr-buffer) returns a process,
+                   ;; matching the contract of native `make-process' with :stderr.
+                   (stderr-process
+                    (when stderr-buffer
+                      (let* ((process-connection-type nil)
+                             (proc (start-process
+                                    (format "%s-stderr" (or name "tramp-rpc-async"))
+                                    stderr-buffer
+                                    "cat")))
+                        (set-process-query-on-exit-flag proc nil)
+                        proc))))
 
-          ;; Feed sudo's stdin password before exposing the relay to callers;
-          ;; subsequent writes use the same queue and stay ordered after it.
-          (when sudo-password
-            (tramp-rpc--write-remote-process
-             v remote-pid (concat sudo-password "\n")))
+              ;; Feed sudo's stdin password before exposing the relay to callers;
+              ;; subsequent writes use the same queue and stay ordered after it.
+              (when sudo-password
+                (tramp-rpc--write-remote-process
+                 v remote-pid (concat sudo-password "\n")))
 
-          ;; Configure the local relay process
-          (when coding
-            (apply #'set-process-coding-system local-process
-                   (tramp-rpc--coding-args coding)))
-          (set-process-query-on-exit-flag local-process (not noquery))
+              ;; Configure the local relay process.
+              (when coding
+                (apply #'set-process-coding-system local-process
+                       (tramp-rpc--coding-args coding)))
+              (set-process-query-on-exit-flag local-process (not noquery))
 
-          (process-put local-process :tramp-rpc-vec v)
-          (process-put local-process :tramp-rpc-pid remote-pid)
-          (process-put local-process 'tramp-vector v)
-          (process-put local-process 'remote-command command)
+              (process-put local-process :tramp-rpc-vec v)
+              (process-put local-process :tramp-rpc-pid remote-pid)
+              (process-put local-process 'tramp-vector v)
+              (process-put local-process 'remote-command orig-command)
 
-          (when filter
-            (set-process-filter local-process filter))
-          (when sentinel
-            ;; Wrap sentinel to handle our cleanup
-            (set-process-sentinel local-process
-                                  (lambda (proc event)
-                                    (tramp-rpc--pipe-process-sentinel proc event sentinel))))
+              (when filter
+                (set-process-filter local-process filter))
+              (when sentinel
+                ;; Wrap sentinel to handle our cleanup.
+                (set-process-sentinel
+                 local-process
+                 (lambda (proc event)
+                   (tramp-rpc--pipe-process-sentinel proc event sentinel))))
 
-          ;; Store process info
-          (puthash local-process
-                   (list :vec v
-                         :pid remote-pid
-                         :stderr-buffer stderr-buffer
-                         :stderr-process stderr-process)
-                   tramp-rpc--async-processes)
+              ;; Store process info.
+              (puthash local-process
+                       (list :vec v
+                             :pid remote-pid
+                             :stderr-buffer stderr-buffer
+                             :stderr-process stderr-process)
+                       tramp-rpc--async-processes)
 
-          (tramp-rpc--debug "MAKE-PROCESS created local=%s remote-pid=%s program=%s"
-                           local-process remote-pid program)
+              (tramp-rpc--debug
+               "MAKE-PROCESS created local=%s remote-pid=%s program=%s"
+               local-process remote-pid program)
 
-          ;; Start async read loop
-          (tramp-rpc--start-async-read local-process)
+              ;; Start async read loop.
+              (tramp-rpc--start-async-read local-process)
 
-          ;; Schedule deferred sentinel cleanup.  Callers like `vc-do-command'
-          ;; replace the sentinel with `set-process-sentinel' AFTER
-          ;; `start-file-process' returns, so we must add our cleanup wrapper
-          ;; after that.  `run-at-time 0' ensures it runs once the current
-          ;; code path (including the caller's sentinel setup) completes.
-          ;; The wrapper calls `delete-process' after the sentinel chain
-          ;; finishes, which removes the process from `Vprocess_alist'.
-          ;; Without this, `get-buffer-process' returns stale exited cat
-          ;; relays, causing e.g. `vc-dir-busy' to report a false positive.
-          (let ((proc local-process))
-            (run-at-time 0 nil
-                         (lambda ()
-                           (when (processp proc)
-                             (tramp-rpc--install-process-cleanup proc)))))
+              ;; Schedule deferred sentinel cleanup.  Callers like `vc-do-command'
+              ;; replace the sentinel with `set-process-sentinel' AFTER
+              ;; `start-file-process' returns, so we must add our cleanup wrapper
+              ;; after that.  `run-at-time 0' ensures it runs once the current
+              ;; code path (including the caller's sentinel setup) completes.
+              ;; The wrapper calls `delete-process' after the sentinel chain
+              ;; finishes, which removes the process from `Vprocess_alist'.
+              ;; Without this, `get-buffer-process' returns stale exited cat
+              ;; relays, causing e.g. `vc-dir-busy' to report a false positive.
+              (let ((proc local-process))
+                (run-at-time 0 nil
+                             (lambda ()
+                               (when (processp proc)
+                                 (tramp-rpc--install-process-cleanup proc)))))
 
-          local-process))))))
+              local-process)))))))
 
 (defun tramp-rpc-handle-start-file-process (name buffer program &rest args)
   "Start async process on remote host.

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -33,6 +33,8 @@
 ;; Functions from tramp.el
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
+(declare-function tramp-rpc--sudo-password-required-p "tramp-rpc")
+(declare-function tramp-rpc--sudo-read-password "tramp-rpc")
 
 ;; Silence byte-compiler warnings for variables defined in vterm
 (defvar vterm-copy-mode)
@@ -55,6 +57,7 @@
 (declare-function tramp-rpc--remote-path-environment "tramp-rpc")
 (declare-function tramp-rpc--tramp-remote-process-environment "tramp-rpc")
 (declare-function tramp-rpc--caller-environment "tramp-rpc")
+(declare-function tramp-rpc--ssh-detail-user "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el
@@ -450,7 +453,7 @@ pair is a symbol."
 (defun tramp-rpc-handle-make-process (&rest args)
   "Create an async process on the remote host.
 ARGS are keyword arguments as per `make-process'.
-Supports PTY allocation when :connection-type is \\='pty or t,
+Supports PTY allocation when :connection-type is \='pty or t,
 or when `process-connection-type' is t.
 For pipe mode, uses async polling for long-running processes.
 Resolves program path and loads direnv environment from working directory."
@@ -460,22 +463,33 @@ Resolves program path and loads direnv environment from working directory."
          ;; as the buffer argument for async commands with stderr.
          ;; Extract the actual buffer from the list.
          (buffer (if (consp buffer-arg) (car buffer-arg) buffer-arg))
-         (command (plist-get args :command))
+         (raw-command (plist-get args :command))
+         (sudo-command (and (car raw-command)
+                            (string= (file-name-nondirectory (car raw-command))
+                                     "sudo")))
+         ;; Check both :connection-type arg and process-connection-type variable.
+         ;; `:connection-type nil' explicitly requests a pipe, so use
+         ;; `plist-member' instead of `or' to preserve that nil value.
+         (connection-type (if (plist-member args :connection-type)
+                              (plist-get args :connection-type)
+                            (when (boundp 'process-connection-type)
+                              process-connection-type)))
+         ;; Determine if PTY is requested.  Only non-PTY literal sudo commands
+         ;; are wrapped for non-interactive stdin authentication; PTY sudo
+         ;; commands stay untouched so sudo can interact with the terminal
+         ;; normally.  For /rpc|sudo paths we follow
+         ;; TRAMP's sudo design and run inside the elevated RPC connection.
+         (use-pty (memq connection-type '(pty t)))
+         (pipe-sudo (and sudo-command (not use-pty)))
+         (command raw-command)
+         (sudo-password nil)
          (coding (tramp-rpc--normalize-coding (plist-get args :coding)))
          (noquery (plist-get args :noquery))
          (filter (plist-get args :filter))
          (sentinel (plist-get args :sentinel))
          (stderr (plist-get args :stderr))
          ;; file-handler is accepted but not used (we ARE the file handler)
-         (_file-handler (plist-get args :file-handler))
-         ;; Check both :connection-type arg and process-connection-type variable
-         (connection-type (or (plist-get args :connection-type)
-                              (when (boundp 'process-connection-type)
-                                process-connection-type)))
-         (program (car command))
-         (program-args (cdr command))
-         ;; Determine if PTY is requested
-         (use-pty (memq connection-type '(pty t))))
+         (_file-handler (plist-get args :file-handler)))
 
     ;; Ensure we're in a remote directory
     (unless (tramp-tramp-file-p default-directory)
@@ -486,6 +500,23 @@ Resolves program path and loads direnv environment from working directory."
     (with-parsed-tramp-file-name default-directory nil
       ;; Unquote localname in case of file-name-quoted paths (e.g. /: prefix).
       (setq localname (file-name-unquote localname))
+      ;; For non-PTY literal sudo commands, validate sudo in the same RPC pipe
+      ;; execution context that will run the command.  If a password is needed,
+      ;; use sudo's stdin wrapper; a separate PTY preauth can miss tty-scoped
+      ;; sudo timestamps and leave the pipe-mode command unauthenticated.
+      (when pipe-sudo
+        (let ((ssh-user (or (tramp-rpc--ssh-detail-user v) (user-login-name))))
+          (if (tramp-rpc--sudo-password-required-p v)
+              (setq sudo-password (tramp-rpc--sudo-read-password v ssh-user)
+                    ;; This RPC path invokes sudo directly, so unlike the SSH
+                    ;; server-start path the empty prompt argument is preserved.
+                    ;; Suppress prompt text so it does not pollute the async
+                    ;; process' stdout/stderr.
+                    command (append (list (car raw-command)
+                                          "-k" "-S" "-p" "")
+                                    (cdr raw-command)))
+            (setq command (append (list (car raw-command) "-n")
+                                  (cdr raw-command))))))
       ;; Get the remote process environment: PATH from `tramp-remote-path'
       ;; (or deprecated `tramp-rpc-remote-path'), direnv for this directory,
       ;; INSIDE_EMACS, and caller-set env vars (e.g. GIT_INDEX_FILE from magit).
@@ -496,15 +527,19 @@ Resolves program path and loads direnv environment from working directory."
                            (tramp-rpc--get-direnv-environment v localname)
                            (tramp-rpc--caller-environment)))))
         (if use-pty
-            ;; PTY mode - start async process with PTY
-            (tramp-rpc--make-pty-process v name buffer command coding noquery
-                                          filter sentinel localname process-env)
+            ;; PTY mode - start async process with PTY.  Do not add -n or
+            ;; pre-authenticate here; sudo owns the terminal prompt.
+            (tramp-rpc--make-pty-process
+             v name buffer command coding noquery
+             filter sentinel localname process-env)
           ;; Pipe mode - use a local cat process as relay for proper I/O events
           ;; This is needed because accept-process-output waits for actual I/O,
           ;; not just filter calls
           ;; Leave relative PROGRAM names unresolved so the server's process
           ;; launcher searches the PATH we pass in PROCESS-ENV.
-          (let* ((remote-pid (tramp-rpc--start-remote-process
+          (let* ((program (car command))
+                 (program-args (cdr command))
+                 (remote-pid (tramp-rpc--start-remote-process
                               v program program-args localname process-env))
                  ;; Use a local cat process as relay - we write output to its stdin
                  ;; and it echoes to stdout, triggering proper I/O events
@@ -528,6 +563,12 @@ Resolves program path and loads direnv environment from working directory."
                                   "cat")))
                       (set-process-query-on-exit-flag proc nil)
                       proc))))
+
+          ;; Feed sudo's stdin password before exposing the relay to callers;
+          ;; subsequent writes use the same queue and stay ordered after it.
+          (when sudo-password
+            (tramp-rpc--write-remote-process
+             v remote-pid (concat sudo-password "\n")))
 
           ;; Configure the local relay process
           (when coding

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -107,6 +107,9 @@
   ;; the predicate to decide which handler to use, and if it were an
   ;; autoload stub it would load tramp-rpc.el which `(require 'tramp)'.
   ;; Reference TRAMP uses the same pattern (defsubst in tramp-loaddefs.el).
+  (defvar tramp-rpc--sudo-file-name-p-in-progress nil
+    "Non-nil while checking hidden rpc+sudo proxy expansion.")
+
   (defsubst tramp-rpc-file-name-p (vec-or-filename)
     "Check if VEC-OR-FILENAME is handled by TRAMP-RPC."
     (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename)))
@@ -118,11 +121,50 @@
   (defsubst tramp-rpc--sudo-file-name-p (vec-or-filename)
     "Check if VEC-OR-FILENAME is a privilege elevation with an rpc hop."
     (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename))
-                (hop (tramp-file-name-hop vec)))
-      (and (string= (tramp-file-name-method (tramp-dissect-hop-name hop))
-		    tramp-rpc-method)
-           (member (tramp-file-name-method vec)
-                   '("sudo" "su" "doas" "sg" "run0" "ksu")))))
+                (target-host (tramp-file-name-host vec)))
+      (and
+       (not tramp-rpc--sudo-file-name-p-in-progress)
+       (string= (tramp-file-name-method vec) "sudo")
+       (tramp-get-method-parameter vec 'tramp-password-previous-hop)
+       (or
+        ;; Explicit ad-hoc hop syntax, as produced by `em-tramp' for Eshell:
+        ;; /rpc:user@host|sudo:root@host:/path.
+        (when-let* ((hop (tramp-file-name-hop vec))
+                    (last-hop (car (last (split-string
+                                          hop tramp-postfix-hop-regexp
+                                          'omit))))
+                    (hop-vec (tramp-dissect-hop-name
+                              (concat last-hop tramp-postfix-hop-format)
+                              'nodefault)))
+          (and (string= (tramp-file-name-method hop-vec) tramp-rpc-method)
+               (string= (tramp-file-name-host hop-vec) target-host)))
+        ;; Native TRAMP helpers such as `tramp-file-name-with-sudo' often hide
+        ;; ad-hoc hops in `tramp-default-proxies-alist'.  Ask TRAMP to expand
+        ;; them and inspect the immediate hop before the sudo target.  Hide this
+        ;; predicate while expanding; `tramp-compute-multi-hops' itself asks
+        ;; `tramp-find-foreign-file-name-handler', which would otherwise recurse.
+        ;; Bind `tramp-verbose' to zero: probing a non-matching hidden proxy is
+        ;; not user-visible connection work and should not emit host-mismatch
+        ;; messages.
+        (unless (tramp-file-name-hop vec)
+          (condition-case nil
+              (let ((tramp-rpc--sudo-file-name-p-in-progress t)
+                    (tramp-verbose 0)
+                    (tramp-foreign-file-name-handler-alist
+                     (delq nil
+                           (mapcar
+                            (lambda (entry)
+                              (unless (eq (car entry)
+                                          'tramp-rpc--sudo-file-name-p)
+                                entry))
+                            tramp-foreign-file-name-handler-alist))))
+                (when-let* ((chain (tramp-compute-multi-hops vec))
+                            (previous-hop (car (last (butlast chain)))))
+                  (and (string= (tramp-file-name-method previous-hop)
+                                tramp-rpc-method)
+                       (string= (tramp-file-name-host previous-hop)
+                                target-host))))
+            (error nil)))))))
 
   ;; Register the foreign handler directly in the alist.  We cannot use
   ;; `tramp-register-foreign-file-name-handler' here because it tries to
@@ -146,12 +188,21 @@
     "Allow the rpc method and rpc+sudo paths in multi-hop chains.
 This is called from `tramp-multi-hop-p-hook'."
     (or (string= (tramp-file-name-method vec) tramp-rpc-method)
-        ;; Also allow privilege elevation methods when the hop contains rpc
-        (when-let* ((hop (tramp-file-name-hop vec)))
-          (and (string= (tramp-file-name-method (tramp-dissect-hop-name hop))
-			tramp-rpc-method)
-               (member (tramp-file-name-method vec)
-                       '("sudo" "su" "doas" "sg" "run0" "ksu"))))))
+        ;; Also allow previous-hop privilege methods when their final hop is rpc.
+        ;; Keep this check explicit-only: `tramp-compute-multi-hops' calls this
+        ;; hook, so consulting hidden proxy expansion here would recurse.
+        (when-let* ((hop (tramp-file-name-hop vec))
+                    (last-hop (car (last (split-string
+                                          hop tramp-postfix-hop-regexp
+                                          'omit))))
+                    (target-host (tramp-file-name-host vec))
+                    (hop-vec (tramp-dissect-hop-name
+                              (concat last-hop tramp-postfix-hop-format)
+                              'nodefault)))
+          (and (string= (tramp-file-name-method vec) "sudo")
+               (tramp-get-method-parameter vec 'tramp-password-previous-hop)
+               (string= (tramp-file-name-method hop-vec) tramp-rpc-method)
+               (string= (tramp-file-name-host hop-vec) target-host)))))
   (add-hook 'tramp-multi-hop-p-hook #'tramp-rpc-multi-hop-p)))
 
 ;; Now the actual implementation
@@ -184,48 +235,234 @@ This is called from `tramp-multi-hop-p-hook'."
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
 
+(defvar tramp-rpc--sudo-file-name-p-in-progress nil
+  "Non-nil while checking hidden rpc+sudo proxy expansion.")
+
 ;; ============================================================================
 ;; Sudo-via-RPC: detect privilege elevation from hop chains
 ;; ============================================================================
 
+(defun tramp-rpc--privilege-elevation-vec-p (vec)
+  "Return non-nil when VEC is TRAMP's sudo previous-hop method.
+Other TRAMP previous-hop privilege methods, such as doas, are not
+supported here because tramp-rpc starts elevated backends with sudo."
+  (and (string= (tramp-file-name-method vec) "sudo")
+       (tramp-get-method-parameter vec 'tramp-password-previous-hop)))
+
+(defun tramp-rpc--hop-string-without-postfix (hop-string)
+  "Return HOP-STRING without its trailing hop delimiter."
+  (if (string-suffix-p tramp-postfix-hop-format hop-string)
+      (substring hop-string 0 (- (length tramp-postfix-hop-format)))
+    hop-string))
+
+(defun tramp-rpc--hop-vec-to-string (hop-vec)
+  "Return HOP-VEC as an ad-hoc hop string without trailing delimiter."
+  (tramp-rpc--hop-string-without-postfix
+   (tramp-make-tramp-hop-name
+    (make-tramp-file-name
+     :method (tramp-file-name-method hop-vec)
+     :user (tramp-file-name-user hop-vec)
+     :domain (tramp-file-name-domain hop-vec)
+     :host (tramp-file-name-host hop-vec)
+     :port (tramp-file-name-port hop-vec)))))
+
+(defun tramp-rpc--explicit-hop-pairs (vec)
+  "Return explicit ad-hoc hops of VEC as (HOP-STRING . HOP-VEC) pairs."
+  (when-let* ((hop (tramp-file-name-hop vec)))
+    (mapcar
+     (lambda (hop-str)
+       (cons hop-str
+             (tramp-dissect-hop-name
+              (concat hop-str tramp-postfix-hop-format) 'nodefault)))
+     (split-string hop tramp-postfix-hop-regexp 'omit))))
+
+(defun tramp-rpc--hidden-sudo-proxy-handler-alist ()
+  "Return foreign handler alist without the tramp-rpc sudo predicate.
+`tramp-compute-multi-hops' asks TRAMP which handler owns the target; if the
+sudo predicate remains registered while it is expanding hidden ad-hoc proxies,
+it can re-enter `tramp-rpc--sudo-file-name-p'."
+  (cl-remove-if
+   (lambda (entry) (eq (car entry) 'tramp-rpc--sudo-file-name-p))
+   tramp-foreign-file-name-handler-alist))
+
+(defun tramp-rpc--computed-hop-pairs (vec)
+  "Return hidden TRAMP proxy hops of VEC as (HOP-STRING . HOP-VEC) pairs.
+Native TRAMP helpers, including `tramp-file-name-with-sudo', can store
+ad-hoc hops in `tramp-default-proxies-alist' instead of VEC's hop slot."
+  (when (and (tramp-rpc--privilege-elevation-vec-p vec)
+             (not tramp-rpc--sudo-file-name-p-in-progress))
+    (condition-case nil
+        (let ((tramp-rpc--sudo-file-name-p-in-progress t)
+              (tramp-verbose 0)
+              (tramp-foreign-file-name-handler-alist
+               (tramp-rpc--hidden-sudo-proxy-handler-alist)))
+          (mapcar
+           (lambda (hop-vec)
+             (cons (tramp-rpc--hop-vec-to-string hop-vec) hop-vec))
+           (butlast (tramp-compute-multi-hops vec))))
+      (error nil))))
+
+(defun tramp-rpc--hop-pairs (vec)
+  "Return VEC's explicit or hidden proxy hops as pairs.
+Explicit hops are preferred because they preserve the exact user spelling
+from the filename.  Hidden proxy expansion is used for native TRAMP sudo
+helpers which record ad-hoc hops in `tramp-default-proxies-alist'."
+  (or (tramp-rpc--explicit-hop-pairs vec)
+      (tramp-rpc--computed-hop-pairs vec)))
+
+(defun tramp-rpc--hop-component-string (value)
+  "Return tramp hop component VALUE as a comparison string."
+  (cond ((null value) "")
+        ((stringp value) (substring-no-properties value))
+        (t (format "%s" value))))
+
+(defun tramp-rpc--same-hop-p (a b)
+  "Return non-nil when tramp vecs A and B denote the same hop."
+  (and (string= (tramp-rpc--hop-component-string
+                 (tramp-file-name-method a))
+                (tramp-rpc--hop-component-string
+                 (tramp-file-name-method b)))
+       (string= (tramp-rpc--hop-component-string
+                 (tramp-file-name-user a))
+                (tramp-rpc--hop-component-string
+                 (tramp-file-name-user b)))
+       (string= (tramp-rpc--hop-component-string
+                 (tramp-file-name-domain a))
+                (tramp-rpc--hop-component-string
+                 (tramp-file-name-domain b)))
+       (string= (tramp-rpc--hop-component-string
+                 (tramp-file-name-host a))
+                (tramp-rpc--hop-component-string
+                 (tramp-file-name-host b)))
+       (string= (tramp-rpc--hop-component-string
+                 (tramp-file-name-port a))
+                (tramp-rpc--hop-component-string
+                 (tramp-file-name-port b)))))
+
+(defun tramp-rpc--same-host-rpc-hop (vec &optional return-string)
+  "Return VEC's matching same-host rpc hop for privilege elevation.
+When RETURN-STRING is non-nil, return (HOP-STRING . HOP-VEC).  Return
+nil for non-privilege targets, so same-host rpc|rpc chains are not
+misclassified as sudo-via-RPC."
+  (when-let* ((target-host (tramp-file-name-host vec)))
+    (when (tramp-rpc--privilege-elevation-vec-p vec)
+      (when-let* ((hop (car (last (tramp-rpc--hop-pairs vec))))
+                  (hop-vec (cdr hop)))
+        ;; Only the final hop before the privilege-elevation method carries the
+        ;; SSH connection details for that sudo target.  Earlier same-host rpc
+        ;; hops are still real proxy hops and must not be stripped.
+        (when (and (string= (tramp-file-name-method hop-vec) "rpc")
+                   (string= (tramp-file-name-host hop-vec) target-host))
+          (if return-string hop hop-vec))))))
+
+(defun tramp-rpc--sudo-rpc-hop-vec (vec)
+  "Return VEC's same-host rpc hop vec for sudo-via-RPC, or nil."
+  (tramp-rpc--same-host-rpc-hop vec))
+
 (defun tramp-rpc--detect-sudo-elevation (vec)
   "Return the SSH user if VEC needs sudo elevation via RPC, or nil.
-Detects when the hop chain has an rpc hop to the same host as the
-target but with a different user, indicating privilege elevation.
-For /rpc:user@host|sudo:root@host:/path, returns \"user\"."
-  (when-let* ((hop (tramp-file-name-hop vec))
-              (target-host (tramp-file-name-host vec)))
-    (let ((hops (split-string hop tramp-postfix-hop-regexp 'omit))
-          result)
-      ;; Walk hops in reverse (closest to target first) looking for
-      ;; an rpc hop to the same host.
-      (dolist (hop-str (reverse hops))
-        (unless result
-          (let* ((hop-name (concat tramp-prefix-format hop-str
-                                   tramp-postfix-host-format))
-                 (hop-vec (tramp-dissect-file-name hop-name 'nodefault)))
-            (when (and (string= (tramp-file-name-method hop-vec) "rpc")
-                       (string= (tramp-file-name-host hop-vec) target-host))
-              (setq result (or (tramp-file-name-user hop-vec)
-                               (user-login-name)))))))
-      result)))
+Detects privilege-elevation targets such as
+/rpc:user@host|sudo:root@host:/path.  Same-host rpc|rpc chains are not
+sudo elevation and return nil."
+  (when-let* ((hop-vec (tramp-rpc--sudo-rpc-hop-vec vec)))
+    (or (tramp-file-name-user hop-vec) (user-login-name))))
+
+(defun tramp-rpc--ssh-detail-vec (vec)
+  "Return the vec carrying SSH connection details for VEC.
+For sudo-via-RPC this is the matching same-host rpc hop.  Otherwise it
+is VEC itself."
+  (or (tramp-rpc--sudo-rpc-hop-vec vec) vec))
+
+(defun tramp-rpc--ssh-detail-user (vec &optional default)
+  "Return the SSH user for VEC, using sudo-via-RPC hop details."
+  (or (tramp-file-name-user (tramp-rpc--ssh-detail-vec vec)) default))
+
+(defun tramp-rpc--ssh-detail-port (vec)
+  "Return the SSH port for VEC, using sudo-via-RPC hop details."
+  (tramp-file-name-port (tramp-rpc--ssh-detail-vec vec)))
+
+(declare-function tramp-read-passwd "tramp")
+
+(defun tramp-rpc--sudo-auth-vec (vec)
+  "Return the unprivileged rpc vector used to validate sudo for VEC."
+  (when-let* ((sudo-hop (tramp-rpc--sudo-rpc-hop-vec vec)))
+    (make-tramp-file-name
+     :method tramp-rpc-method
+     :user (or (tramp-file-name-user sudo-hop) (user-login-name))
+     :domain (tramp-file-name-domain sudo-hop)
+     :host (tramp-file-name-host sudo-hop)
+     :port (tramp-file-name-port sudo-hop)
+     :localname (tramp-file-name-localname vec)
+     :hop (tramp-rpc--proxy-hop-string vec))))
+
+(defun tramp-rpc--sudo-password-required-p (vec)
+  "Return non-nil when sudo on VEC needs a password for non-PTY use."
+  (let* ((auth-vec (or (tramp-rpc--sudo-auth-vec vec) vec))
+         (result (tramp-rpc--call auth-vec "process.run"
+                                  '((cmd . "sudo")
+                                    (args . ["-n" "-v"])
+                                    (cwd . "/"))))
+         (exit-code (alist-get 'exit_code result)))
+    (not (eq exit-code 0))))
+
+(defun tramp-rpc--password-string (password)
+  "Return PASSWORD as a string, unwrapping auth-source cache entries.
+Some Emacs/auth-source combinations can hand `password-read' callers a
+cached auth-source plist whose `:secret' is a function.  Normalize that
+shape before passing the value to `sudo -S'."
+  (while (and (listp password) (plist-member password :secret))
+    (setq password (plist-get password :secret)))
+  (while (functionp password)
+    (setq password (funcall password))
+    (while (and (listp password) (plist-member password :secret))
+      (setq password (plist-get password :secret))))
+  (unless (stringp password)
+    (error "sudo password is not a string: %S" password))
+  password)
+
+(defun tramp-rpc--sudo-read-password (vec ssh-user)
+  "Read sudo password for SSH-USER on VEC using TRAMP auth machinery."
+  (let* ((host (tramp-file-name-host vec))
+         (raw-port (tramp-rpc--ssh-detail-port vec))
+         (port (cond ((stringp raw-port) raw-port)
+                     ((numberp raw-port) (number-to-string raw-port))))
+         (buffer (get-buffer-create " *tramp-rpc-sudo-password*"))
+         (process (make-pipe-process
+                   :name "tramp-rpc-sudo-password"
+                   :buffer buffer
+                   :noquery t)))
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            (erase-buffer)
+            (insert "Password:"))
+          (process-put process 'tramp-vector vec)
+          (tramp-set-connection-property process "hop-vector" vec)
+          (tramp-set-connection-property
+           process "pw-vector"
+           (make-tramp-file-name
+            :method "sudo" :user ssh-user :host host :port port))
+          (tramp-rpc--password-string
+           (tramp-read-passwd
+            process
+            (format "Password for /sudo:%s%s: "
+                    (if ssh-user (concat ssh-user "@") "") host))))
+      (when (process-live-p process)
+        (delete-process process)))))
 
 (defun tramp-rpc--proxy-hop-string (vec)
-  "Return VEC's hop string with same-host sudo hops removed.
+  "Return VEC's hop string with its sudo rpc hop removed.
 For /rpc:gw|rpc:user@host|sudo:root@host:/path, returns \"rpc:gw|\".
-Returns nil if no proxy hops remain."
-  (when-let* ((hop (tramp-file-name-hop vec))
-              (target-host (tramp-file-name-host vec)))
-    (let ((hops (split-string hop tramp-postfix-hop-regexp 'omit))
-          proxy-hops)
-      (dolist (hop-str hops)
-        (let* ((hop-name (concat tramp-prefix-format hop-str
-                                 tramp-postfix-host-format))
-               (hop-vec (tramp-dissect-file-name hop-name 'nodefault)))
-          ;; Keep hops that are genuine proxies (different host)
-          (unless (and (string= (tramp-file-name-method hop-vec) "rpc")
-                       (string= (tramp-file-name-host hop-vec) target-host))
-            (push hop-str proxy-hops))))
+For non-sudo paths, returns the original hop string.  Returns nil if no
+proxy hops remain."
+  (when-let* ((hop-pairs (tramp-rpc--hop-pairs vec)))
+    (let ((sudo-hop (tramp-rpc--same-host-rpc-hop vec 'return-string))
+          (proxy-hops nil))
+      (dolist (hop hop-pairs)
+        ;; Drop only the rpc hop that represents privilege elevation.
+        ;; Same-host rpc|rpc chains are real hops and must be preserved.
+        (unless (and sudo-hop (tramp-rpc--same-hop-p (cdr hop) (cdr sudo-hop)))
+          (push (car hop) proxy-hops)))
       (when proxy-hops
         (concat (mapconcat #'identity (nreverse proxy-hops)
                            tramp-postfix-hop-format)
@@ -443,8 +680,10 @@ FORCE-UNCOMPRESSED is non-nil."
 ;; ============================================================================
 
 (defvar tramp-rpc--connections (make-hash-table :test 'equal)
-  "Hash table mapping connection keys to RPC process info.
-Key is (host user port hop), value is a plist with :process and :buffer.")
+  "Hash table mapping normalized connection keys to RPC process info.
+Keys include target method/user/host/port plus the effective route (explicit
+or hidden TRAMP ad-hoc proxy hops).  Values are plists with :process, :buffer,
+and optional :stderr-buffer.")
 
 ;; tramp-rpc--async-processes and tramp-rpc--pty-processes are defined in
 ;; tramp-rpc-process.el (loaded via require below)
@@ -785,14 +1024,28 @@ avoids breakage if callers supply numeric defaults."
         ((numberp port) (number-to-string port))
         (t nil)))
 
+(defun tramp-rpc--connection-key-route-hop (hop-vec)
+  "Return normalized route identity for HOP-VEC."
+  (list (tramp-rpc--hop-component-string (tramp-file-name-method hop-vec))
+        (tramp-rpc--hop-component-string (tramp-file-name-user hop-vec))
+        (tramp-rpc--hop-component-string (tramp-file-name-domain hop-vec))
+        (tramp-rpc--hop-component-string (tramp-file-name-host hop-vec))
+        (or (tramp-rpc--port-to-string (tramp-file-name-port hop-vec)) "22")))
+
 (defun tramp-rpc--connection-key (vec)
   "Generate a connection key for VEC.
-Includes the hop chain so that different multi-hop routes to the
-same host produce distinct connections."
-  (list (tramp-file-name-host vec)
-        (tramp-file-name-user vec)
-        (or (tramp-rpc--port-to-string (tramp-file-name-port vec)) "22")
-        (tramp-file-name-hop vec)))
+Includes the effective hop chain, including hidden TRAMP ad-hoc proxy hops, so
+that different multi-hop routes to the same host produce distinct connections.
+Hidden and explicit rpc+sudo spellings for the same route share a key, while a
+direct root rpc connection does not collide with sudo over an unprivileged rpc
+hop."
+  (list :method (tramp-rpc--hop-component-string (tramp-file-name-method vec))
+        :host (tramp-rpc--hop-component-string (tramp-file-name-host vec))
+        :user (tramp-rpc--hop-component-string (tramp-file-name-user vec))
+        :port (or (tramp-rpc--port-to-string (tramp-file-name-port vec)) "22")
+        :route (mapcar (lambda (hop)
+                         (tramp-rpc--connection-key-route-hop (cdr hop)))
+                       (tramp-rpc--hop-pairs vec))))
 
 (defun tramp-rpc--get-connection (vec)
   "Get the RPC connection for VEC, or nil if not connected."
@@ -883,48 +1136,31 @@ The target socket path is read from the dynamic variable
 Handles password prompts, host-key verification, and detects the
 ControlMaster socket file appearing as the success condition.")
 
-(defun tramp-rpc--action-sudo-complete (proc _vec)
-  "Succeed when `sudo -v' exits with code 0, fail otherwise."
-  (unless (process-live-p proc)
-    (while (tramp-accept-process-output proc))
-    (throw 'tramp-action
-           (if (zerop (process-exit-status proc)) 'ok 'permission-denied))))
-
-(defconst tramp-rpc--sudo-actions
-  '((tramp-password-prompt-regexp tramp-action-password)
-    (tramp-wrong-passwd-regexp tramp-action-permission-denied)
-    (tramp-process-alive-regexp tramp-rpc--action-sudo-complete))
-  "Actions for `sudo -v' pre-authentication.
-Handles password prompts and detects sudo exit as success.")
-
 ;;; ============================================================================
 ;;; Multi-hop support
 ;;; ============================================================================
 
 (defun tramp-rpc--hops-to-proxyjump (vec)
   "Convert VEC's hop chain to an SSH ProxyJump (-J) string.
-Parses the TRAMP hop field (e.g. \"rpc:user@gateway|\") and converts
-each hop to the SSH ProxyJump format (e.g. \"user@gateway\").
+Parses the TRAMP hop field (for example, `rpc:user@gateway|') and converts
+each hop to the SSH ProxyJump format (for example, `user@gateway').
 Returns nil if there are no hops.
 
-Same-host rpc hops are skipped because they represent sudo elevation,
-not proxy jumps.  Supports mixed methods: both \"rpc:\" and \"ssh:\"
-hops are accepted since ProxyJump only needs host connectivity."
-  (when-let* ((hops (tramp-file-name-hop vec))
-              (target-host (tramp-file-name-host vec)))
-    (let (proxy-parts)
-      (dolist (hop-str (split-string hops tramp-postfix-hop-regexp 'omit))
-        (let* ((hop-name (concat tramp-prefix-format hop-str
-                                 tramp-postfix-host-format))
-               (hop-vec (tramp-dissect-file-name hop-name 'nodefault))
-               (hop-host (tramp-file-name-host hop-vec)))
-          ;; Skip same-host rpc hops (sudo elevation, not proxy)
-          (unless (and (string= (tramp-file-name-method hop-vec) "rpc")
-                       (string= hop-host target-host))
+For sudo-via-RPC paths, the same-host rpc hop carrying the SSH details is
+not a ProxyJump; other same-host rpc hops are preserved.  Supports mixed
+methods: both `rpc:' and `ssh:' hops are accepted since ProxyJump only
+needs host connectivity."
+  (when-let* ((hop-pairs (tramp-rpc--hop-pairs vec)))
+    (let ((sudo-hop (tramp-rpc--same-host-rpc-hop vec 'return-string))
+          proxy-parts)
+      (dolist (hop hop-pairs)
+        (let* ((hop-vec (cdr hop)))
+          ;; Skip only the rpc hop that represents sudo-via-RPC.
+          (unless (and sudo-hop (tramp-rpc--same-hop-p (cdr hop) (cdr sudo-hop)))
             (push (concat
                    (when (tramp-file-name-user hop-vec)
                      (concat (tramp-file-name-user hop-vec) "@"))
-                   hop-host
+                   (tramp-file-name-host hop-vec)
                    (when-let* ((port (tramp-rpc--port-to-string
                                       (tramp-file-name-port hop-vec))))
                      (concat ":" port)))
@@ -937,12 +1173,20 @@ hops are accepted since ProxyJump only needs host connectivity."
 Expands SSH escape sequences in `tramp-rpc-controlmaster-path'.
 For sudo-via-RPC paths, uses the SSH user and excludes the sudo
 hop so the socket is shared with the normal rpc connection."
-  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+  (let* ((sudo-hop (tramp-rpc--sudo-rpc-hop-vec vec))
          (host (tramp-file-name-host vec))
-         (user (or sudo-ssh-user (tramp-file-name-user vec) (user-login-name)))
-         (port (or (tramp-rpc--port-to-string (tramp-file-name-port vec)) "22"))
+         (user (or (and sudo-hop
+                         (or (tramp-file-name-user sudo-hop)
+                             (user-login-name)))
+                   (tramp-file-name-user vec)
+                   (user-login-name)))
+         (port (or (tramp-rpc--port-to-string
+                    (if sudo-hop
+                        (tramp-file-name-port sudo-hop)
+                      (tramp-file-name-port vec)))
+                   "22"))
          ;; For sudo, use only proxy hops (exclude the same-host sudo hop)
-         (hop (if sudo-ssh-user
+         (hop (if sudo-hop
                   (tramp-rpc--proxy-hop-string vec)
                 (tramp-file-name-hop vec)))
          (path tramp-rpc-controlmaster-path))
@@ -963,11 +1207,11 @@ hop so the socket is shared with the normal rpc connection."
 
 (defun tramp-rpc--controlmaster-active-p (vec)
   "Return non-nil if a ControlMaster connection is active for VEC."
-  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
-         (socket-path (tramp-rpc--controlmaster-socket-path vec))
+  (let* ((socket-path (tramp-rpc--controlmaster-socket-path vec))
          (host (tramp-file-name-host vec))
-         (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
+         (user (tramp-rpc--ssh-detail-user vec))
+         (port (tramp-rpc--port-to-string
+                (tramp-rpc--ssh-detail-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec)))
     (and (file-exists-p socket-path)
          ;; Check if the socket is actually usable via ssh -O check
@@ -991,10 +1235,10 @@ Returns non-nil on success."
     (tramp-rpc--debug "ControlMaster already active for %s" (tramp-file-name-host vec))
     (cl-return-from tramp-rpc--establish-controlmaster t))
   (tramp-rpc--ensure-controlmaster-directory)
-  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
-         (host (tramp-file-name-host vec))
-         (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
+  (let* ((host (tramp-file-name-host vec))
+         (user (tramp-rpc--ssh-detail-user vec))
+         (port (tramp-rpc--port-to-string
+                (tramp-rpc--ssh-detail-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          (socket-path (tramp-rpc--controlmaster-socket-path vec))
          (process-name (format "*tramp-rpc-auth %s*" host))
@@ -1035,7 +1279,7 @@ Returns non-nil on success."
     (tramp-set-connection-property process "hop-vector" vec)
     (tramp-set-connection-property
      process "pw-vector"
-     (make-tramp-file-name :method "ssh" :user user :host host))
+     (make-tramp-file-name :method "ssh" :user user :host host :port port))
     ;; Use upstream tramp-process-actions for password/host-key handling.
     ;; The custom action checks for the ControlMaster socket appearing.
     (let ((tramp-rpc--controlmaster-socket-path socket-path))
@@ -1045,66 +1289,17 @@ Returns non-nil on success."
     (sleep-for 0.1)
     t))
 
-(defun tramp-rpc--sudo-authenticate (vec ssh-user)
-  "Pre-authenticate sudo on the remote host for VEC.
-Uses the ControlMaster to run `sudo -v' interactively, caching
-credentials so the server can be started with sudo via pipes.
-SSH-USER is the user for the SSH connection (from the rpc hop).
-
-Uses `tramp-process-actions' with `tramp-rpc--sudo-actions' for
-password handling, giving auth-source integration and password
-caching for free."
-  (let* ((host (tramp-file-name-host vec))
-         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
-         (proxyjump (tramp-rpc--hops-to-proxyjump vec))
-         (socket-path (tramp-rpc--controlmaster-socket-path vec))
-         (process-name (format "*tramp-rpc-sudo %s*" host))
-         (buffer (get-buffer-create (format " *tramp-rpc-sudo %s*" host)))
-         (ssh-args (append
-                    (list "ssh")
-                    tramp-rpc-ssh-args
-                    (when ssh-user (list "-l" ssh-user))
-                    (when port (list "-p" port))
-                    ;; Multi-hop via ProxyJump
-                    (when proxyjump (list "-J" proxyjump))
-                    ;; Reuse ControlMaster for the SSH layer
-                    (when (and tramp-rpc-use-controlmaster
-                               (file-exists-p socket-path))
-                      (list "-o" "ControlMaster=auto"
-                            "-o" (format "ControlPath=%s" socket-path)))
-                    (list "-o" "StrictHostKeyChecking=accept-new")
-                    ;; Run sudo -v to cache credentials, then exit
-                    (list host "sudo" "-v")))
-         process)
-    (with-current-buffer buffer (erase-buffer))
-    ;; Use PTY for the sudo password prompt
-    (let ((process-connection-type t))
-      (setq process (apply #'start-process process-name buffer ssh-args)))
-    (set-process-query-on-exit-flag process nil)
-    (set-process-sentinel process #'ignore)
-    ;; Set up process properties for tramp-process-actions / tramp-read-passwd.
-    ;; pw-vector points to the sudo user so auth-source can look up
-    ;; credentials via e.g. "machine host login user port sudo".
-    (process-put process 'tramp-vector vec)
-    (tramp-set-connection-property process "hop-vector" vec)
-    (tramp-set-connection-property
-     process "pw-vector"
-     (make-tramp-file-name :method "sudo" :user ssh-user :host host))
-    ;; Use upstream tramp-process-actions for password handling.
-    ;; tramp-rpc--action-sudo-complete throws 'ok on exit 0,
-    ;; 'permission-denied otherwise.  tramp-process-actions handles
-    ;; timeout, wrong-password cleanup, and error signaling.
-    (tramp-process-actions process vec nil tramp-rpc--sudo-actions 60)))
-
-(defun tramp-rpc--start-server-process (vec binary-path)
+(defun tramp-rpc--start-server-process (vec binary-path &optional sudo-password)
   "Start the RPC server on VEC at BINARY-PATH and verify it responds.
 BINARY-PATH is the remote localname of the server binary (may contain ~).
-For sudo-via-RPC paths, the server is started via sudo.
+For sudo-via-RPC paths, the server is started via sudo.  If SUDO-PASSWORD
+is non-nil, feed it to sudo -S before the RPC server starts reading stdin.
 Returns the connection plist.  Signals `remote-file-error' on failure."
   (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
          (host (tramp-file-name-host vec))
          (user (or sudo-ssh-user (tramp-file-name-user vec)))
-         (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
+         (port (tramp-rpc--port-to-string
+                (tramp-rpc--ssh-detail-port vec)))
          (proxyjump (tramp-rpc--hops-to-proxyjump vec))
          ;; Build SSH command to run the RPC server
          (ssh-args (append
@@ -1131,11 +1326,25 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
                                          (tramp-rpc--controlmaster-socket-path vec))
                             "-o" (format "ControlPersist=%s"
                                          tramp-rpc-controlmaster-persist)))
-                    ;; For sudo elevation, wrap the binary in sudo
+                    ;; For sudo elevation, wrap the binary in sudo.  This is
+                    ;; the RPC analogue of TRAMP's native sudo method: open an
+                    ;; elevated long-lived backend connection, then run process
+                    ;; operations inside that connection.
                     (if sudo-ssh-user
-                        (list host "sudo" "-n"
-                              "-u" (tramp-file-name-user vec)
-                              binary-path)
+                        (append
+                         (list host "sudo")
+                         ;; Do not use an empty sudo prompt here.  OpenSSH
+                         ;; builds the remote command from argv and drops the
+                         ;; empty argument, making sudo parse "-u" as the
+                         ;; prompt string instead of the user option.
+                         (if sudo-password
+                             '("-k" "-S" "-p" "Password:")
+                           '("-n"))
+                         ;; Match TRAMP's sudo method: run with the target
+                         ;; user's home environment rather than preserving the
+                         ;; SSH user's HOME.
+                         (list "-u" (tramp-file-name-user vec) "-H"
+                               binary-path))
                       (list host binary-path))))
          ;; Use TRAMP's standard naming so tramp-get-connection-process works
          (process-name (tramp-get-connection-name vec))
@@ -1170,6 +1379,12 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
            :noquery t
            :stderr stderr-buffer
            :filter #'tramp-rpc--connection-filter))
+
+    ;; If sudo is reading the password from stdin, send it before the RPC
+    ;; server starts.  sudo consumes this line; after exec, the same pipe
+    ;; carries MessagePack-RPC frames to the server.
+    (when sudo-password
+      (process-send-string process (concat sudo-password "\n")))
 
     ;; Store connection
     (tramp-rpc--set-connection vec process buffer stderr-buffer)
@@ -1251,15 +1466,19 @@ accidentally routing file operations through tramp-sh."
              (tramp-rpc--establish-controlmaster vec)
            (remote-file-error
             (signal (car err) (cdr err))))))))
-  ;; For sudo-via-RPC, pre-authenticate sudo so the server can be
-  ;; started with `sudo -n' (non-interactive) via pipes.
-  (when-let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec)))
-    (tramp-rpc--sudo-authenticate vec sudo-ssh-user))
-  (if tramp-rpc-deploy-never-deploy
+  (let* ((sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         ;; TRAMP's sudo method opens an elevated backend connection.  For the
+         ;; RPC backend that means starting the server via sudo.  Prefer sudo
+         ;; -n when a ticket is already valid; otherwise read the password with
+         ;; TRAMP's auth machinery and feed it to sudo -S during server start.
+         (sudo-password (when (and sudo-ssh-user
+                                   (tramp-rpc--sudo-password-required-p vec))
+                          (tramp-rpc--sudo-read-password vec sudo-ssh-user))))
+    (if tramp-rpc-deploy-never-deploy
       ;; Never-deploy mode: use the configured path directly, no fallback.
       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
         (condition-case err
-            (tramp-rpc--start-server-process vec binary-path)
+            (tramp-rpc--start-server-process vec binary-path sudo-password)
           (remote-file-error
            (tramp-rpc--cleanup-failed-connection vec)
            (signal 'remote-file-error
@@ -1276,7 +1495,7 @@ accidentally routing file operations through tramp-sh."
     ;; via scpx, and retry.
     (condition-case nil
         (tramp-rpc--start-server-process
-         vec (tramp-rpc-deploy-expected-binary-localname))
+         vec (tramp-rpc-deploy-expected-binary-localname) sudo-password)
       (remote-file-error
        ;; Connection failed - binary likely missing.  Clean up and deploy.
        (tramp-rpc--cleanup-failed-connection vec)
@@ -1285,7 +1504,7 @@ accidentally routing file operations through tramp-sh."
          ;; leaving it alive can cause vc/diff-hl sentinels to route
          ;; file operations through tramp-sh instead of tramp-rpc.
          (tramp-rpc--cleanup-bootstrap-connection vec)
-         (tramp-rpc--start-server-process vec binary-path))))))
+         (tramp-rpc--start-server-process vec binary-path sudo-password)))))))
 
 (defun tramp-rpc--disconnect (vec)
   "Disconnect the RPC connection to VEC."
@@ -1311,8 +1530,9 @@ Sends an SSH -O exit command to gracefully close the ControlMaster
 socket, then kills the auth process and buffer."
   (when tramp-rpc-use-controlmaster
     (let* ((host (tramp-file-name-host vec))
-           (user (tramp-file-name-user vec))
-           (port (tramp-rpc--port-to-string (tramp-file-name-port vec)))
+           (user (tramp-rpc--ssh-detail-user vec))
+           (port (tramp-rpc--port-to-string
+                  (tramp-rpc--ssh-detail-port vec)))
            (proxyjump (tramp-rpc--hops-to-proxyjump vec))
            (socket-path (tramp-rpc--controlmaster-socket-path vec))
            (auth-process-name (format "*tramp-rpc-auth %s*" host))
@@ -4276,6 +4496,12 @@ VEC-OR-FILENAME can be either a tramp-file-name struct or a filename string."
 ;; Connection cleanup support
 ;; ============================================================================
 
+(defun tramp-rpc--managed-file-name-p (vec-or-filename)
+  "Return non-nil when VEC-OR-FILENAME is managed by TRAMP-RPC."
+  (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename)))
+    (or (tramp-rpc-file-name-p vec)
+        (tramp-rpc--sudo-file-name-p vec))))
+
 (defun tramp-rpc-cleanup-connection (vec)
   "Clean up TRAMP-RPC resources for connection VEC.
 This is called from `tramp-cleanup-connection-hook' after TRAMP's
@@ -4286,7 +4512,7 @@ Handles RPC-specific state: the connection hash table, async/PTY
 processes, file watches, ControlMaster process/socket, pending RPC
 responses, and RPC-specific caches (direnv, executable, file-exists,
 file-truename)."
-  (when (tramp-rpc-file-name-p vec)
+  (when (tramp-rpc--managed-file-name-p vec)
     ;; Save buffer reference before disconnect removes the connection
     ;; entry.  The buffer is already killed by TRAMP's generic cleanup,
     ;; but we need the object to remove its pending-responses hash entry.

--- a/test/run-autoload-tests.sh
+++ b/test/run-autoload-tests.sh
@@ -8,14 +8,31 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TRAMP_SOURCE_CONFIGURED=0
+if [[ -n "${TRAMP_SOURCE:-}" ]]; then
+    TRAMP_SOURCE_CONFIGURED=1
+fi
+TRAMP_SOURCE="${TRAMP_SOURCE:-$HOME/src/tramp}"
+
+EMACS_LOAD_PATH_ARGS=(-L "$PROJECT_ROOT/lisp")
+if [[ -d "$TRAMP_SOURCE/lisp" ]]; then
+    # The sudo autoload tests exercise TRAMP >= 2.8 hidden ad-hoc proxy
+    # behavior.  Prefer the configured TRAMP checkout over the bundled Emacs
+    # TRAMP, which can be too old for this project.
+    EMACS_LOAD_PATH_ARGS=(-L "$TRAMP_SOURCE/lisp" "${EMACS_LOAD_PATH_ARGS[@]}")
+elif (( TRAMP_SOURCE_CONFIGURED )); then
+    echo "TRAMP_SOURCE does not contain a lisp/ directory: $TRAMP_SOURCE" >&2
+    exit 1
+fi
 
 echo "Running tramp-rpc autoload tests..."
 echo "Project root: $PROJECT_ROOT"
+echo "TRAMP source: $TRAMP_SOURCE"
 echo
 
 # Install msgpack if needed, then run tests
 emacs -Q --batch \
-    -L "$PROJECT_ROOT/lisp" \
+    "${EMACS_LOAD_PATH_ARGS[@]}" \
     --eval "(require 'package)" \
     --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
     --eval "(package-initialize)" \

--- a/test/tramp-rpc-autoload-tests.el
+++ b/test/tramp-rpc-autoload-tests.el
@@ -108,6 +108,8 @@ This allows testing autoload behavior in a clean state."
           (when (fboundp sym) (fmakunbound sym)))
         '(tramp-rpc-method
           tramp-rpc-file-name-p
+          tramp-rpc--sudo-file-name-p
+          tramp-rpc--sudo-file-name-p-in-progress
           tramp-rpc-file-name-handler)))
 
 ;;; ============================================================================
@@ -201,6 +203,62 @@ This allows testing autoload behavior in a clean state."
   (should-not (tramp-rpc-file-name-p "/ssh:user@host:/path"))
   (should-not (tramp-rpc-file-name-p "/sudo:root@localhost:/path"))
   (should-not (tramp-rpc-file-name-p "/path/to/local/file")))
+
+(ert-deftest tramp-rpc-autoload-test-sudo-predicate-explicit-different-host ()
+  "Autoloaded sudo predicate must not claim rpc proxy to another host."
+  (tramp-rpc-autoload-test--clean-environment)
+  (tramp-rpc-autoload-test--generate-autoloads)
+  (add-to-list 'load-path tramp-rpc-autoload-test--lisp-dir)
+  (load tramp-rpc-autoload-test--autoloads-file nil t)
+  (require 'tramp)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@gateway|sudo:root@server:/root")))
+    (should-not (tramp-rpc--sudo-file-name-p vec))))
+
+(ert-deftest tramp-rpc-autoload-test-sudo-predicate-ignores-doas ()
+  "Autoloaded sudo predicate must not claim non-sudo previous-hop methods."
+  (tramp-rpc-autoload-test--clean-environment)
+  (tramp-rpc-autoload-test--generate-autoloads)
+  (add-to-list 'load-path tramp-rpc-autoload-test--lisp-dir)
+  (load tramp-rpc-autoload-test--autoloads-file nil t)
+  (require 'tramp)
+  (let ((vec (make-tramp-file-name :method "doas" :user "root"
+                                   :host "server" :localname "/root"
+                                   :hop "rpc:alice@server|")))
+    (should (tramp-get-method-parameter vec 'tramp-password-previous-hop))
+    (should-not (tramp-rpc--sudo-file-name-p vec))
+    (should-not (featurep 'tramp-rpc))))
+
+(ert-deftest tramp-rpc-autoload-test-sudo-predicate-hidden-native ()
+  "Autoloaded sudo predicate claims hidden native rpc+sudo without recursion."
+  (tramp-rpc-autoload-test--clean-environment)
+  (tramp-rpc-autoload-test--generate-autoloads)
+  (add-to-list 'load-path tramp-rpc-autoload-test--lisp-dir)
+  (load tramp-rpc-autoload-test--autoloads-file nil t)
+  (require 'tramp)
+  (require 'tramp-cmds)
+  (should (fboundp 'tramp-rpc--sudo-file-name-p))
+  (should-not (autoloadp (symbol-function 'tramp-rpc--sudo-file-name-p)))
+  (should-not (featurep 'tramp-rpc))
+  (let* ((tramp-default-proxies-alist
+          (list (list "^server$" "^root$"
+                      (propertize "/rpc:alice@server:"
+                                  'tramp-ad-hoc t))))
+         ;; This is the hidden ad-hoc proxy shape TRAMP records for native
+         ;; `tramp-file-name-with-sudo' when `tramp-show-ad-hoc-proxies' is nil.
+         ;; Avoid calling that helper here: expanding the original /rpc: file
+         ;; would intentionally autoload the full handler before this test's
+         ;; first-use sudo predicate assertion.
+         (vec (tramp-dissect-file-name "/sudo:root@server:/root")))
+    ;; First use must be TRAMP's handler lookup.  The inline predicate should
+    ;; claim the hidden native sudo path without loading full tramp-rpc.el.
+    (should (eq (tramp-find-foreign-file-name-handler vec)
+                'tramp-rpc-file-name-handler))
+    (should-not (featurep 'tramp-rpc))
+    (should (tramp-rpc--sudo-file-name-p vec))
+    (should-not (featurep 'tramp-rpc))
+    (should (assq 'tramp-rpc--sudo-file-name-p
+                  tramp-foreign-file-name-handler-alist))))
 
 (ert-deftest tramp-rpc-autoload-test-autoloads-content ()
   "Test that autoloads file contains expected content."

--- a/test/tramp-rpc-autoload-tests.el
+++ b/test/tramp-rpc-autoload-tests.el
@@ -37,6 +37,21 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
+
+(declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
+(declare-function make-tramp-file-name "tramp")
+(declare-function tramp-dissect-file-name "tramp")
+(declare-function tramp-find-foreign-file-name-handler "tramp")
+(declare-function tramp-get-method-parameter "tramp")
+(declare-function loaddefs-generate "autoload")
+(declare-function update-file-autoloads "autoload")
+(defvar generated-autoload-file)
+(defvar tramp-rpc-method)
+(defvar tramp-foreign-file-name-handler-alist)
+(defvar tramp-default-proxies-alist)
+(defvar tramp-methods)
 
 ;; Get project root
 (defvar tramp-rpc-autoload-test--project-root

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1618,7 +1618,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
   (let ((vec (make-tramp-file-name :method "rpc" :host "target"
                                    :user "user" :localname "/path")))
     (should (equal (tramp-rpc--connection-key vec)
-                   '("target" "user" "22" nil)))))
+                   '(:method "rpc" :host "target" :user "user"
+                     :port "22" :route nil)))))
 
 (ert-deftest tramp-rpc-mock-test-connection-key-with-hop ()
   "Test connection key includes hop for differentiation."
@@ -1631,13 +1632,14 @@ This matches the behavior expected by `tramp-test28-process-file'."
          (key2 (tramp-rpc--connection-key vec2)))
     ;; Keys should differ because one has a hop and the other doesn't
     (should-not (equal key1 key2))
-    ;; Both should have the same host/user/port
-    (should (equal (nth 0 key1) (nth 0 key2)))
-    (should (equal (nth 1 key1) (nth 1 key2)))
-    (should (equal (nth 2 key1) (nth 2 key2)))
-    ;; Hop should differ
-    (should (nth 3 key1))
-    (should-not (nth 3 key2))))
+    ;; Both should have the same target method/host/user/port.
+    (should (equal (plist-get key1 :method) (plist-get key2 :method)))
+    (should (equal (plist-get key1 :host) (plist-get key2 :host)))
+    (should (equal (plist-get key1 :user) (plist-get key2 :user)))
+    (should (equal (plist-get key1 :port) (plist-get key2 :port)))
+    ;; Route should differ.
+    (should (plist-get key1 :route))
+    (should-not (plist-get key2 :route))))
 
 (ert-deftest tramp-rpc-mock-test-connection-key-different-hops ()
   "Test that different hop routes produce different connection keys."
@@ -1648,6 +1650,23 @@ This matches the behavior expected by `tramp-test28-process-file'."
          (key1 (tramp-rpc--connection-key vec1))
          (key2 (tramp-rpc--connection-key vec2)))
     (should-not (equal key1 key2))))
+
+(ert-deftest tramp-rpc-mock-test-connection-key-hidden-sudo-route ()
+  "Hidden native sudo routes should not collide with direct root rpc."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
+         (hidden (tramp-dissect-file-name
+                  (tramp-file-name-with-sudo "/rpc:alice@server:/root")))
+         (explicit (tramp-dissect-file-name
+                    "/rpc:alice@server|sudo:root@server:/root"))
+         (direct-root (tramp-dissect-file-name "/rpc:root@server:/root")))
+    (should (equal (tramp-rpc--connection-key hidden)
+                   (tramp-rpc--connection-key explicit)))
+    (should-not (equal (tramp-rpc--connection-key hidden)
+                       (tramp-rpc--connection-key direct-root)))))
 
 (ert-deftest tramp-rpc-mock-test-controlmaster-socket-different-hops ()
   "Test that different hop routes produce different ControlMaster socket paths."
@@ -2213,26 +2232,31 @@ This matches the behavior expected by `tramp-test28-process-file'."
 ;; method is now multi-hop capable (inherits ssh connection params).
 (ert-deftest tramp-rpc-mock-test-zz-file-name-with-sudo-native ()
   "Test that tramp-file-name-with-sudo natively produces rpc+sudo path."
-  :tags '(:multi-hop)
+  :tags '(:multi-hop :sudo)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
-  (let* ((tramp-file-name-with-method "sudo")
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
          (filename (tramp-file-name-with-sudo "/rpc:user@target:/etc/hosts"))
          (vec (tramp-dissect-file-name filename)))
     (should (tramp-tramp-file-p filename))
     (should (equal (tramp-file-name-localname vec) "/etc/hosts"))
     (should (string= (tramp-file-name-method vec) "sudo"))
     (should (string= (tramp-file-name-host vec) "target"))
-    ;; The hop should preserve the rpc method
-    (when (tramp-file-name-hop vec)
-      (should (string-match-p "rpc:" (tramp-file-name-hop vec)))))
-  ;; Also verify non-rpc paths still work
-  (let* ((tramp-file-name-with-method "sudo")
+    ;; Upstream TRAMP hides this ad-hoc hop in `tramp-default-proxies-alist'
+    ;; when `tramp-show-ad-hoc-proxies' is nil; tramp-rpc must still claim it.
+    (should-not (tramp-file-name-hop vec))
+    (should (tramp-rpc--sudo-file-name-p filename))
+    (should (equal (tramp-rpc--detect-sudo-elevation vec) "user")))
+  ;; Also verify non-rpc paths still work and are not claimed by tramp-rpc.
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
          (filename (tramp-file-name-with-sudo "/ssh:user@target:/etc/hosts"))
          (vec (tramp-dissect-file-name filename)))
     (should (tramp-tramp-file-p filename))
     (should (string= (tramp-file-name-method vec) "sudo"))
-    (should (string= (tramp-file-name-host vec) "target"))))
+    (should (string= (tramp-file-name-host vec) "target"))
+    (should-not (tramp-rpc--sudo-file-name-p filename))))
 
 (ert-deftest tramp-rpc-mock-test-rpc-method-advertises-host-arg ()
   "Test that the rpc method declares %%h in tramp-login-args.
@@ -2253,8 +2277,15 @@ The rpc method inherits all ssh connection parameters, so
   :tags '(:multi-hop)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   ;; Manually install the proxy entry that tramp-add-hops would create
-  ;; when processing /rpc:server|sudo:root@server:/path.
-  (let* ((tramp-default-proxies-alist
+  ;; when processing /rpc:server|sudo:root@server:/path.  Disable the
+  ;; tramp-rpc sudo foreign predicate for this low-level TRAMP check; otherwise
+  ;; the hidden rpc+sudo path is intentionally claimed by tramp-rpc before
+  ;; tramp-sh computes its multi-hop chain.
+  (let* ((tramp-foreign-file-name-handler-alist
+          (cl-remove-if
+           (lambda (entry) (eq (car entry) 'tramp-rpc--sudo-file-name-p))
+           tramp-foreign-file-name-handler-alist))
+         (tramp-default-proxies-alist
           (list (list "^server$" "^root$"
                       (propertize "/rpc:server:" 'tramp-ad-hoc t))))
          (sudo-vec (make-tramp-file-name :method "sudo" :user "root"
@@ -2322,7 +2353,28 @@ as a hop in multi-hop chains."
   ;; ssh+sudo should not match (no rpc in hop)
   (should-not (tramp-rpc--sudo-file-name-p
                (tramp-dissect-file-name
-                "/ssh:user@server|sudo:root@server:/root"))))
+                "/ssh:user@server|sudo:root@server:/root")))
+  ;; rpc as a real proxy to a different host should not match either.
+  (should-not (tramp-rpc--sudo-file-name-p
+               (tramp-dissect-file-name
+                "/rpc:user@gateway|sudo:root@server:/root"))))
+
+(ert-deftest tramp-rpc-mock-test-doas-previous-hop-not-sudo-via-rpc ()
+  "Non-sudo previous-hop methods must not be treated as sudo-via-RPC."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "doas" :user "root"
+                                   :host "server" :localname "/root"
+                                   :hop "rpc:alice@server|")))
+    (should (tramp-rpc--privilege-elevation-vec-p
+             (make-tramp-file-name :method "sudo" :user "root"
+                                   :host "server" :localname "/root"
+                                   :hop "rpc:alice@server|")))
+    (should (tramp-get-method-parameter vec 'tramp-password-previous-hop))
+    (should-not (tramp-rpc--privilege-elevation-vec-p vec))
+    (should-not (tramp-rpc--sudo-file-name-p vec))
+    (should-not (tramp-rpc--detect-sudo-elevation vec))
+    (should-not (tramp-rpc-multi-hop-p vec))))
 
 (ert-deftest tramp-rpc-mock-test-proxy-hop-string-sudo ()
   "Test that same-host sudo hops are excluded from proxy hop string."
@@ -2355,6 +2407,331 @@ as a hop in multi-hop chains."
       (should pj)
       (should (string-match-p "gw" pj))
       (should-not (string-match-p "server" pj)))))
+
+(ert-deftest tramp-rpc-mock-test-sudo-rpc-hop-must-be-final-hop ()
+  "Only the final hop before sudo is the sudo-via-RPC SSH detail hop."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@server|ssh:gateway|sudo:root@server:/root")))
+    (should-not (tramp-rpc--detect-sudo-elevation vec))
+    (should (equal (tramp-rpc--proxy-hop-string vec)
+                   "rpc:alice@server|ssh:gateway|"))
+    (should (equal (tramp-rpc--hops-to-proxyjump vec)
+                   "alice@server,gateway"))))
+
+(ert-deftest tramp-rpc-mock-test-hidden-sudo-proxies-from-native-tramp ()
+  "TRAMP hidden ad-hoc proxies should still identify rpc+sudo paths."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
+         (filename (tramp-file-name-with-sudo
+                    "/rpc:gw|rpc:alice@server:/root"))
+         (vec (tramp-dissect-file-name filename)))
+    (should-not (tramp-file-name-hop vec))
+    (should (tramp-rpc--sudo-file-name-p filename))
+    (should (equal (tramp-rpc--detect-sudo-elevation vec) "alice"))
+    (should (equal (substring-no-properties (tramp-rpc--proxy-hop-string vec))
+                   "rpc:gw|"))
+    (should (equal (substring-no-properties (tramp-rpc--hops-to-proxyjump vec))
+                   "gw"))))
+
+(ert-deftest tramp-rpc-mock-test-hidden-sudo-handler-no-recursion ()
+  "Hidden native rpc+sudo should be claimed without unregistering predicate."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
+         (filename (tramp-file-name-with-sudo "/rpc:alice@server:/root")))
+    (should (eq (tramp-find-foreign-file-name-handler
+                 (tramp-dissect-file-name filename))
+                'tramp-rpc-file-name-handler))
+    (should (assq 'tramp-rpc--sudo-file-name-p
+                  tramp-foreign-file-name-handler-alist))))
+
+(ert-deftest tramp-rpc-mock-test-hidden-different-host-sudo-not-claimed ()
+  "Hidden rpc proxy to another host is not sudo-via-rpc for the target."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((tramp-default-proxies-alist
+          (list (list "^server$" "^root$"
+                      (propertize "/rpc:alice@gateway:"
+                                  'tramp-ad-hoc t))))
+         (filename "/sudo:root@server:/root")
+         (vec (tramp-dissect-file-name filename)))
+    (should-not (tramp-rpc--sudo-file-name-p vec))
+    (should-not (eq (tramp-find-foreign-file-name-handler vec)
+                    'tramp-rpc-file-name-handler))))
+
+(ert-deftest tramp-rpc-mock-test-different-host-sudo-probing-is-quiet ()
+  "Non-matching rpc sudo probes should not emit TRAMP host-mismatch messages."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((messages nil))
+    (cl-letf (((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (when format-string
+                   (push (apply #'format-message format-string args)
+                         messages)))))
+      ;; Explicit rpc proxy to a different host.
+      (should-not (tramp-rpc--sudo-file-name-p
+                   (tramp-dissect-file-name
+                    "/rpc:alice@gateway|sudo:root@server:/root")))
+      ;; Hidden native ad-hoc proxy to a different host.
+      (let* ((tramp-default-proxies-alist
+              (list (list "^server$" "^root$"
+                          (propertize "/rpc:alice@gateway:"
+                                      'tramp-ad-hoc t))))
+             (vec (tramp-dissect-file-name "/sudo:root@server:/root")))
+        (should-not (tramp-rpc--sudo-file-name-p vec))))
+    (should-not
+     (cl-some (lambda (msg)
+                (string-match-p "Host name .* does not match" msg))
+              messages))))
+
+(ert-deftest tramp-rpc-mock-test-eshell-sudo-uses-native-em-tramp ()
+  "Eshell sudo should keep using em-tramp's TRAMP sudo rewrite."
+  :tags '(:sudo :eshell)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'em-tramp)
+  (let* ((default-directory "/rpc:alice@server:/tmp/")
+         (form (catch 'eshell-replace-command
+                 (eshell/sudo "id")))
+         (binding (caadr form)))
+    (should (eq (car-safe form) 'let))
+    (should (eq (car binding) 'default-directory))
+    (should (string-match-p "/rpc:alice@server|sudo:root@server:/tmp/"
+                            (cadr binding)))))
+
+(ert-deftest tramp-rpc-mock-test-exec-path-sudo-uses-native-sudo-rpc-server ()
+  "Eshell command lookup in /rpc|sudo should use the sudo RPC backend."
+  :tags '(:sudo :eshell)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:alice@server|sudo:root@server:/tmp/")
+        captured)
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (vec)
+                 (setq captured vec)
+                 '("/bin"))))
+      (should (equal (tramp-rpc-handle-exec-path) '("/bin" "/tmp/")))
+      (should (string= (tramp-file-name-method captured) "sudo"))
+      (should (string= (tramp-file-name-user captured) "root")))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-sudo-uses-native-sudo-rpc-server ()
+  "process-file in /rpc|sudo should run inside the sudo RPC connection."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:alice@server|sudo:root@server:/root/")
+        captured)
+    (cl-letf (((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--directory-watched-p)
+               (lambda (&rest _) t))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (vec _method params)
+                 (setq captured (list vec params))
+                 '((exit_code . 0) (stdout . "") (stderr . "")))))
+      (should (= (tramp-rpc-handle-process-file "id" nil nil nil "-u") 0))
+      (let ((vec (car captured))
+            (params (cadr captured)))
+        (should (string= (tramp-file-name-method vec) "sudo"))
+        (should (string= (tramp-file-name-user vec) "root"))
+        (should (equal (alist-get 'cmd params) "id"))
+        (should (equal (alist-get 'cwd params) "/root/"))
+        (should (equal (append (alist-get 'args params) nil) '("-u")))))))
+
+(ert-deftest tramp-rpc-mock-test-make-process-sudo-uses-native-sudo-rpc-server ()
+  "make-process in /rpc|sudo should use the elevated RPC connection."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:alice@server|sudo:root@server:/root/")
+        captured proc)
+    (cl-letf (((symbol-function 'tramp-rpc--sudo-password-required-p)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--start-remote-process)
+               (lambda (vec program args cwd _env)
+                 (setq captured (list vec program args cwd))
+                 4242))
+              ((symbol-function 'tramp-rpc--write-remote-process)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--start-async-read)
+               (lambda (&rest _) nil)))
+      (unwind-protect
+          (progn
+            (setq proc (tramp-rpc-handle-make-process
+                        :name "tramp-rpc-sudo-process-test"
+                        :buffer nil
+                        :command '("id" "-u")
+                        :connection-type nil
+                        :noquery t))
+            (should (processp proc))
+            (let ((vec (nth 0 captured)))
+              (should (string= (tramp-file-name-method vec) "sudo"))
+              (should (string= (tramp-file-name-user vec) "root")))
+            (should (equal (nth 1 captured) "id"))
+            (should (equal (nth 3 captured) "/root/"))
+            (should (equal (nth 2 captured) '("-u"))))
+        (when (processp proc)
+          (delete-process proc))))))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-connection-hidden-sudo-via-rpc ()
+  "Cleanup should remove RPC state for hidden native rpc+sudo paths."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless (tramp-rpc-mock-test--sudo-helper-available-p))
+  (let* ((tramp-default-proxies-alist nil)
+         (tramp-file-name-with-method "sudo")
+         (vec (tramp-dissect-file-name
+               (tramp-file-name-with-sudo "/rpc:alice@server:/root")))
+         (buffer (generate-new-buffer " *tramp-rpc-cleanup-sudo-test*"))
+         (proc (make-process :name "tramp-rpc-cleanup-sudo-test"
+                             :buffer buffer
+                             :command '("cat")
+                             :connection-type 'pipe
+                             :noquery t))
+         (key (tramp-rpc--connection-key vec)))
+    (unwind-protect
+        (progn
+          (puthash key (list :process proc :buffer buffer)
+                   tramp-rpc--connections)
+          (puthash buffer 'pending tramp-rpc--pending-responses)
+          (cl-letf (((symbol-function 'tramp-rpc--cleanup-async-processes)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--cleanup-pty-processes)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--cleanup-watches-for-connection)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--cleanup-file-notify-for-connection)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--clear-direnv-cache)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--cleanup-controlmaster)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-flush-directory-properties)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-flush-connection-properties)
+                     (lambda (&rest _) nil)))
+            (tramp-rpc-cleanup-connection vec))
+          (should-not (gethash key tramp-rpc--connections))
+          (should-not (gethash buffer tramp-rpc--pending-responses)))
+      (remhash key tramp-rpc--connections)
+      (remhash buffer tramp-rpc--pending-responses)
+      (when (process-live-p proc)
+        (delete-process proc))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-start-server-sudo-password-uses-stdin ()
+  "When sudo needs a password, start the elevated RPC server with sudo -S."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@server|sudo:root@server:/root/"))
+        (orig-make-process (symbol-function 'make-process))
+        command sent proc)
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest plist)
+                 (setq command (plist-get plist :command))
+                 (setq proc (funcall orig-make-process
+                                      :name "tramp-rpc-mock-cat"
+                                      :buffer nil
+                                      :command '("cat")
+                                      :connection-type 'pipe
+                                      :noquery t))))
+              ((symbol-function 'process-send-string)
+               (lambda (_process string)
+                 (setq sent string)))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method _params)
+                 (should (equal method "system.info"))
+                 '((uid . 0) (gid . 0) (home . "/root") (shell . "/bin/sh"))))
+              ((symbol-function 'tramp-set-connection-local-variables)
+               (lambda (&rest _) nil)))
+      (unwind-protect
+          (progn
+            (should (tramp-rpc--start-server-process
+                     vec "/tmp/tramp-rpc-server" "secret"))
+            (should (member "sudo" command))
+            (should (member "-k" command))
+            (should (member "-S" command))
+            (should-not (member "-n" command))
+            (should (member "-p" command))
+            (should (member "Password:" command))
+            (should (member "-H" command))
+            (should-not (member "" command))
+            (should (equal sent "secret\n")))
+        (when (processp proc)
+          (delete-process proc))
+        (tramp-rpc--remove-connection vec)))))
+
+(ert-deftest tramp-rpc-mock-test-start-server-sudo-noninteractive-uses-n-H ()
+  "When sudo has a cached ticket, start the elevated RPC server with sudo -n -H."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@server|sudo:root@server:/root/"))
+        (orig-make-process (symbol-function 'make-process))
+        command sent proc)
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest plist)
+                 (setq command (plist-get plist :command))
+                 (setq proc (funcall orig-make-process
+                                      :name "tramp-rpc-mock-cat"
+                                      :buffer nil
+                                      :command '("cat")
+                                      :connection-type 'pipe
+                                      :noquery t))))
+              ((symbol-function 'process-send-string)
+               (lambda (_process string)
+                 (setq sent string)))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method _params)
+                 (should (equal method "system.info"))
+                 '((uid . 0) (gid . 0) (home . "/root") (shell . "/bin/sh"))))
+              ((symbol-function 'tramp-set-connection-local-variables)
+               (lambda (&rest _) nil)))
+      (unwind-protect
+          (progn
+            (should (tramp-rpc--start-server-process
+                     vec "/tmp/tramp-rpc-server" nil))
+            (should (member "sudo" command))
+            (should (member "-n" command))
+            (should (member "-H" command))
+            (should-not (member "-S" command))
+            (should-not (member "-p" command))
+            (should-not (member "Password:" command))
+            (should-not sent))
+        (when (processp proc)
+          (delete-process proc))
+        (tramp-rpc--remove-connection vec)))))
+
+(ert-deftest tramp-rpc-mock-test-password-string-unwraps-auth-source-entry ()
+  "Normalize auth-source plist secrets before sending them to sudo -S."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (should (equal (tramp-rpc--password-string
+                  '(:host "x220-nixos" :user "arthur" :port "sudo"
+                    :secret (lambda () "secret")))
+                 "secret")))
 
 (ert-deftest tramp-rpc-mock-test-controlmaster-socket-shared ()
   "Test that sudo and normal connections share the ControlMaster socket."
@@ -2866,6 +3243,105 @@ discard it for being unreadable."
       (should (equal (assoc "TERM" captured-env) '("TERM" . "dumb")))
       (should (equal (assoc "PYTHONUNBUFFERED" captured-env)
                      '("PYTHONUNBUFFERED" . "1"))))))
+
+(ert-deftest tramp-rpc-mock-test-make-process-connection-type-nil-is-pipe ()
+  "An explicit `:connection-type nil' must not fall back to global PTY mode."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/")
+        (process-connection-type t)
+        (started nil)
+        (password-probed nil)
+        (pty-called nil)
+        proc)
+    (cl-letf (((symbol-function 'tramp-rpc--sudo-password-required-p)
+               (lambda (_vec)
+                 (setq password-probed t)
+                 nil))
+              ((symbol-function 'tramp-rpc--sudo-read-password)
+               (lambda (&rest _)
+                 (error "Password should not be read when sudo -n succeeds")))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--start-remote-process)
+               (lambda (_vec program args _cwd _env)
+                 (setq started (list program args))
+                 4242))
+              ((symbol-function 'tramp-rpc--write-remote-process)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--start-async-read)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--make-pty-process)
+               (lambda (&rest _)
+                 (setq pty-called t)
+                 'pty-process)))
+      (unwind-protect
+          (progn
+            (setq proc (tramp-rpc-handle-make-process
+                        :name "tramp-rpc-connection-type-nil-test"
+                        :buffer nil
+                        :command '("sudo" "id")
+                        :connection-type nil
+                        :noquery t))
+            (should (processp proc))
+            (should-not pty-called)
+            (should password-probed)
+            (should (equal (car started) "sudo"))
+            (should (equal (cadr started) '("-n" "id"))))
+        (when (processp proc)
+          (delete-process proc))))))
+
+(ert-deftest tramp-rpc-mock-test-make-process-sudo-pipe-uses-stdin-password ()
+  "Pipe-mode literal sudo should authenticate in the same stdin context."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/")
+        (started nil)
+        (written nil)
+        proc)
+    (cl-letf (((symbol-function 'tramp-rpc--sudo-password-required-p)
+               (lambda (_vec) t))
+              ((symbol-function 'tramp-rpc--sudo-read-password)
+               (lambda (_vec user)
+                 (should (equal user "user"))
+                 "secret"))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--start-remote-process)
+               (lambda (_vec program args _cwd _env)
+                 (setq started (list program args))
+                 4242))
+              ((symbol-function 'tramp-rpc--write-remote-process)
+               (lambda (_vec pid data)
+                 (setq written (list pid data))))
+              ((symbol-function 'tramp-rpc--start-async-read)
+               (lambda (&rest _) nil)))
+      (unwind-protect
+          (progn
+            (setq proc (tramp-rpc-handle-make-process
+                        :name "tramp-rpc-sudo-stdin-test"
+                        :buffer nil
+                        :command '("sudo" "id")
+                        :connection-type nil
+                        :noquery t))
+            (should (processp proc))
+            (should (equal (car started) "sudo"))
+            (should (equal (cadr started)
+                           '("-k" "-S" "-p" "" "id")))
+            (should-not (member "-n" (cadr started)))
+            (should (equal written '(4242 "secret\n"))))
+        (when (processp proc)
+          (delete-process proc))))))
 
 ;;; ============================================================================
 ;;; Direnv Cache Path Normalization Tests (No server or SSH required)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -3343,6 +3343,57 @@ discard it for being unreadable."
         (when (processp proc)
           (delete-process proc))))))
 
+(ert-deftest tramp-rpc-mock-test-process-cleanup-handles-already-exited-relay ()
+  "Deferred cleanup must remove relays that exit before installation."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-cleanup-exited-test*"))
+         (proc (let ((process-connection-type nil))
+                 (start-process "tramp-rpc-cleanup-exited-test" buffer "cat"))))
+    (unwind-protect
+        (progn
+          (puthash proc '(:pid 4242) tramp-rpc--async-processes)
+          (process-send-eof proc)
+          (while (process-live-p proc)
+            (accept-process-output proc 0.01 nil t))
+          (should (gethash proc tramp-rpc--async-processes))
+          (tramp-rpc--install-process-cleanup proc)
+          (accept-process-output nil 0.05)
+          (should-not (gethash proc tramp-rpc--async-processes))
+          (should-not (get-buffer-process buffer)))
+      (when (processp proc)
+        (ignore-errors (delete-process proc)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-sudo-via-rpc-pty-uses-rpc-backend ()
+  "PTYs for sudo-via-RPC must not use direct SSH as the sudo target user."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:alice@server|sudo:root@server:/root/"))
+        (tramp-rpc-use-direct-ssh-pty t)
+        (rpc-called nil))
+    (cl-letf (((symbol-function 'tramp-rpc--make-direct-ssh-pty-process)
+               (lambda (&rest _)
+                 (error "sudo-via-RPC PTY must not use direct SSH")))
+              ((symbol-function 'tramp-rpc--make-rpc-pty-process)
+               (lambda (got-vec name buffer command coding noquery
+                         filter sentinel localname &optional direnv-env)
+                 (setq rpc-called t)
+                 (should (eq got-vec vec))
+                 (should (equal name "sudo-pty"))
+                 (should-not buffer)
+                 (should (equal command '("id")))
+                 (should-not coding)
+                 (should noquery)
+                 (should-not filter)
+                 (should-not sentinel)
+                 (should (equal localname "/root/"))
+                 (should-not direnv-env)
+                 'rpc-pty)))
+      (should (eq (tramp-rpc--make-pty-process
+                   vec "sudo-pty" nil '("id") nil t nil nil "/root/" nil)
+                  'rpc-pty))
+      (should rpc-called))))
+
 ;;; ============================================================================
 ;;; Direnv Cache Path Normalization Tests (No server or SSH required)
 ;;; ============================================================================


### PR DESCRIPTION
Keep Eshell sudo in rpc buffers as a remote sudo process instead of letting em-tramp rewrite it to a TRAMP sudo filename. Non-PTY sudo processes now use a stdin password wrapper, while PTY processes remain interactive so terminal sudo prompts still work.

Also carry the rpc hop's SSH user, port, proxy hops, and ControlMaster identity through sudo-via-RPC paths so deployment and server startup use the normal SSH connection before elevating privileges. Hidden native TRAMP rpc+sudo proxies are detected without handler recursion, and route normalization keeps connection keys, ProxyJump, deploy bootstrap, and ControlMaster identity aligned.

Review updates:
- Passworded sudo server starts now use `sudo -k -S` so sudo must consume the queued stdin password before the RPC server starts reading MessagePack frames.
- Non-PTY literal `sudo` processes authenticate in the same RPC pipe context; when a password is required they use `sudo -k -S -p ""` and queue the password before caller writes.
- Autoload and mock tests cover the hidden-sudo no-load assertion, exclusive sudo mode flags, and pipe-mode stdin password flow.

Validation:
- `TRAMP_SOURCE=/home/arthur/src/tramp ./test/run-autoload-tests.sh` (11 passed)
- `TRAMP_SOURCE=/tmp/does-not-exist-tramp ./test/run-autoload-tests.sh` fails fast with `TRAMP_SOURCE does not contain a lisp/ directory`
- `emacs -Q --batch --eval '(add-to-list (quote load-path) "/home/arthur/src/tramp/lisp")' -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-.*\\(sudo\\|doas\\|connection-type-nil\\)")'` (24 passed)
- Byte-compiled `lisp/*.el` with `byte-compile-error-on-warn` and `/home/arthur/src/tramp/lisp` on `load-path`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable sudo/proxy-aware RPC routing for multi-hop elevated connections.
* **Bug Fixes**
  * Improved detection and routing for sudo-over-RPC, with safer handling to avoid incorrect re-elevation.
  * Enhanced non-PTY literal `sudo` execution to correctly supply credentials via stdin while leaving PTY behavior unchanged.
  * Tightened connection identity, cleanup, and ControlMaster targeting to focus on managed elevated routes.
* **Tests**
  * Expanded autoload, routing, connection-key, and process-creation coverage for sudo/proxy scenarios.
* **Chores**
  * Updated the autoload test runner to support a configurable external TRAMP checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


