### PR TITLE
Magit | Accept msgpack-bin truename prefetch results

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -1008,9 +1008,9 @@ whitespace."
   "Populate `file-truename' cache for LOCALNAME from RESULT."
   (when result
     (let* ((truename-local (tramp-rpc--decode-string
-                            (if (stringp result)
-                                result
-                              (alist-get 'path result))))
+                            (if (consp result)
+                                (alist-get 'path result)
+                              result)))
            (filename (tramp-rpc-magit--remote-path vec localname))
            (truename (tramp-rpc-magit--remote-path vec truename-local)))
       (tramp-rpc--cache-put tramp-rpc--file-truename-cache filename truename))))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -779,6 +779,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (declare-function tramp-rpc-magit--process-cache-key "tramp-rpc-magit" (&rest args))
 (declare-function tramp-rpc-magit--process-cache-lookup "tramp-rpc-magit" (program args))
 (declare-function tramp-rpc-magit--process-cache-store "tramp-rpc-magit" (program args exit-code stdout))
+(declare-function tramp-rpc-magit--cache-file-truename "tramp-rpc-magit" (vec localname result))
 (declare-function tramp-rpc-handle-magit-status-setup-buffer "tramp-rpc-magit" (&optional directory))
 (declare-function tramp-rpc-handle-file-regular-p "tramp-rpc" (filename))
 (declare-function tramp-rpc--clear-file-caches-for-connection "tramp-rpc-magit" (vec))
@@ -960,6 +961,20 @@ This matches the behavior expected by `tramp-test28-process-file'."
                (lambda (_operation _args) 'ok)))
       (tramp-rpc-handle-magit-status-setup-buffer "/ssh:mock:/repo"))
     (should (equal cleared '("/ssh:mock:/repo/")))))
+
+(ert-deftest tramp-rpc-mock-test-magit-cache-file-truename-accepts-bin-result ()
+  "Magit metadata prefetch accepts bin file.truename results."
+  (skip-unless (and tramp-rpc-mock-test--tramp-rpc-magit-loaded
+                   tramp-rpc-mock-test--msgpack-available))
+  (let ((tramp-rpc--file-truename-cache (make-hash-table :test 'equal))
+        (vec (tramp-dissect-file-name "/rpc:mock:/repo/")))
+    (cl-letf (((symbol-function 'tramp-rpc--decode-string)
+               #'tramp-rpc-mock-test--bytes-string))
+      (tramp-rpc-magit--cache-file-truename
+       vec "/repo" (msgpack-bin-make "/home/arthur/src/doom")))
+    (should (equal (tramp-rpc--cache-get
+                    tramp-rpc--file-truename-cache "/rpc:mock:/repo")
+                   "/rpc:mock:/home/arthur/src/doom"))))
 
 (defun tramp-rpc-mock-test--sudo-helper-available-p ()
   "Return non-nil when the sudo path helpers needed by this test are available."


### PR DESCRIPTION
Fix Magit status metadata prefetch when file.truename returns a bare
msgpack-bin path instead of an alist. This keeps tramp-rpc from calling
alist-get on the bin wrapper.

Add a regression test for the direct bin result case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cached remote path values so they are decoded correctly in more result shapes.
  * Fixed an issue where certain string-like cache entries could be interpreted incorrectly when resolving file names.

* **Tests**
  * Added coverage for cached path decoding to verify the expected TRAMP path is returned from stored results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->