### PR TITLE
fix: start interactive RPC shells as login shells

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -48,6 +48,7 @@
 (declare-function tramp-rpc--call-fast "tramp-rpc")
 (declare-function tramp-rpc--call-async "tramp-rpc")
 (declare-function tramp-rpc--get-direnv-environment "tramp-rpc")
+(declare-function tramp-rpc--get-remote-login-shell "tramp-rpc")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
@@ -460,6 +461,28 @@ pair is a symbol."
         (cons decoding encoding))))
    (t coding)))
 
+(defun tramp-rpc--maybe-login-shell-command (vec command)
+  "Add login-shell args to interactive PTY login-shell COMMAND.
+Non-shell commands, `shell -c ...', and script launches are left untouched."
+  (let* ((program (car command))
+         (args (cdr command))
+         (base (and (stringp program) (file-name-nondirectory program)))
+         (login-args (tramp-get-method-parameter
+                      vec 'tramp-remote-shell-login)))
+    (if (and base
+             (or (null args)
+                 (member "-i" args)
+                 (member "--interactive" args))
+             (not (member "-c" args))
+             (not (member "--command" args))
+             (not (member "--login" args))
+             (not (cl-intersection login-args args :test #'string=))
+             (equal base (ignore-errors
+                           (file-name-nondirectory
+                            (tramp-rpc--get-remote-login-shell vec)))))
+        (append (list program) login-args args)
+      command)))
+
 ;; ============================================================================
 ;; make-process handler
 ;; ============================================================================
@@ -523,6 +546,8 @@ Resolves program path and loads direnv environment from working directory."
                                       (cdr command)))
               (setq command (append (list (car command) "-n")
                                     (cdr command))))))
+        (when use-pty
+          (setq command (tramp-rpc--maybe-login-shell-command v command)))
         ;; Get the remote process environment: PATH from `tramp-remote-path'
         ;; (or deprecated `tramp-rpc-remote-path'), direnv for this directory,
         ;; INSIDE_EMACS, and caller-set env vars (e.g. GIT_INDEX_FILE from magit).

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -83,6 +83,9 @@
                  ;; The actual tramp-login-args value is never used for login
                  ;; because rpc is a foreign (non-tramp-sh) file handler.
                  (tramp-login-args (("%h")))
+                 ;; Match TRAMP's remote-shell convention so PTY login shells
+                 ;; can honor method/connection-local overrides.
+                 (tramp-remote-shell-login ("-l"))
                  ;; Direct async process support: tramp-rpc uses direct SSH
                  ;; PTY connections for async processes, which means stderr
                  ;; is mixed with stdout (normal PTY behavior).  Setting

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1757,6 +1757,71 @@ This is the root cause of the lsp-mode crash reported with tramp-rpc."
             (should (equal expected actual))))))))
 
 ;;; ============================================================================
+;;; Test 20: PTY login shell command normalization
+;;; ============================================================================
+
+(ert-deftest tramp-rpc-test20-pty-shell-login-args ()
+  "Interactive PTY login shells should be started as login shells."
+  (cl-letf (((symbol-function 'tramp-rpc--get-remote-login-shell)
+             (lambda (_vec) "/opt/bin/my-shell"))
+            ((symbol-function 'tramp-get-method-parameter)
+             (lambda (_vec parameter &optional default)
+               (if (eq parameter 'tramp-remote-shell-login) '("-l") default))))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell"))
+                   '("/opt/bin/my-shell" "-l")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "-i"))
+                   '("/opt/bin/my-shell" "-l" "-i")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "-l" "-i"))
+                   '("/opt/bin/my-shell" "-l" "-i")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "/tmp/script.sh"))
+                   '("/opt/bin/my-shell" "/tmp/script.sh")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "-c" "echo ok"))
+                   '("/opt/bin/my-shell" "-c" "echo ok")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/bin/bash" "-i"))
+                   '("/bin/bash" "-i")))
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("python3" "-i"))
+                   '("python3" "-i")))))
+
+(ert-deftest tramp-rpc-test20-make-process-pty-normalizes-login-shell ()
+  "`tramp-rpc-handle-make-process' sends normalized login command to PTY path."
+  (let ((default-directory "/rpc:test-host:/tmp/")
+        captured-command)
+    (cl-letf (((symbol-function 'tramp-rpc--get-remote-login-shell)
+               (lambda (_vec) "/bin/bash"))
+              ((symbol-function 'tramp-get-method-parameter)
+               (lambda (_vec parameter &optional default)
+                 (if (eq parameter 'tramp-remote-shell-login) '("-l") default)))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _args) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--ensure-inside-emacs-env)
+               (lambda (env) env))
+              ((symbol-function 'tramp-rpc--make-pty-process)
+               (lambda (_vec _name _buffer command &rest _args)
+                 (setq captured-command command)
+                 'tramp-rpc-test-pty-process)))
+      (should (eq (tramp-rpc-handle-make-process
+                   :name "tramp-rpc-test"
+                   :buffer nil
+                   :command '("/bin/bash" "-i")
+                   :connection-type 'pty)
+                  'tramp-rpc-test-pty-process))
+      (should (equal captured-command '("/bin/bash" "-l" "-i")))
+      (let ((process-connection-type t))
+        (setq captured-command nil)
+        (should (eq (tramp-rpc-handle-make-process
+                     :name "tramp-rpc-test-dynamic"
+                     :buffer nil
+                     :command '("/bin/bash" "-i"))
+                    'tramp-rpc-test-pty-process))
+        (should (equal captured-command '("/bin/bash" "-l" "-i")))))))
+
+;;; ============================================================================
 ;;; Test Runner
 ;;; ============================================================================
 


### PR DESCRIPTION
## Summary
- start interactive PTY launches of the remote user's login shell as login shells
- leave pipe processes, non-shell commands, `shell -c`, and script launches unchanged
- add focused helper and handler-level coverage for PTY normalization

Fixes #227

## Validation
- [x] `emacs -Q --batch -L ../tramp/lisp -l test/tramp-rpc-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-test20")'`
- [x] byte-compiled `lisp/*.el` with `byte-compile-error-on-warn`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PTY-based remote sessions now more consistently apply the expected login-shell options for interactive shells.
  * Interactive shell launches preserve existing command behavior and avoid unnecessary changes for script-like invocations and non-shell commands.

* **Tests**
  * Added ERT coverage for PTY login-shell argument normalization, including direct and make-process command paths.  

* **Documentation**
  * Updated TRAMP RPC method registration to use the standard remote-shell login convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->