### PR TITLE
Require msgpack 0.1.1 binary support

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ TRAMP-RPC replaces this with a lightweight Rust server that runs on the remote h
 
 - Emacs 30.1 or later
 - Tramp 2.8.1.4 or later (install from GNU ELPA if your Emacs bundles an older version)
-- =msgpack.el= package (installed automatically from MELPA)
+- =msgpack.el= 0.1.1 or later (installed automatically from MELPA)
 - SSH access to remote hosts
 - Remote host running Linux or macOS (x86_64 or aarch64)
 

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -4,7 +4,7 @@
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Keywords: comm, processes
-;; Package-Requires: ((emacs "30.1") (msgpack "0"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1"))
 
 ;; This file is part of tramp-rpc.
 

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -4,7 +4,7 @@
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Keywords: comm, processes, vc
-;; Package-Requires: ((emacs "30.1") (msgpack "0"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1"))
 
 ;; This file is part of tramp-rpc.
 

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -4,7 +4,7 @@
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Keywords: comm, processes
-;; Package-Requires: ((emacs "30.1") (msgpack "0"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1"))
 
 ;; This file is part of tramp-rpc.
 

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -4,7 +4,7 @@
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Keywords: comm, processes
-;; Package-Requires: ((emacs "30.1") (msgpack "0"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1"))
 
 ;; This file is part of tramp-rpc.
 
@@ -65,13 +65,13 @@ Returns a cons cell (ID . BYTES) for pipelining support."
 Returns a plist with :id, :result, and :error keys for responses.
 For server-initiated notifications (no :id, has :method), returns a plist
 with :notification t, :method, and :params keys."
-  (let* ((msgpack-map-type 'alist)
-         (msgpack-key-type 'symbol)
-         (msgpack-array-type 'list)
-         (response
+  (let* ((response
 	  (with-current-buffer buffer
 	    (goto-char start)
-	    (msgpack-read)))
+	    (msgpack-read :map-type 'alist
+                          :key-type 'symbol
+                          :array-type 'list
+                          :bin-type 'msgpack-bin)))
          (id (alist-get 'id response))
          (method (alist-get 'method response))
          (result

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -5,7 +5,7 @@
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
 ;; Version: 0.11.0
 ;; Keywords: comm, processes, files
-;; Package-Requires: ((emacs "30.1") (msgpack "0") (tramp "2.8.1.4"))
+;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1") (tramp "2.8.1.4"))
 
 ;; This file is part of tramp-rpc.
 
@@ -640,9 +640,10 @@ telemetry even when later tests unload TRAMP and remove debug buffers."
 (defun tramp-rpc--extract-file-read-content (rpc-result)
   "Extract and optionally decompress content from FILE.READ RPC-RESULT.
 Signals `remote-file-error' on compressed payload decode failures."
-  (let ((content (if (stringp rpc-result)
-                     rpc-result
-                   (alist-get 'content rpc-result))))
+  (let ((content (tramp-rpc--binary-bytes
+                  (if (or (stringp rpc-result) (msgpack-bin-p rpc-result))
+                      rpc-result
+                    (alist-get 'content rpc-result)))))
     (if (and (not (stringp rpc-result))
              (alist-get 'compressed rpc-result))
         (let ((compression (or (alist-get 'compression rpc-result) "zlib")))
@@ -1976,22 +1977,30 @@ This is more efficient when the server has async support."
 ;; ============================================================================
 
 (defun tramp-rpc--decode-string (data)
-  "Decode DATA from raw bytes to multibyte UTF-8 string.
-With MessagePack, strings come as raw bytes (unibyte string).
-We decode them as UTF-8 to get proper multibyte strings.
-Returns nil if DATA is nil, empty string if DATA is empty."
+  "Decode binary DATA to a multibyte UTF-8 string.
+MessagePack `bin' values carry bytes; MessagePack `str' values are already
+text strings.  Returns nil if DATA is nil."
   (cond
    ((null data) nil)
-   ((and (stringp data) (> (length data) 0))
-    (decode-coding-string data 'utf-8-unix))
+   ((msgpack-bin-p data)
+    (decode-coding-string (msgpack-bin-string data) 'utf-8-unix))
+   ((stringp data) data)
+   (t data)))
+
+(defun tramp-rpc--binary-bytes (data)
+  "Return raw bytes from DATA, unwrapping MessagePack bin values."
+  (cond
+   ((msgpack-bin-p data) (msgpack-bin-string data))
+   ((and (stringp data) (multibyte-string-p data))
+    (encode-coding-string data 'utf-8-unix))
    (t data)))
 
 (defun tramp-rpc--decode-output (data _encoding)
-  "Decode DATA from raw bytes to multibyte UTF-8 string.
-With MessagePack, data comes as raw bytes (unibyte string).
-We decode it as UTF-8 to get a proper multibyte string.
+  "Decode binary process DATA to a multibyte UTF-8 string.
 ENCODING is ignored (kept for API compatibility)."
-  (or (tramp-rpc--decode-string data) ""))
+  (if data
+      (decode-coding-string (tramp-rpc--binary-bytes data) 'utf-8-unix)
+    ""))
 
 (defun tramp-rpc--decode-filename (entry)
   "Get filename from directory ENTRY.
@@ -2008,12 +2017,21 @@ the server, since the remote side does not understand it."
         (encode-coding-string unquoted 'utf-8-unix)
       unquoted)))
 
+(defun tramp-rpc--path-to-string (path)
+  "Return unquoted PATH as a text string for RPC fields typed as strings."
+  (let ((unquoted (file-name-unquote path)))
+    (if (multibyte-string-p unquoted)
+        unquoted
+      (decode-coding-string unquoted 'utf-8-unix))))
+
+(defun tramp-rpc--path-to-bin (path)
+  "Return PATH as an explicit MessagePack bin value."
+  (msgpack-bin-make (tramp-rpc--path-to-bytes path)))
+
 (defun tramp-rpc--encode-path (path)
-  "Encode PATH for transmission to the server.
-With MessagePack, paths are sent directly as strings/binary.
-Strips any Emacs file-name quoting (\"/:\") before encoding.
-Returns an alist with path."
-  `((path . ,(tramp-rpc--path-to-bytes path))))
+  "Encode PATH for transmission to path-or-bytes server parameters.
+Returns an alist with PATH as an explicit MessagePack bin value."
+  `((path . ,(tramp-rpc--path-to-bin path))))
 
 ;; ============================================================================
 ;; File name handler operations
@@ -2083,11 +2101,10 @@ path unchanged (after resolving any symlinks in parent directories)."
     (condition-case nil
         (let* ((result (tramp-rpc--call v "file.truename"
                                         (tramp-rpc--encode-path localname)))
-               ;; With MessagePack, path comes as raw bytes - decode to UTF-8
                (path (tramp-rpc--decode-string
-                      (if (stringp result)
-                          result
-                        (alist-get 'path result)))))
+                      (if (and (listp result) (not (msgpack-bin-p result)))
+                          (alist-get 'path result)
+                        result))))
           (or path localname))
       ;; If file doesn't exist or has a symlink loop, fall back to
       ;; symlink-chasing approach (same as tramp-handle-file-truename).
@@ -2294,7 +2311,7 @@ Return readable dir-locals files in DIRECTORY in increasing priority order."
            (names (tramp-rpc--dir-locals-candidate-files base-el-only))
            (result (tramp-rpc--call
                     v "highlevel.test_files_in_dir"
-                    `((directory . ,(tramp-rpc--path-to-bytes localdir))
+                    `((directory . ,(tramp-rpc--path-to-string localdir))
                       (names . ,(vconcat names))))))
       (mapcar (lambda (path)
                 (tramp-make-tramp-file-name
@@ -2321,7 +2338,7 @@ to the built-in implementation."
              (names (ensure-list name))
              (result (tramp-rpc--call
                       v "highlevel.locate_dominating_file_multi"
-                      `((file . ,(tramp-rpc--path-to-bytes localname))
+                      `((file . ,(tramp-rpc--path-to-string localname))
                         (names . ,(vconcat names))))))
         (when-let* ((marker (car result))
                     (marker-path (tramp-rpc--decode-string marker)))
@@ -2358,7 +2375,7 @@ to the built-in implementation."
               collect (file-name-unquote (file-local-name cache-dir))))))
       (tramp-rpc--call
        v "highlevel.dir_locals_find_file_cache_update"
-       `((file . ,(tramp-rpc--path-to-bytes localname))
+       `((file . ,(tramp-rpc--path-to-string localname))
          (names . ,(vconcat names))
          (cache_dirs . ,(vconcat cache-dirs)))))))
 
@@ -2603,7 +2620,8 @@ network round-trip."
                                               (let ((r (tramp-rpc--call
                                                         v "file.read"
                                                         (tramp-rpc--encode-path localname))))
-                                                (alist-get 'content r))
+                                                (tramp-rpc--binary-bytes
+                                                 (alist-get 'content r)))
                                             (file-missing nil)))
                                  (prefix (if existing
                                              (substring existing 0 (min append (length existing)))
@@ -2673,9 +2691,9 @@ network round-trip."
            newname ok-if-already-exists))
          (t
           (tramp-rpc--call v1 "file.copy"
-                           `((src . ,(tramp-rpc--path-to-bytes
+                           `((src . ,(tramp-rpc--path-to-bin
                                       (file-name-unquote v1-localname)))
-                             (dest . ,(tramp-rpc--path-to-bytes
+                             (dest . ,(tramp-rpc--path-to-bin
                                        (file-name-unquote v2-localname)))
                              (preserve . ,(if (or keep-time preserve-permissions)
                                               t :msgpack-false))
@@ -2732,9 +2750,9 @@ network round-trip."
       (with-parsed-tramp-file-name filename v1
         (with-parsed-tramp-file-name newname v2
           (tramp-rpc--call v1 "file.copy"
-                           `((src . ,(tramp-rpc--path-to-bytes
+                           `((src . ,(tramp-rpc--path-to-bin
                                       (file-name-unquote v1-localname)))
-                             (dest . ,(tramp-rpc--path-to-bytes
+                             (dest . ,(tramp-rpc--path-to-bin
                                        (file-name-unquote v2-localname)))
                              (preserve . ,(if (or keep-time preserve-permissions) t :msgpack-false))
                              (overwrite . ,(if ok-if-already-exists t :msgpack-false)))))))
@@ -2833,9 +2851,9 @@ network round-trip."
              (expand-file-name (file-name-nondirectory filename) newname)
              ok-if-already-exists)))
         (tramp-rpc--call v1 "file.rename"
-                         `((src . ,(tramp-rpc--path-to-bytes
+                         `((src . ,(tramp-rpc--path-to-bin
                                     (file-name-unquote v1-localname)))
-                           (dest . ,(tramp-rpc--path-to-bytes
+                           (dest . ,(tramp-rpc--path-to-bin
                                      (file-name-unquote v2-localname)))
                            (overwrite . ,(if ok-if-already-exists
                                              t :msgpack-false))))
@@ -2878,9 +2896,9 @@ network round-trip."
       (with-parsed-tramp-file-name filename v1
         (with-parsed-tramp-file-name newname v2
           (tramp-rpc--call v1 "file.rename"
-                           `((src . ,(tramp-rpc--path-to-bytes
+                           `((src . ,(tramp-rpc--path-to-bin
                                       (file-name-unquote v1-localname)))
-                             (dest . ,(tramp-rpc--path-to-bytes
+                             (dest . ,(tramp-rpc--path-to-bin
                                        (file-name-unquote v2-localname)))
                              (overwrite . ,(if ok-if-already-exists t :msgpack-false)))))))
      ;; Different hosts, copy then delete
@@ -3125,7 +3143,7 @@ implementation, which will use the normal TRAMP-RPC file handlers underneath."
                                   p)))
                             link-path-params)))
       (tramp-rpc--call v "file.make_symlink"
-                       (append `((target . ,(tramp-rpc--path-to-bytes target-path))) params)))
+                       (append `((target . ,(tramp-rpc--path-to-bin target-path))) params)))
     (tramp-rpc--invalidate-cache-for-path linkname)))
 
 (defun tramp-rpc-handle-add-name-to-file (filename newname &optional ok-if-already-exists)
@@ -3155,9 +3173,9 @@ Creates a hard link from NEWNAME to FILENAME."
           (delete-file newname)))
       (tramp-flush-file-properties v2 v2-localname)
       (tramp-rpc--call v1 "file.make_hardlink"
-                       `((src . ,(tramp-rpc--path-to-bytes
+                       `((src . ,(tramp-rpc--path-to-bin
                                   (file-name-unquote v1-localname)))
-                         (dest . ,(tramp-rpc--path-to-bytes
+                         (dest . ,(tramp-rpc--path-to-bin
                                    (file-name-unquote v2-localname))))))))
 
 (defun tramp-rpc-handle-set-file-uid-gid (filename &optional uid gid)

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -22,6 +22,11 @@ use crate::protocol::path_or_bytes;
 /// - On Linux: st_mode is u32; time fields are i32 on 32-bit, i64 on 64-bit
 /// - On macOS: st_mode is u16, time fields are i64
 #[inline]
+fn stat_time_to_i64<T: Into<i64>>(time: T) -> i64 {
+    time.into()
+}
+
+#[inline]
 fn extract_stat_fields(stat_buf: &libc::stat) -> (i64, i64, i64, u32) {
     #[cfg(target_os = "macos")]
     let mode = stat_buf.st_mode as u32;
@@ -29,9 +34,9 @@ fn extract_stat_fields(stat_buf: &libc::stat) -> (i64, i64, i64, u32) {
     let mode = stat_buf.st_mode;
 
     (
-        stat_buf.st_atime.into(),
-        stat_buf.st_mtime.into(),
-        stat_buf.st_ctime.into(),
+        stat_time_to_i64(stat_buf.st_atime),
+        stat_time_to_i64(stat_buf.st_mtime),
+        stat_time_to_i64(stat_buf.st_ctime),
         mode,
     )
 }
@@ -81,7 +86,7 @@ fn get_file_attributes_at(
 
     // Get link target if symlink
     let link_target = if file_type == FileType::Symlink {
-        let full_name = if name == b"." || name == b".." {
+        if name == b"." || name == b".." {
             // For . and .., we need the full path for readlink
             None
         } else {
@@ -97,12 +102,11 @@ fn get_file_attributes_at(
             };
             if len >= 0 {
                 buf.truncate(len as usize);
-                Some(String::from_utf8_lossy(&buf).to_string())
+                Some(buf)
             } else {
                 None
             }
-        };
-        full_name
+        }
     } else {
         None
     };

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -75,7 +75,7 @@ pub async fn get_file_attributes(path: &Path, lstat: bool) -> Result<FileAttribu
         fs::read_link(path)
             .await
             .ok()
-            .map(|p| p.to_string_lossy().into_owned())
+            .map(|p| p.as_os_str().as_bytes().to_vec())
     } else {
         None
     };

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -95,7 +95,9 @@ pub async fn read(params: Value) -> HandlerResult {
     } else {
         Ok(msgpack_map! {
             "content" => Value::Binary(content),
-            "size" => size
+            "size" => size,
+            "compressed" => false,
+            "compression" => Value::Nil
         })
     }
 }

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -247,9 +247,9 @@ pub struct FileAttributes {
     pub inode: u64,
     /// Device number
     pub dev: u64,
-    /// Symlink target (if symlink)
+    /// Symlink target as raw bytes (if symlink)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link_target: Option<String>,
+    pub link_target: Option<Vec<u8>>,
 }
 
 impl FileAttributes {
@@ -308,7 +308,7 @@ impl FileAttributes {
         if let Some(ref link_target) = self.link_target {
             pairs.push((
                 Value::String("link_target".into()),
-                Value::String(link_target.clone().into()),
+                Value::Binary(link_target.clone()),
             ));
         }
 

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -16,7 +16,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration};
 
-use crate::protocol::from_value;
+use crate::handlers::file::bytes_to_path;
+use crate::protocol::{from_value, path_or_bytes};
 
 /// Duration to debounce filesystem events before sending a notification.
 /// During bulk operations (e.g. git checkout), many events fire in rapid
@@ -349,7 +350,9 @@ enum WatchInput {
 }
 
 fn path_to_value(path: &Path) -> Value {
-    Value::String(path.to_string_lossy().into_owned().into())
+    use std::os::unix::ffi::OsStrExt;
+
+    Value::Binary(path.as_os_str().as_bytes().to_vec())
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1126,7 +1129,8 @@ use crate::handlers::HandlerResult;
 pub fn handle_add(params: Value) -> HandlerResult {
     #[derive(serde::Deserialize)]
     struct Params {
-        path: String,
+        #[serde(with = "path_or_bytes")]
+        path: Vec<u8>,
         #[serde(default = "default_recursive")]
         recursive: bool,
         #[serde(default)]
@@ -1138,19 +1142,20 @@ pub fn handle_add(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let expanded = crate::handlers::expand_tilde(&params.path);
+    // `bytes_to_path` preserves the legacy ~ expansion used by watch paths.
+    let path = bytes_to_path(&params.path);
 
     let manager = get().ok_or_else(|| RpcError::internal_error("File watcher not available"))?;
 
     let canonical = if params.nofollow {
-        manager.watch_with_options(Path::new(&expanded), params.recursive, true)
+        manager.watch_with_options(&path, params.recursive, true)
     } else {
-        manager.watch(Path::new(&expanded), params.recursive)
+        manager.watch(&path, params.recursive)
     }
     .map_err(|e| RpcError::internal_error(format!("Failed to watch: {}", e)))?;
 
     Ok(msgpack_map! {
-        "path" => canonical.to_string_lossy().into_owned(),
+        "path" => path_to_value(&canonical),
         "recursive" => Value::Boolean(params.recursive),
         "nofollow" => Value::Boolean(params.nofollow)
     })
@@ -1162,17 +1167,19 @@ pub fn handle_add(params: Value) -> HandlerResult {
 pub fn handle_remove(params: Value) -> HandlerResult {
     #[derive(serde::Deserialize)]
     struct Params {
-        path: String,
+        #[serde(with = "path_or_bytes")]
+        path: Vec<u8>,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let expanded = crate::handlers::expand_tilde(&params.path);
+    // `bytes_to_path` preserves the legacy ~ expansion used by watch paths.
+    let path = bytes_to_path(&params.path);
 
     let manager = get().ok_or_else(|| RpcError::internal_error("File watcher not available"))?;
 
     manager
-        .unwatch(Path::new(&expanded))
+        .unwatch(&path)
         .map_err(|e| RpcError::internal_error(format!("Failed to unwatch: {}", e)))?;
 
     Ok(Value::Boolean(true))
@@ -1189,7 +1196,7 @@ pub fn handle_list(_params: Value) -> HandlerResult {
         .into_iter()
         .map(|(path, recursive)| {
             msgpack_map! {
-                "path" => path.to_string_lossy().into_owned(),
+                "path" => path_to_value(&path),
                 "recursive" => Value::Boolean(recursive)
             }
         })
@@ -1363,7 +1370,7 @@ mod tests {
     }
 
     #[test]
-    fn test_watch_event_serializes_paths_as_strings() {
+    fn test_watch_event_serializes_paths_as_binary() {
         let event = WatchEvent::rename(PathBuf::from("/tmp/old"), PathBuf::from("/tmp/new"));
         let value = event.to_value();
 
@@ -1373,11 +1380,11 @@ mod tests {
         );
         assert_eq!(
             map_value(&value, "path"),
-            Some(&Value::String("/tmp/old".into()))
+            Some(&Value::Binary(b"/tmp/old".to_vec()))
         );
         assert_eq!(
             map_value(&value, "path1"),
-            Some(&Value::String("/tmp/new".into()))
+            Some(&Value::Binary(b"/tmp/new".to_vec()))
         );
     }
 
@@ -1408,7 +1415,7 @@ mod tests {
         );
         assert_eq!(
             map_value(&events[0], "path"),
-            Some(&Value::String("/tmp/new".into()))
+            Some(&Value::Binary(b"/tmp/new".to_vec()))
         );
         assert_eq!(
             map_value(&events[1], "action"),

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -60,6 +60,12 @@
 (when tramp-rpc-mock-test--msgpack-available
   (require 'tramp-rpc-protocol))
 
+(defun tramp-rpc-mock-test--bytes-string (data)
+  "Return DATA as a plain byte string, unwrapping MessagePack bin."
+  (if (and tramp-rpc-mock-test--msgpack-available (msgpack-bin-p data))
+      (msgpack-bin-string data)
+    data))
+
 ;;; ============================================================================
 ;;; Protocol Tests (No server required)
 ;;; ============================================================================
@@ -434,7 +440,8 @@ Returns the result or signals an error."
                          "file.read" `((path . ,(encode-coding-string test-file 'utf-8))))))
             (should result)
             (let ((content (alist-get 'content result)))
-              (should (equal content "hello world"))))
+              (should (msgpack-bin-p content))
+              (should (equal (msgpack-bin-string content) "hello world"))))
 
           ;; Get file stats
           (let ((result (tramp-rpc-mock-test--rpc-call
@@ -487,7 +494,10 @@ Returns the result or signals an error."
                                       (include_attrs . :msgpack-false)
                                       (include_hidden . t)))))
             (should result)
-            (let ((names (mapcar (lambda (e) (alist-get 'name e)) result)))
+            (let ((names (mapcar (lambda (e)
+                                    (tramp-rpc-mock-test--bytes-string
+                                     (alist-get 'name e)))
+                                  result)))
               (should (member "file1.txt" names))
               (should (member "file2.txt" names))))
 
@@ -700,7 +710,8 @@ Returns the result or signals an error."
           (should (= (alist-get 'exit_code result) 0))
           ;; stdout is now raw binary
           (let ((stdout (alist-get 'stdout result)))
-            (should (string-match-p "hello world" stdout)))))
+            (should (msgpack-bin-p stdout))
+            (should (string-match-p "hello world" (msgpack-bin-string stdout))))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-process-signal-exit ()
@@ -1932,7 +1943,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                        ("dir.list"
                         (should (eq (alist-get 'include_attrs params) t))
                         (should (eq (alist-get 'include_hidden params) t))
-                        (pcase (alist-get 'path params)
+                        (pcase (tramp-rpc-mock-test--bytes-string
+                                (alist-get 'path params))
                           ("/tmp/dir"
                            `(((name . ".") (type . "directory") (attrs . ,dir-stat))
                              ((name . "..") (type . "directory") (attrs . ,dir-stat))
@@ -1949,7 +1961,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                   ((symbol-function 'tramp-rpc--call-batch)
                    (lambda (_vec requests)
                      (mapcar (lambda (request)
-                               (pcase (alist-get 'path (cdr request))
+                               (pcase (tramp-rpc-mock-test--bytes-string
+                                       (alist-get 'path (cdr request)))
                                  ("/tmp/dir/a.txt" '((content . "root")))
                                  ("/tmp/dir/sub/b.txt" '((content . "child")))
                                  (_ (error "Unexpected batch request: %S" request))))
@@ -2104,7 +2117,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                      (mapcar (lambda (request)
                                `((content . ,(format "content:%s"
                                               (file-name-nondirectory
-                                               (alist-get 'path (cdr request)))))))
+                                               (tramp-rpc-mock-test--bytes-string
+                                                (alist-get 'path (cdr request))))))))
                              requests)))
                   ((symbol-function 'tramp-rpc--invalidate-cache-for-path) #'ignore)
                   ((symbol-function 'tramp-flush-file-properties) #'ignore)


### PR DESCRIPTION
## Summary
- require msgpack.el 0.1.1 across the Elisp package headers
- preserve MessagePack bin wrappers when decoding RPC responses
- send/return filesystem byte paths as MessagePack binary instead of lossy strings

## Tests
- `cargo test`
- `emacs -Q --batch --eval "(add-to-list 'load-path \"$(pwd)/../msgpack.el\")" --eval "(add-to-list 'load-path \"$(pwd)/lisp\")" -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "tramp-rpc-mock-test")'`
- `rm -f lisp/*.elc && emacs -Q --batch --eval "(add-to-list 'load-path \"$(pwd)/../msgpack.el\")" --eval "(setq byte-compile-error-on-warn t)" --eval "(push \"$(pwd)/lisp\" load-path)" -f batch-byte-compile lisp/*.el`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of MessagePack binary data and non-text paths for remote operations, including more reliable file contents and symlink target handling.
  * Watch events and related notifications now preserve raw path data more consistently.

* **Bug Fixes**
  * Fixed inconsistencies in decoding/encoding of MessagePack values (including response decoding rules) and normalized `file.read` metadata (now always includes compression fields when applicable).
  * Updated symlink attribute serialization to return raw bytes instead of lossy text.

* **Documentation**
  * Documented and required a minimum `msgpack` version in the README and package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->