### PR TITLE
Fix TRAMP-RPC file notify monitor reporting

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -34,6 +34,7 @@
 ;; Functions from tramp.el
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
+(declare-function tramp-message "tramp-message")
 
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
@@ -249,6 +250,7 @@ DIRECTORY itself returns the empty string.  Descendants can contain slashes."
   (let ((events (alist-get 'events params)))
     (when events
       (tramp-rpc--debug "fs.events: %d events" (length events))
+      (tramp-message process 6 "%s" events)
       (when-let* ((vec (process-get process :tramp-rpc-vec)))
         (unless tramp-rpc--suppress-fs-notifications
           ;; Also clear the magit process-file cache since git state may have changed.

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -25,8 +25,19 @@
 (require 'cl-lib)
 (require 'msgpack)
 
+(declare-function tramp-message "tramp-message")
+
 (defvar tramp-rpc-protocol--request-id 0
   "Counter for generating unique request IDs.")
+
+(defvar tramp-rpc-protocol--message-target nil
+  "TRAMP vector or process used for level-6 protocol debug messages.")
+
+(defun tramp-rpc-protocol--message (object)
+  "Log OBJECT as a level-6 Tramp debug message when possible."
+  (when (and tramp-rpc-protocol--message-target
+             (fboundp 'tramp-message))
+    (tramp-message tramp-rpc-protocol--message-target 6 "%s" object)))
 
 (defun tramp-rpc-protocol--next-id ()
   "Generate the next request ID."
@@ -46,6 +57,7 @@ Returns a cons cell (ID . BYTES) for pipelining support."
                     (method . ,method)
                     (params . ,params)))
          (payload (msgpack-encode request)))
+    (tramp-rpc-protocol--message request)
     (cons id (tramp-rpc-protocol--length-prefix payload))))
 
 (defun tramp-rpc-protocol-decode-response (buffer start)
@@ -61,21 +73,24 @@ with :notification t, :method, and :params keys."
 	    (goto-char start)
 	    (msgpack-read)))
          (id (alist-get 'id response))
-         (method (alist-get 'method response)))
-    ;; Notifications have method but no id (JSON-RPC 2.0 spec)
-    (if (and method (not id))
-        (list :notification t
-              :method method
-              :params (alist-get 'params response))
-      ;; Normal response
-      (let ((result (alist-get 'result response))
-            (error-obj (alist-get 'error response)))
-        (list :id id
-              :result result
-              :error (when error-obj
-                       (list :code (alist-get 'code error-obj)
-                             :message (alist-get 'message error-obj)
-                             :data (alist-get 'data error-obj))))))))
+         (method (alist-get 'method response))
+         (result
+          ;; Notifications have method but no id (JSON-RPC 2.0 spec)
+          (if (and method (not id))
+              (list :notification t
+                    :method method
+                    :params (alist-get 'params response))
+            ;; Normal response
+            (let ((result (alist-get 'result response))
+                  (error-obj (alist-get 'error response)))
+              (list :id id
+                    :result result
+                    :error (when error-obj
+                             (list :code (alist-get 'code error-obj)
+                                   :message (alist-get 'message error-obj)
+                                   :data (alist-get 'data error-obj))))))))
+    (tramp-rpc-protocol--message result)
+    result))
 
 (defun tramp-rpc-protocol-error-p (response)
   "Return non-nil if RESPONSE contains an error."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1356,27 +1356,28 @@ Uses length-prefixed binary framing: <4-byte BE length><msgpack payload>."
                           (length output) (buffer-size))
         ;; Process complete messages
         (goto-char (point-min))
-        (while (setq response (tramp-rpc-protocol-try-read-message buffer))
-          ;; Replace buffer contents with remaining data
-          (delete-region (point-min) (mark-marker))
-          (goto-char (point-min))
-          ;; Check for server-initiated notification (no id, has method)
-          (if (plist-get response :notification)
-              (tramp-rpc--handle-notification
-               process
-               (plist-get response :method)
-               (plist-get response :params))
-            ;; Handle normal response
-            (let* ((id (plist-get response :id))
-                   (callback (gethash id tramp-rpc--async-callbacks)))
-              (if callback
-                  (progn
-                    (tramp-rpc--debug "FILTER dispatching async id=%s" id)
-                    (remhash id tramp-rpc--async-callbacks)
-                    (funcall callback response))
-                ;; Not an async response - store for sync code
-                (tramp-rpc--debug "FILTER storing sync response id=%s" id)
-                (puthash id response (tramp-rpc--get-pending-responses buffer))))))))))
+        (let ((tramp-rpc-protocol--message-target process))
+          (while (setq response (tramp-rpc-protocol-try-read-message buffer))
+            ;; Replace buffer contents with remaining data
+            (delete-region (point-min) (mark-marker))
+            (goto-char (point-min))
+            ;; Check for server-initiated notification (no id, has method)
+            (if (plist-get response :notification)
+                (tramp-rpc--handle-notification
+                 process
+                 (plist-get response :method)
+                 (plist-get response :params))
+              ;; Handle normal response
+              (let* ((id (plist-get response :id))
+                     (callback (gethash id tramp-rpc--async-callbacks)))
+                (if callback
+                    (progn
+                      (tramp-rpc--debug "FILTER dispatching async id=%s" id)
+                      (remhash id tramp-rpc--async-callbacks)
+                      (funcall callback response))
+                  ;; Not an async response - store for sync code
+                  (tramp-rpc--debug "FILTER storing sync response id=%s" id)
+                  (puthash id response (tramp-rpc--get-pending-responses buffer)))))))))))
 
 (defun tramp-rpc--call-async (vec method params callback)
   "Call METHOD with PARAMS asynchronously on the RPC server for VEC.
@@ -1384,7 +1385,9 @@ CALLBACK is called with the response plist when it arrives.
 Returns the request ID."
   (let* ((conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
-         (id-and-request (tramp-rpc-protocol-encode-request-with-id method params))
+         (id-and-request (let ((tramp-rpc-protocol--message-target process))
+                           (tramp-rpc-protocol-encode-request-with-id
+                            method params)))
          (id (car id-and-request))
          (request (cdr id-and-request)))
     (tramp-rpc--debug "SEND-ASYNC id=%s method=%s" id method)
@@ -1451,7 +1454,9 @@ Returns the result or signals an error."
   (let* ((conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
-         (id-and-request (tramp-rpc-protocol-encode-request-with-id method params))
+         (id-and-request (let ((tramp-rpc-protocol--message-target process))
+                           (tramp-rpc-protocol-encode-request-with-id
+                            method params)))
          (expected-id (car id-and-request))
          (request (cdr id-and-request)))
 
@@ -1577,7 +1582,9 @@ Returns:
   (let* ((conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
-         (id-and-request (tramp-rpc-protocol-encode-batch-request-with-id requests))
+         (id-and-request (let ((tramp-rpc-protocol--message-target process))
+                           (tramp-rpc-protocol-encode-batch-request-with-id
+                            requests)))
          (expected-id (car id-and-request))
          (request (cdr id-and-request)))
 
@@ -1656,8 +1663,9 @@ Returns a list of request IDs in the same order."
          (process (plist-get conn :process))
          ids)
     (dolist (req requests)
-      (let* ((id-and-bytes (tramp-rpc-protocol-encode-request-with-id
-                            (car req) (cdr req)))
+      (let* ((id-and-bytes (let ((tramp-rpc-protocol--message-target process))
+                             (tramp-rpc-protocol-encode-request-with-id
+                              (car req) (cdr req))))
              (id (car id-and-bytes))
              (bytes (cdr id-and-bytes)))
         (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
@@ -1980,11 +1988,20 @@ errors instead of probing first."
 (defun tramp-rpc-handle-set-file-times (filename &optional timestamp flag)
   "Like `set-file-times' for TRAMP-RPC files."
   (tramp-rpc--with-set-file-attributes-rpc filename
-    (let ((mtime (floor (float-time (or timestamp (current-time))))))
-      (tramp-rpc--call v "file.set_times"
-                       (append (tramp-rpc--encode-path localname)
-                               `((mtime . ,mtime)
-                                 (nofollow . ,(if flag t :msgpack-false))))))))
+    (let* ((mtime (floor (float-time (or timestamp (current-time)))))
+           (tramp-name (tramp-make-tramp-file-name v localname))
+           (result
+            (tramp-rpc--call v "file.set_times"
+                             (append (tramp-rpc--encode-path localname)
+                                     `((mtime . ,mtime)
+                                       (nofollow . ,(if flag t :msgpack-false)))))))
+      ;; Synthetic symlink watches intentionally do not install a server watch,
+      ;; because the notify backend follows symlink watch paths.  Attribute
+      ;; changes made through this handler are the one symlink event we can
+      ;; report precisely without watching the target.
+      (when (and flag (tramp-rpc--file-notify-synthetic-watch-p tramp-name))
+        (tramp-rpc--file-notify-dispatch "attribute-changed" tramp-name))
+      result)))
 
 
 ;; ============================================================================
@@ -3671,8 +3688,31 @@ would otherwise flood the echo area with \"Cannot expand tilde\"."
   "Reference counts for directories watched via file notifications.
 Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
 
+(defvar tramp-rpc-protocol--message-target)
+
 (declare-function file-notify--rm-descriptor "filenotify")
 (declare-function file-notify-rm-watch "filenotify")
+
+(defun tramp-rpc--file-notify-monitor (vec)
+  "Return the file notification monitor symbol for VEC."
+  (let* ((info (ignore-errors (tramp-rpc--system-info vec)))
+         (watcher (and (listp info)
+                       (tramp-rpc--decode-string (alist-get 'watcher info))))
+         (os (and (listp info)
+                  (tramp-rpc--decode-string (alist-get 'os info)))))
+    (pcase watcher
+      ("inotify" 'TrampRPCinotify)
+      ("kqueue" 'TrampRPCkqueue)
+      ("fsevent" 'TrampRPCfsevent)
+      ("poll" 'TrampRPCpoll)
+      ((pred null)
+       (pcase os
+         ("linux" 'TrampRPCinotify)
+         ((or "freebsd" "openbsd" "netbsd" "dragonfly" "ios")
+          'TrampRPCkqueue)
+         ("macos" 'TrampRPCfsevent)
+         (_ 'TrampRPC)))
+      (_ 'TrampRPC))))
 
 (defun tramp-rpc--file-notify-process-sentinel (descriptor event)
   "Clean up file notification DESCRIPTOR after EVENT closes it."
@@ -3686,10 +3726,9 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
 (defun tramp-rpc--make-file-notify-descriptor (vec _directory localname)
   "Create a TRAMP-style process descriptor for a file notification watch."
   (let* (;; Emacs' remote file notification tests use the process name to
-         ;; identify the remote backend and inject synthetic backend events.
-         ;; TRAMP-RPC's server uses the notify crate; on GNU/Linux its behavior
-         ;; is closest to TRAMP's inotifywait backend.
-         (name "inotifywait")
+         ;; identify the remote library.  The concrete backend is exposed via
+         ;; the "file-monitor" connection property below.
+         (name "tramp-rpc")
          ;; This synthetic process is only a watch descriptor; it never
          ;; receives output.  Do not attach a buffer: `global-auto-revert-mode'
          ;; iterates over `buffer-list' while removing file notification
@@ -3703,6 +3742,10 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
     ;; validity helpers expect on watch descriptors.
     (process-put descriptor 'tramp-vector vec)
     (process-put descriptor 'tramp-watch-name localname)
+    ;; Match gio/smb-notify: tests can use the library name for broad behavior
+    ;; and this property for backend-specific expectations.
+    (tramp-set-connection-property
+     descriptor "file-monitor" (tramp-rpc--file-notify-monitor vec))
     ;; RPC-private metadata lives in `tramp-rpc--file-notify-descriptors', but
     ;; mark the process as ours for debugging and defensive cleanup.
     (process-put descriptor 'tramp-rpc-file-notify t)
@@ -3918,6 +3961,22 @@ we cannot derive one."
              (tramp-rpc--file-notify-direct-child-p
               canonical-directory file-name)))))
 
+(defun tramp-rpc--file-notify-synthetic-watch-p (file-name)
+  "Return non-nil if FILE-NAME is covered by a synthetic symlink watch."
+  (let (matched)
+    (when (hash-table-p tramp-rpc--file-notify-descriptors)
+      (maphash
+       (lambda (_descriptor data)
+         (let* ((watch-key (plist-get data :watch-key))
+                (entry (and watch-key
+                            (gethash watch-key
+                                     tramp-rpc--file-notify-watch-counts))))
+           (when (and (plist-get entry :synthetic)
+                      (tramp-rpc--file-notify-path-matches-p data file-name))
+             (setq matched t))))
+       tramp-rpc--file-notify-descriptors))
+    matched))
+
 (defun tramp-rpc--file-notify-dispatch (action file-name &optional file-name1 cookie)
   "Dispatch a `file-notify' ACTION for TRAMP FILE-NAME.
 FILE-NAME1 is the destination for `renamed' events.  COOKIE pairs
@@ -3972,6 +4031,10 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                               localname))
            (entry (gethash watch-key tramp-rpc--file-notify-watch-counts))
            (preexisting (gethash watch-key tramp-rpc--watched-directories))
+           ;; file-notify does not follow symlinks.  Ask the server for a
+           ;; nofollow symlink watch when needed, falling back to a synthetic
+           ;; client-side descriptor on platforms without nofollow support.
+           (symlink-watch (ignore-errors (file-symlink-p directory)))
            (descriptor (tramp-rpc--make-file-notify-descriptor
                         v directory localname)))
       (if entry
@@ -3980,10 +4043,30 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
         ;; `tramp-rpc--watched-directories'.  That table is also used by Magit
         ;; and cache invalidation, where a truthy entry means a recursive
         ;; worktree/cache watch may already exist.
-        (let* ((result (unless preexisting
+        (let* ((synthetic nil)
+               (result (cond
+                        (symlink-watch
+                         (if preexisting
+                             (progn
+                               (setq synthetic symlink-watch)
+                               nil)
+                           (condition-case err
+                               (tramp-rpc--call
+                                v "watch.add"
+                                `((path . ,localname)
+                                  (recursive . :msgpack-false)
+                                  (nofollow . t)))
+                             (error
+                              (setq synthetic symlink-watch)
+                              (tramp-rpc--debug
+                               "nofollow file-notify watch unsupported for %s: %s"
+                               directory (error-message-string err))
+                              nil))))
+                        (preexisting nil)
+                        (t
                          (tramp-rpc--call v "watch.add"
                                           `((path . ,localname)
-                                            (recursive . :msgpack-false)))))
+                                            (recursive . :msgpack-false))))))
                (canonical-localname (and (listp result)
                                          (alist-get 'path result)))
                (canonical-directory (cond
@@ -4003,7 +4086,8 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                                         (file-truename directory))))))
           (puthash watch-key
                    (list :count 1
-                         :owned (not preexisting)
+                         :owned (and (not preexisting) (not synthetic))
+                         :synthetic synthetic
                          :directory directory
                          :canonical-directory canonical-directory)
                    tramp-rpc--file-notify-watch-counts)))

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -35,6 +35,7 @@ fn system_info() -> HandlerResult {
         "version" => env!("CARGO_PKG_VERSION"),
         "os" => std::env::consts::OS,
         "arch" => std::env::consts::ARCH,
+        "watcher" => watcher_kind(),
         "hostname" => hostname(),
         "uid" => unsafe { libc::getuid() },
         "gid" => unsafe { libc::getgid() },
@@ -42,6 +43,20 @@ fn system_info() -> HandlerResult {
         "user" => env::var("USER").ok().into_value(),
         "shell" => login_shell().into_value()
     })
+}
+
+fn watcher_kind() -> &'static str {
+    use notify::{RecommendedWatcher, Watcher, WatcherKind};
+
+    match RecommendedWatcher::kind() {
+        WatcherKind::Inotify => "inotify",
+        WatcherKind::Fsevent => "fsevent",
+        WatcherKind::Kqueue => "kqueue",
+        WatcherKind::PollWatcher => "poll",
+        WatcherKind::ReadDirectoryChangesWatcher => "windows",
+        WatcherKind::NullWatcher => "null",
+        _ => "unknown",
+    }
 }
 
 /// Look up the current user's login shell from the passwd database.

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -342,8 +342,252 @@ impl WatchEvent {
     }
 }
 
+enum WatchInput {
+    Notify(Event),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Direct(Vec<WatchEvent>),
+}
+
 fn path_to_value(path: &Path) -> Value {
     Value::String(path.to_string_lossy().into_owned().into())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+struct NofollowSymlinkWatcher {
+    fd: libc::c_int,
+    watches: HashMap<PathBuf, SymlinkWatchEntry>,
+    wd_to_path: Arc<Mutex<HashMap<libc::c_int, PathBuf>>>,
+    ignored_wds: Arc<Mutex<HashSet<libc::c_int>>>,
+    running: Arc<std::sync::atomic::AtomicBool>,
+    reader: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Debug, Clone, Copy)]
+struct SymlinkWatchEntry {
+    wd: libc::c_int,
+    count: usize,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl NofollowSymlinkWatcher {
+    fn new(tx: mpsc::UnboundedSender<WatchInput>) -> Result<Self, notify::Error> {
+        let fd = unsafe { libc::inotify_init1(libc::IN_NONBLOCK | libc::IN_CLOEXEC) };
+        if fd < 0 {
+            return Err(notify::Error::io(std::io::Error::last_os_error()));
+        }
+
+        let wd_to_path = Arc::new(Mutex::new(HashMap::new()));
+        let ignored_wds = Arc::new(Mutex::new(HashSet::new()));
+        let running = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let reader = Some(spawn_nofollow_reader(
+            fd,
+            Arc::clone(&wd_to_path),
+            Arc::clone(&ignored_wds),
+            Arc::clone(&running),
+            tx,
+        ));
+
+        Ok(Self {
+            fd,
+            watches: HashMap::new(),
+            wd_to_path,
+            ignored_wds,
+            running,
+            reader,
+        })
+    }
+
+    fn contains(&mut self, path: &Path) -> bool {
+        self.purge_ignored();
+        self.watches.contains_key(path)
+    }
+
+    fn watch(&mut self, path: &Path) -> Result<PathBuf, notify::Error> {
+        self.purge_ignored();
+        let path = path.to_path_buf();
+        if let Some(entry) = self.watches.get_mut(&path) {
+            entry.count += 1;
+            return Ok(path);
+        }
+
+        let metadata = std::fs::symlink_metadata(&path)
+            .map_err(|err| notify::Error::io(err).add_path(path.clone()))?;
+        if !metadata.file_type().is_symlink() {
+            return Err(notify::Error::generic(&format!(
+                "nofollow watch path is not a symlink: {}",
+                path.display()
+            )));
+        }
+
+        let c_path = path_to_cstring(&path)?;
+        // Only request symlink metadata changes.  Emacs' symlink tests expect
+        // no target events and no event when the symlink is deleted as part of
+        // cleanup, but do expect `set-file-times' with nofollow to report an
+        // attribute change.
+        let mask = libc::IN_ATTRIB | libc::IN_DONT_FOLLOW;
+        let wd = unsafe { libc::inotify_add_watch(self.fd, c_path.as_ptr(), mask) };
+        if wd < 0 {
+            return Err(notify::Error::io(std::io::Error::last_os_error()).add_path(path));
+        }
+
+        self.watches
+            .insert(path.clone(), SymlinkWatchEntry { wd, count: 1 });
+        lock_or_recover(&self.wd_to_path).insert(wd, path.clone());
+        Ok(path)
+    }
+
+    fn unwatch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        self.purge_ignored();
+        let Some(entry) = self.watches.get_mut(path) else {
+            return Err(notify::Error::watch_not_found().add_path(path.to_path_buf()));
+        };
+
+        if entry.count > 1 {
+            entry.count -= 1;
+            return Ok(());
+        }
+
+        let wd = entry.wd;
+        if unsafe { libc::inotify_rm_watch(self.fd, wd) } < 0 {
+            return Err(
+                notify::Error::io(std::io::Error::last_os_error()).add_path(path.to_path_buf())
+            );
+        }
+
+        self.watches.remove(path);
+        lock_or_recover(&self.wd_to_path).remove(&wd);
+        Ok(())
+    }
+
+    fn purge_ignored(&mut self) {
+        let ignored: Vec<_> = lock_or_recover(&self.ignored_wds).drain().collect();
+        if ignored.is_empty() {
+            return;
+        }
+
+        let mut wd_to_path = lock_or_recover(&self.wd_to_path);
+        for wd in ignored {
+            if let Some(path) = self
+                .watches
+                .iter()
+                .find_map(|(path, entry)| (entry.wd == wd).then(|| path.clone()))
+            {
+                self.watches.remove(&path);
+            }
+            wd_to_path.remove(&wd);
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl Drop for NofollowSymlinkWatcher {
+    fn drop(&mut self) {
+        self.running
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn path_to_cstring(path: &Path) -> Result<std::ffi::CString, notify::Error> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| notify::Error::generic(&format!("path contains NUL: {}", path.display())))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn spawn_nofollow_reader(
+    fd: libc::c_int,
+    wd_to_path: Arc<Mutex<HashMap<libc::c_int, PathBuf>>>,
+    ignored_wds: Arc<Mutex<HashSet<libc::c_int>>>,
+    running: Arc<std::sync::atomic::AtomicBool>,
+    tx: mpsc::UnboundedSender<WatchInput>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut buf = vec![0_u8; 4096];
+        while running.load(std::sync::atomic::Ordering::Relaxed) {
+            let len = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+            if len > 0 {
+                emit_nofollow_events(&buf[..len as usize], &wd_to_path, &ignored_wds, &tx);
+                continue;
+            }
+
+            if len < 0 {
+                let err = std::io::Error::last_os_error();
+                match err.raw_os_error() {
+                    Some(libc::EAGAIN) | Some(libc::EINTR) => {}
+                    _ => break,
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn emit_nofollow_events(
+    bytes: &[u8],
+    wd_to_path: &Mutex<HashMap<libc::c_int, PathBuf>>,
+    ignored_wds: &Mutex<HashSet<libc::c_int>>,
+    tx: &mpsc::UnboundedSender<WatchInput>,
+) {
+    let event_size = std::mem::size_of::<libc::inotify_event>();
+    let mut offset = 0;
+    while offset + event_size <= bytes.len() {
+        let event = unsafe {
+            std::ptr::read_unaligned(bytes.as_ptr().add(offset).cast::<libc::inotify_event>())
+        };
+        offset += event_size + event.len as usize;
+
+        let mut paths = lock_or_recover(wd_to_path);
+        let path = paths.get(&event.wd).cloned();
+        if event.mask & libc::IN_IGNORED != 0 {
+            paths.remove(&event.wd);
+            lock_or_recover(ignored_wds).insert(event.wd);
+        }
+        drop(paths);
+
+        if event.mask & libc::IN_ATTRIB != 0 {
+            if let Some(path) = path {
+                let _ = tx.send(WatchInput::Direct(vec![WatchEvent::path(
+                    "attribute-changed",
+                    path,
+                )]));
+            }
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+struct NofollowSymlinkWatcher;
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+impl NofollowSymlinkWatcher {
+    fn new(_tx: mpsc::UnboundedSender<WatchInput>) -> Result<Self, notify::Error> {
+        Ok(Self)
+    }
+
+    fn contains(&mut self, _path: &Path) -> bool {
+        false
+    }
+
+    fn watch(&mut self, path: &Path) -> Result<PathBuf, notify::Error> {
+        Err(notify::Error::generic(&format!(
+            "nofollow symlink watches are not supported on this platform: {}",
+            path.display()
+        )))
+    }
+
+    fn unwatch(&mut self, path: &Path) -> Result<(), notify::Error> {
+        Err(notify::Error::watch_not_found().add_path(path.to_path_buf()))
+    }
 }
 
 /// Manages filesystem watchers and sends change notifications to the client.
@@ -358,6 +602,9 @@ pub struct WatchManager {
     /// that unwatch() doesn't need to re-canonicalize (which would fail if
     /// the directory has been deleted).
     watched_paths: Mutex<HashMap<PathBuf, RecursiveMode>>,
+
+    /// Nofollow symlink watches for file-notify descriptors.
+    symlink_watcher: Mutex<Option<NofollowSymlinkWatcher>>,
 }
 
 impl WatchManager {
@@ -368,6 +615,7 @@ impl WatchManager {
     /// via the shared stdout writer.
     pub fn new(writer: WriterHandle) -> Result<Arc<Self>, notify::Error> {
         let (tx, rx) = mpsc::unbounded_channel();
+        let notify_tx = tx.clone();
 
         let watcher = FilteredWatcher::new(move |event: notify::Result<Event>| {
             if let Ok(event) = event {
@@ -378,7 +626,7 @@ impl WatchManager {
                 {
                     // Topology events cannot be dropped, and blocking here can
                     // deadlock notify's watch/unwatch event loop.
-                    let _ = tx.send(event);
+                    let _ = notify_tx.send(WatchInput::Notify(event));
                 }
             }
         })?;
@@ -386,6 +634,7 @@ impl WatchManager {
         let manager = Arc::new(Self {
             watcher: Mutex::new(watcher),
             watched_paths: Mutex::new(HashMap::new()),
+            symlink_watcher: Mutex::new(NofollowSymlinkWatcher::new(tx).ok()),
         });
 
         // Spawn the debounce background task
@@ -402,6 +651,26 @@ impl WatchManager {
     ///
     /// Repeated watches are idempotent; non-recursive watches can be upgraded.
     pub fn watch(&self, path: &Path, recursive: bool) -> Result<PathBuf, notify::Error> {
+        self.watch_with_options(path, recursive, false)
+    }
+
+    /// Start watching a path, optionally without following a symlink path.
+    pub fn watch_with_options(
+        &self,
+        path: &Path,
+        recursive: bool,
+        nofollow: bool,
+    ) -> Result<PathBuf, notify::Error> {
+        if nofollow {
+            let mut watcher = lock_or_recover(&self.symlink_watcher);
+            let Some(watcher) = watcher.as_mut() else {
+                return Err(notify::Error::generic(
+                    "nofollow symlink watches are not available",
+                ));
+            };
+            return watcher.watch(path);
+        }
+
         let mode = if recursive {
             RecursiveMode::Recursive
         } else {
@@ -447,6 +716,15 @@ impl WatchManager {
     ///
     /// Lock ordering: watcher -> watched_paths (same as watch()).
     pub fn unwatch(&self, path: &Path) -> Result<(), notify::Error> {
+        {
+            let mut symlink_watcher = lock_or_recover(&self.symlink_watcher);
+            if let Some(watcher) = symlink_watcher.as_mut() {
+                if watcher.contains(path) {
+                    return watcher.unwatch(path);
+                }
+            }
+        }
+
         // Try to canonicalize, but fall back to the raw path
         let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
@@ -724,7 +1002,7 @@ fn paths_as_events<'paths>(
 /// 4. When the timer fires, send one notification with all collected events
 /// 5. Go back to step 1
 async fn debounce_loop(
-    mut rx: mpsc::UnboundedReceiver<Event>,
+    mut rx: mpsc::UnboundedReceiver<WatchInput>,
     writer: WriterHandle,
     manager: Weak<WatchManager>,
 ) {
@@ -738,7 +1016,7 @@ async fn debounce_loop(
         let mut pending_events: Vec<WatchEvent> = Vec::new();
         let mut roots_to_refresh: HashSet<PathBuf> = HashSet::new();
         let mut suspect_paths: HashSet<PathBuf> = HashSet::new();
-        collect_event(
+        collect_input(
             event,
             &manager,
             &mut pending_events,
@@ -756,7 +1034,7 @@ async fn debounce_loop(
                 event = rx.recv() => {
                     match event {
                         Some(e) => {
-                            collect_event(
+                            collect_input(
                                 e,
                                 &manager,
                                 &mut pending_events,
@@ -785,19 +1063,25 @@ async fn debounce_loop(
     }
 }
 
-fn collect_event(
-    event: Event,
+fn collect_input(
+    input: WatchInput,
     manager: &Weak<WatchManager>,
     pending_events: &mut Vec<WatchEvent>,
     roots_to_refresh: &mut HashSet<PathBuf>,
     suspect_paths: &mut HashSet<PathBuf>,
 ) {
-    if let Some(manager) = manager.upgrade() {
-        roots_to_refresh.extend(manager.recursive_roots_for_event(&event));
-    }
+    match input {
+        WatchInput::Notify(event) => {
+            if let Some(manager) = manager.upgrade() {
+                roots_to_refresh.extend(manager.recursive_roots_for_event(&event));
+            }
 
-    suspect_paths.extend(inode_replacing_paths(&event));
-    pending_events.extend(event_to_watch_events(&event));
+            suspect_paths.extend(inode_replacing_paths(&event));
+            pending_events.extend(event_to_watch_events(&event));
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        WatchInput::Direct(events) => pending_events.extend(events),
+    }
 }
 
 fn fs_events_notification(events: &[WatchEvent]) -> Notification {
@@ -837,13 +1121,16 @@ use crate::handlers::HandlerResult;
 
 /// Handle `watch.add` - start watching a directory for changes.
 ///
-/// Params: { "path": "/path/to/dir", "recursive": true|false }
+/// Params: { "path": "/path/to/dir", "recursive": true|false,
+/// "nofollow": true|false }
 pub fn handle_add(params: Value) -> HandlerResult {
     #[derive(serde::Deserialize)]
     struct Params {
         path: String,
         #[serde(default = "default_recursive")]
         recursive: bool,
+        #[serde(default)]
+        nofollow: bool,
     }
     fn default_recursive() -> bool {
         true
@@ -855,13 +1142,17 @@ pub fn handle_add(params: Value) -> HandlerResult {
 
     let manager = get().ok_or_else(|| RpcError::internal_error("File watcher not available"))?;
 
-    let canonical = manager
-        .watch(Path::new(&expanded), params.recursive)
-        .map_err(|e| RpcError::internal_error(format!("Failed to watch: {}", e)))?;
+    let canonical = if params.nofollow {
+        manager.watch_with_options(Path::new(&expanded), params.recursive, true)
+    } else {
+        manager.watch(Path::new(&expanded), params.recursive)
+    }
+    .map_err(|e| RpcError::internal_error(format!("Failed to watch: {}", e)))?;
 
     Ok(msgpack_map! {
         "path" => canonical.to_string_lossy().into_owned(),
-        "recursive" => Value::Boolean(params.recursive)
+        "recursive" => Value::Boolean(params.recursive),
+        "nofollow" => Value::Boolean(params.nofollow)
     })
 }
 
@@ -918,9 +1209,11 @@ mod tests {
     use std::time::{Duration, Instant};
 
     fn test_manager() -> WatchManager {
+        let (tx, _rx) = mpsc::unbounded_channel();
         WatchManager {
             watcher: Mutex::new(FilteredWatcher::new(|_: notify::Result<Event>| {}).unwrap()),
             watched_paths: Mutex::new(HashMap::new()),
+            symlink_watcher: Mutex::new(NofollowSymlinkWatcher::new(tx).ok()),
         }
     }
 
@@ -965,6 +1258,76 @@ mod tests {
                 &Event::new(EventKind::Remove(RemoveKind::File)).add_path(path.clone())
             ),
             vec![WatchEvent::path("deleted", path)]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_nofollow_symlink_watch_reports_link_attribute_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        fs::write(&target, "target").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut watcher = NofollowSymlinkWatcher::new(tx).unwrap();
+        assert_eq!(watcher.watch(&link).unwrap(), link);
+
+        fs::write(&target, "changed").unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(
+            rx.try_recv().is_err(),
+            "target changes must not be reported"
+        );
+
+        set_symlink_mtime(&link, 1);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut found = false;
+        while Instant::now() < deadline {
+            match rx.try_recv() {
+                Ok(WatchInput::Direct(events)) => {
+                    found |= events.iter().any(|event| {
+                        event.action == "attribute-changed" && event.path.as_ref() == Some(&link)
+                    });
+                    if found {
+                        break;
+                    }
+                }
+                Ok(WatchInput::Notify(_)) => {}
+                Err(_) => std::thread::sleep(Duration::from_millis(25)),
+            }
+        }
+
+        assert!(found, "symlink metadata changes should be reported");
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_symlink_mtime(path: &Path, seconds: libc::time_t) {
+        let c_path = path_to_cstring(path).unwrap();
+        let times = [
+            libc::timespec {
+                tv_sec: seconds,
+                tv_nsec: 0,
+            },
+            libc::timespec {
+                tv_sec: seconds,
+                tv_nsec: 0,
+            },
+        ];
+        let ret = unsafe {
+            libc::utimensat(
+                libc::AT_FDCWD,
+                c_path.as_ptr(),
+                times.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        assert_eq!(
+            ret,
+            0,
+            "utimensat failed: {}",
+            std::io::Error::last_os_error()
         );
     }
 
@@ -1523,6 +1886,7 @@ mod tests {
                 .unwrap(),
             ),
             watched_paths: Mutex::new(HashMap::new()),
+            symlink_watcher: Mutex::new(None),
         };
         manager.watch(&root, true).unwrap();
 
@@ -1589,6 +1953,7 @@ mod tests {
                 .unwrap(),
             ),
             watched_paths: Mutex::new(HashMap::new()),
+            symlink_watcher: Mutex::new(None),
         };
         manager.watch(&root, true).unwrap();
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -393,6 +393,9 @@ Returns the result or signals an error."
           (should (assoc 'uid result))
           (should (assoc 'gid result))
           (should (assoc 'home result))
+          (should (member (alist-get 'watcher result)
+                          '("inotify" "fsevent" "kqueue" "poll"
+                            "windows" "null" "unknown")))
           ;; shell field should be present and be a string
           (should (assoc 'shell result))
           (let ((shell (alist-get 'shell result)))
@@ -762,6 +765,111 @@ This matches the behavior expected by `tramp-test28-process-file'."
   "Return non-nil when the sudo path helpers needed by this test are available."
   (and (require 'tramp-cmds nil t)
        (fboundp 'tramp-file-name-with-sudo)))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-descriptor-monitor-name ()
+  "File notification descriptors expose library and monitor names for tests."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
+         descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--system-info)
+                   (lambda (_vec) '((os . "linux") (watcher . "inotify")))))
+          (setq descriptor
+                (tramp-rpc--make-file-notify-descriptor
+                 vec "/rpc:mock:/tmp/" "/tmp/"))
+          (should (string-equal (process-name descriptor) "tramp-rpc"))
+          (should (eq (tramp-get-connection-property
+                       descriptor "file-monitor" nil)
+                      'TrampRPCinotify)))
+      (when descriptor
+        (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-symlink-requests-nofollow-watch ()
+  "File notification watches on symlinks request nofollow server watches."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (directory "/rpc:mock:/tmp/link")
+         (vec (tramp-dissect-file-name directory))
+         (watch-key (format "%s:%s" (tramp-rpc--connection-key-string vec)
+                            "/tmp/link"))
+         calls
+         descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'file-symlink-p)
+                   (lambda (_filename) "/tmp/real"))
+                  ((symbol-function 'tramp-rpc--system-info)
+                   (lambda (_vec) '((os . "linux") (watcher . "inotify"))))
+                  ((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method params)
+                     (push (list method params) calls)
+                     '((path . "/tmp/link"))))
+                  ((symbol-function 'tramp-rpc-unwatch-directory)
+                   (lambda (directory)
+                     (push (list "watch.remove" directory) calls))))
+          (setq descriptor
+                (tramp-rpc-handle-file-notify-add-watch
+                 directory '(change attribute-change) #'ignore))
+          (let ((entry (gethash watch-key tramp-rpc--file-notify-watch-counts)))
+            (should entry)
+            (should-not (plist-get entry :synthetic))
+            (should (plist-get entry :owned))
+            (should (string= (plist-get entry :canonical-directory)
+                             "/rpc:mock:/tmp/link")))
+          (let ((watch-add (car (last calls))))
+            (should (equal (car watch-add) "watch.add"))
+            (should (eq (alist-get 'nofollow (cadr watch-add)) t))
+            (should (eq (alist-get 'recursive (cadr watch-add))
+                        :msgpack-false)))
+          (tramp-rpc-handle-file-notify-rm-watch descriptor)
+          (setq descriptor nil)
+          (should (equal (caar calls) "watch.remove")))
+      (when descriptor
+        (remhash descriptor tramp-rpc--file-notify-descriptors)
+        (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
+
+(ert-deftest tramp-rpc-mock-test-file-notify-symlink-falls-back-to-synthetic ()
+  "Symlink file notification watches stay synthetic without server support."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'filenotify)
+  (let* ((tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (directory "/rpc:mock:/tmp/link")
+         (vec (tramp-dissect-file-name directory))
+         (watch-key (format "%s:%s" (tramp-rpc--connection-key-string vec)
+                            "/tmp/link"))
+         calls
+         descriptor)
+    (unwind-protect
+        (cl-letf (((symbol-function 'file-symlink-p)
+                   (lambda (_filename) "/tmp/real"))
+                  ((symbol-function 'tramp-rpc--system-info)
+                   (lambda (_vec) '((os . "linux") (watcher . "inotify"))))
+                  ((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params)
+                     (push method calls)
+                     (signal 'remote-file-error '("nofollow unsupported"))))
+                  ((symbol-function 'tramp-rpc-unwatch-directory)
+                   (lambda (_directory)
+                     (push "watch.remove" calls))))
+          (setq descriptor
+                (tramp-rpc-handle-file-notify-add-watch
+                 directory '(change attribute-change) #'ignore))
+          (let ((entry (gethash watch-key tramp-rpc--file-notify-watch-counts)))
+            (should entry)
+            (should (plist-get entry :synthetic))
+            (should-not (plist-get entry :owned))
+            (should-not (plist-get entry :canonical-directory)))
+          (should (equal calls '("watch.add")))
+          (tramp-rpc-handle-file-notify-rm-watch descriptor)
+          (setq descriptor nil)
+          (should (equal calls '("watch.add"))))
+      (when descriptor
+        (remhash descriptor tramp-rpc--file-notify-descriptors)
+        (tramp-rpc--delete-file-notify-descriptor-process descriptor)))))
 
 (ert-deftest tramp-rpc-mock-test-file-notify-suppression-still-dispatches ()
   "fs.events suppression skips cache work but still dispatches file notifications."


### PR DESCRIPTION
## Summary
- apply Michael's level-6 Tramp debug logging for RPC requests, responses, and fs.events
- expose TRAMP-RPC file notification descriptors as `tramp-rpc` with a concrete `file-monitor` property
- add server-side Linux nofollow symlink watches via raw inotify `IN_DONT_FOLLOW`
- fall back to synthetic symlink descriptors on platforms without nofollow support
- report the Rust notify backend through `system.info` and cover the behavior in mock/server tests
- address CodeRabbit findings around explicit watcher names, normalized synthetic paths, preexisting symlink watches, and drop ordering

## Tests
- `cargo +stable fmt --check`
- `cargo +stable check`
- `RUSTFLAGS='-D warnings' cargo +stable check`
- `cargo +stable test`
- `cargo +stable build --release`
- `emacs -Q --batch -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "^tramp-rpc-mock-test-\\(protocol\\|server\\)")'`
- byte-compiled `lisp/*.el` with `byte-compile-error-on-warn`
- `check-parens` on modified Elisp files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime reporting of the active filesystem watcher backend to the server.
  * Extended file-notify watch support with optional `nofollow` handling for symlink watches, including server capability-driven fallback.
  * Added optional debug logging of request/response MessagePack-RPC payloads.

* **Bug Fixes**
  * Made RPC message routing and logging consistent across all request encoding paths.
  * Ensured synthetic symlink watches handle attribute changes via `attribute-changed` events.

* **Tests**
  * Expanded mock and TRAMP file-notify coverage for monitor selection, `nofollow`, synthetic behavior, and watcher reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->