### PR TITLE
fix: append login shell arg so bash M-x shell starts

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -463,7 +463,10 @@ pair is a symbol."
 
 (defun tramp-rpc--maybe-login-shell-command (vec command)
   "Add login-shell args to interactive PTY login-shell COMMAND.
-Non-shell commands, `shell -c ...', and script launches are left untouched."
+Non-shell commands, `shell -c ...', and script launches are left untouched.
+Login args are appended after the existing args: `M-x shell' passes bash
+`--noediting -i', and bash rejects the long `--noediting' option once a short
+option like `-l' precedes it (an invalid-option error)."
   (let* ((program (car command))
          (args (cdr command))
          (base (and (stringp program) (file-name-nondirectory program)))
@@ -480,7 +483,8 @@ Non-shell commands, `shell -c ...', and script launches are left untouched."
              (equal base (ignore-errors
                            (file-name-nondirectory
                             (tramp-rpc--get-remote-login-shell vec)))))
-        (append (list program) login-args args)
+        ;; bash refuses `bash -l --noediting -i' but accepts `bash --noediting -i -l'.
+        (append command login-args)
       command)))
 
 ;; ============================================================================

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -2150,7 +2150,11 @@ This is the root cause of the lsp-mode crash reported with tramp-rpc."
     (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell"))
                    '("/opt/bin/my-shell" "-l")))
     (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "-i"))
-                   '("/opt/bin/my-shell" "-l" "-i")))
+                   '("/opt/bin/my-shell" "-i" "-l")))
+    ;; Real `M-x shell' bash case: --noediting is a long option, so -l must be
+    ;; appended -- bash rejects `-l --noediting' with "--: invalid option".
+    (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "--noediting" "-i"))
+                   '("/opt/bin/my-shell" "--noediting" "-i" "-l")))
     (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "-l" "-i"))
                    '("/opt/bin/my-shell" "-l" "-i")))
     (should (equal (tramp-rpc--maybe-login-shell-command nil '("/opt/bin/my-shell" "/tmp/script.sh"))
@@ -2191,7 +2195,7 @@ This is the root cause of the lsp-mode crash reported with tramp-rpc."
                    :command '("/bin/bash" "-i")
                    :connection-type 'pty)
                   'tramp-rpc-test-pty-process))
-      (should (equal captured-command '("/bin/bash" "-l" "-i")))
+      (should (equal captured-command '("/bin/bash" "-i" "-l")))
       (let ((process-connection-type t))
         (setq captured-command nil)
         (should (eq (tramp-rpc-handle-make-process
@@ -2199,7 +2203,7 @@ This is the root cause of the lsp-mode crash reported with tramp-rpc."
                      :buffer nil
                      :command '("/bin/bash" "-i"))
                     'tramp-rpc-test-pty-process))
-        (should (equal captured-command '("/bin/bash" "-l" "-i")))))))
+        (should (equal captured-command '("/bin/bash" "-i" "-l")))))))
 
 ;;; ============================================================================
 ;;; Test Runner


### PR DESCRIPTION
The previous login-shell fix (tzxsqvou) prepended the login flag, producing `bash -l --noediting -i'. bash rejects the long `--noediting' option once a short option precedes it (invalid-option error), so the interactive shell failed to start -- issue #227 stayed broken.

Append the login args instead: `bash --noediting -i -l' starts cleanly as a login shell. Tests updated to cover the real `M-x shell' --noediting case.

Fixes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of interactive (`-i`) and login (`-l`) flags for certain PTY-based shell launches, improving shell startup behavior.
  * Updated command normalization so login-shell arguments are applied in the correct sequence for interactive shell commands.

* **Tests**
  * Updated PTY and login-shell command-order assertions to reflect the new interactive/login flag ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->