### PR TITLE
fix: avoid removed VC private sentinel

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -59,7 +59,6 @@
 ;; Functions from vc-dispatcher.el (used by vc-exec-after handler)
 (declare-function vc-exec-after "vc-dispatcher")
 (declare-function vc-set-mode-line-busy-indicator "vc-dispatcher")
-(declare-function vc--process-sentinel "vc-dispatcher")
 
 ;; Functions from python.el (used by python-shell integration)
 (declare-function python-shell--tramp-with-environment "python")
@@ -296,7 +295,15 @@ process-file calls are routed through the TRAMP handler."
     (tramp-run-real-handler
      #'vc-call-backend (append `(,backend ,function-name) args))))
 
-(defun tramp-rpc-handle-vc-exec-after (code &optional success)
+(defun tramp-rpc--vc-exec-after-real (code okstatus proc)
+  "Call the real `vc-exec-after' with the arity this Emacs supports."
+  (tramp-run-real-handler
+   #'vc-exec-after
+   (if (and proc (>= (cdr (func-arity #'vc-exec-after)) 3))
+       (list code okstatus proc)       ; Emacs 31+
+     (list code okstatus))))           ; Emacs 30
+
+(defun tramp-rpc-handle-vc-exec-after (code &optional okstatus proc)
   "Handler for `vc-exec-after' to handle TRAMP-RPC relay processes.
 
 Some native-compiled VC functions can observe the raw local relay process
@@ -306,7 +313,7 @@ non-`exit' state while TRAMP-RPC has already recorded the remote exit.  The
 stock `vc-exec-after' then signals \"Unexpected process state\".  For
 TRAMP-RPC processes, reproduce `vc-exec-after' using the logical process
 state."
-  (let ((proc (get-buffer-process (current-buffer))))
+  (let ((proc (or proc (get-buffer-process (current-buffer)))))
     (if (and (processp proc)
              (process-get proc :tramp-rpc-pid))
         (let ((status (cond
@@ -321,18 +328,23 @@ state."
             ;; run with `inhibit-quit' bound; Emacs 30 warns about blocking
             ;; `accept-process-output' in that context.
             (while (accept-process-output proc 0 nil t))
-            (when (or (not success)
-                      (zerop (process-exit-status success)))
+            (when (cond
+                   ((null okstatus) t)
+                   ((processp okstatus) (zerop (process-exit-status okstatus))) ; Emacs 30
+                   ((integerp okstatus) (<= (process-exit-status proc) okstatus))) ; Emacs 31+
               (if (functionp code) (funcall code) (eval code t))))
            ((eq status 'run)
             (vc-set-mode-line-busy-indicator)
             (letrec ((fun (lambda (p _msg)
                             (remove-function (process-sentinel p) fun)
-                            (vc--process-sentinel p code success))))
+                            (when-let* ((buf (process-buffer p))
+                                        (_ (buffer-live-p buf)))
+                              (with-current-buffer buf
+                                (tramp-rpc-handle-vc-exec-after code okstatus p))))))
               (add-function :after (process-sentinel proc) fun)))
            (t
-            (tramp-run-real-handler #'vc-exec-after (list code success)))))
-      (tramp-run-real-handler #'vc-exec-after (list code success))))
+            (tramp-rpc--vc-exec-after-real code okstatus proc))))
+      (tramp-rpc--vc-exec-after-real code okstatus proc)))
   nil)
 
 ;; ============================================================================

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -2920,6 +2920,34 @@ as a hop in multi-hop chains."
         (delete-process proc))
       (kill-buffer buffer))))
 
+(ert-deftest tramp-rpc-mock-test-vc-exec-after-running-process-no-private-vc-sentinel ()
+  "Test run-state handler doesn't call removed `vc--process-sentinel'."
+  :tags '(:vc-handler)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (require 'vc-dispatcher)
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-vc-exec-after-test*"))
+         (proc (make-process :name "tramp-rpc-vc-exec-after-test"
+                             :buffer buffer
+                             :command '("sh" "-c" "sleep 60")
+                             :noquery t))
+         (ran nil))
+    (unwind-protect
+        (with-current-buffer buffer
+          (process-put proc :tramp-rpc-pid 123)
+          (cl-letf (((symbol-function 'vc--process-sentinel)
+                     (lambda (&rest _) (error "vc--process-sentinel called")))
+                    ((symbol-function 'tramp-run-real-handler)
+                     (lambda (&rest _) (error "Unexpected process state"))))
+            (tramp-rpc-handle-vc-exec-after
+             (lambda () (setq ran t)))
+            (cl-letf (((symbol-function 'process-status) (lambda (_process) 'exit))
+                      ((symbol-function 'process-exit-status) (lambda (_process) 0)))
+              (funcall (process-sentinel proc) proc "finished")))
+          (should ran))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer buffer))))
+
 ;;; ============================================================================
 ;;; Dir-locals advice tests (No server or SSH required)
 ;;; ============================================================================


### PR DESCRIPTION
## Summary
- avoid calling removed private VC helper `vc--process-sentinel`
- recurse through the TRAMP-RPC `vc-exec-after` handler when the process sentinel fires
- support Emacs 31 `vc-exec-after` fallback arity

Fixes #229

## Tests
- `rm -f lisp/*.elc && emacs -Q --batch --eval '(require (quote package))' --eval '(package-initialize)' --eval '(setq byte-compile-error-on-warn t)' --eval "(push \"$(pwd)/lisp\" load-path)" -f batch-byte-compile lisp/*.el && rm -f lisp/*.elc`
- targeted ERT selector was invoked locally but skipped because bundled Tramp is 2.7.3.30.2 and tramp-rpc requires >= 2.8.1.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for VC-related process handling in TRAMP-RPC relay sessions.
  * Better handles both running and exited process states when continuing VC actions.
  * Added support for multiple Emacs versions when invoking VC callbacks.

* **Tests**
  * Added a new regression test covering relay process behavior without relying on private VC internals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->