### PR TITLE
fix: drain async process output before exit

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -298,51 +298,55 @@ RESPONSE is the decoded RPC response plist."
   (when (and (processp local-process)
              (process-live-p local-process)
              (gethash local-process tramp-rpc--async-processes))
-    (condition-case err
-        (let* ((info (gethash local-process tramp-rpc--async-processes))
-               (stderr-buffer (plist-get info :stderr-buffer))
-               (result (plist-get response :result))
-               (stdout (when-let* ((s (alist-get 'stdout result)))
-                         (tramp-rpc--decode-output
-                          s (alist-get 'stdout_encoding result))))
-               (stderr (when-let* ((s (alist-get 'stderr result)))
-                         (tramp-rpc--decode-output
-                          s (alist-get 'stderr_encoding result))))
-               (exited (alist-get 'exited result))
-               (exit-code (alist-get 'exit_code result)))
+    (if-let* ((rpc-error (plist-get response :error)))
+        (progn
+          (tramp-rpc--debug "ASYNC-READ RPC error: %S" rpc-error)
+          (tramp-rpc--handle-process-exit local-process -1))
+      (condition-case err
+          (let* ((info (gethash local-process tramp-rpc--async-processes))
+                 (stderr-buffer (plist-get info :stderr-buffer))
+                 (result (plist-get response :result))
+                 (stdout (when-let* ((s (alist-get 'stdout result)))
+                           (tramp-rpc--decode-output
+                            s (alist-get 'stdout_encoding result))))
+                 (stderr (when-let* ((s (alist-get 'stderr result)))
+                           (tramp-rpc--decode-output
+                            s (alist-get 'stderr_encoding result))))
+                 (exited (alist-get 'exited result))
+                 (exit-code (alist-get 'exit_code result)))
 
-          (tramp-rpc--debug "ASYNC-READ response: stdout=%s stderr=%s exited=%s"
-                           (if stdout (length stdout) "nil")
-                           (if stderr (length stderr) "nil")
-                           exited)
+            (tramp-rpc--debug "ASYNC-READ response: stdout=%s stderr=%s exited=%s"
+                             (if stdout (length stdout) "nil")
+                             (if stderr (length stderr) "nil")
+                             exited)
 
-          ;; Deliver output.  When the remote process reports EXITED, flush
-          ;; data immediately before sending EOF to the local relay; otherwise
-          ;; the deferred delivery can race with relay shutdown and lose output.
-          (if exited
+            ;; Deliver output.  When the remote process reports EXITED, flush
+            ;; data immediately before sending EOF to the local relay; otherwise
+            ;; the deferred delivery can race with relay shutdown and lose output.
+            (if exited
+                (when (or stdout stderr)
+                  (tramp-rpc--deliver-process-output
+                   local-process stdout stderr stderr-buffer))
+              ;; Keep deferred delivery for the non-exit hot path so
+              ;; accept-process-output observes normal I/O activity.
               (when (or stdout stderr)
-                (tramp-rpc--deliver-process-output
-                 local-process stdout stderr stderr-buffer))
-            ;; Keep deferred delivery for the non-exit hot path so
-            ;; accept-process-output observes normal I/O activity.
-            (when (or stdout stderr)
-              (run-at-time 0 nil #'tramp-rpc--deliver-process-output
-                           local-process stdout stderr stderr-buffer)))
+                (run-at-time 0 nil #'tramp-rpc--deliver-process-output
+                             local-process stdout stderr stderr-buffer)))
 
-          ;; Handle process exit or chain next read
-          (if exited
-              ;; Handle exit immediately so `process-live-p' flips to nil
-              ;; before callers can issue another round of remote operations.
-              ;; Deferring this via `run-at-time 0' leaves a small window where
-              ;; loops that poll `process-live-p' can observe a stale live
-              ;; process and run one extra iteration.
-              (tramp-rpc--handle-process-exit local-process exit-code)
-            ;; Chain another read - use run-at-time to avoid stack overflow
-            (run-at-time 0 nil #'tramp-rpc--start-async-read local-process)))
-      (error
-       (tramp-rpc--debug "ASYNC-READ-ERROR: %S" err)
-       ;; On error, clean up
-       (run-at-time 0 nil #'tramp-rpc--handle-process-exit local-process -1)))))
+            ;; Handle process exit or chain next read
+            (if exited
+                ;; Handle exit immediately so `process-live-p' flips to nil
+                ;; before callers can issue another round of remote operations.
+                ;; Deferring this via `run-at-time 0' leaves a small window where
+                ;; loops that poll `process-live-p' can observe a stale live
+                ;; process and run one extra iteration.
+                (tramp-rpc--handle-process-exit local-process exit-code)
+              ;; Chain another read - use run-at-time to avoid stack overflow
+              (run-at-time 0 nil #'tramp-rpc--start-async-read local-process)))
+        (error
+         (tramp-rpc--debug "ASYNC-READ-ERROR: %S" err)
+         ;; On error, clean up
+         (run-at-time 0 nil #'tramp-rpc--handle-process-exit local-process -1))))))
 
 (defun tramp-rpc--handle-process-exit (local-process exit-code)
   "Handle exit of remote process associated with LOCAL-PROCESS.

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
-use std::process::{Command as StdCommand, Stdio};
+use std::process::{Command as StdCommand, ExitStatus, Stdio};
 use std::sync::{Arc, OnceLock};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
@@ -40,6 +40,7 @@ async fn get_next_pid() -> u32 {
 
 struct ManagedProcess {
     child: Child,
+    exit_status: Option<ExitStatus>,
     stdin: Arc<Mutex<Option<ChildStdin>>>,
     stdout: Arc<Mutex<Option<ChildStdout>>>,
     stderr: Arc<Mutex<Option<ChildStderr>>>,
@@ -177,6 +178,7 @@ pub async fn start(params: Value) -> HandlerResult {
     let pid = get_next_pid().await;
 
     let managed = ManagedProcess {
+        exit_status: None,
         stdin: Arc::new(Mutex::new(child.stdin.take())),
         stdout: Arc::new(Mutex::new(child.stdout.take())),
         stderr: Arc::new(Mutex::new(child.stderr.take())),
@@ -247,6 +249,12 @@ pub async fn read(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    if params.max_bytes == 0 {
+        return Err(RpcError::invalid_params(
+            "max_bytes must be greater than zero",
+        ));
+    }
+
     let timeout = params.timeout_ms.unwrap_or(0);
 
     let (stdout, stderr) = {
@@ -262,19 +270,38 @@ pub async fn read(params: Value) -> HandlerResult {
     // the Emacs client; holding that lock here makes concurrent
     // `process.write` calls wait behind the read timeout, which turns LSP
     // typing into a synchronous round-trip bottleneck.
-    let (stdout_data, stderr_data) = tokio::join!(
+    let (stdout_result, stderr_result) = tokio::join!(
         try_read_optional_stream(stdout, params.max_bytes, timeout),
         try_read_optional_stream(stderr, params.max_bytes, timeout)
     );
+
+    let stdout_result = stdout_result
+        .map_err(|e| RpcError::process_error(format!("Failed to read stdout: {e}")))?;
+    let stderr_result = stderr_result
+        .map_err(|e| RpcError::process_error(format!("Failed to read stderr: {e}")))?;
+
+    let stdout_eof = matches!(stdout_result, ReadResult::Eof);
+    let stderr_eof = matches!(stderr_result, ReadResult::Eof);
+    let stdout_data = stdout_result.into_data();
+    let stderr_data = stderr_result.into_data();
 
     // Check if process has exited.  Reacquire the map briefly; do not hold it
     // across any await points above.
     let exit_status = {
         let mut processes = get_process_map().lock().await;
-        processes
+        let managed = processes
             .get_mut(&params.pid)
-            .and_then(|managed| managed.child.try_wait().ok().flatten())
+            .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
+        poll_exit_status(managed)
+            .map_err(|e| RpcError::process_error(format!("Failed to query process status: {e}")))?
     };
+
+    // Child exit and pipe EOF are separate events.  A child can exit after a
+    // read returns data while additional bytes are still buffered in either
+    // pipe.  Only report the terminal state after both streams have returned
+    // EOF so the client continues issuing process.read requests until all
+    // output has been delivered.
+    let exited = exit_status.is_some() && stdout_eof && stderr_eof;
 
     // Return binary data directly (no encoding!)
     let stdout_val = if stdout_data.is_empty() {
@@ -289,12 +316,43 @@ pub async fn read(params: Value) -> HandlerResult {
         Value::Binary(stderr_data)
     };
 
+    let exit_code = if exited {
+        exit_status
+            .map(crate::protocol::exit_code_from_status)
+            .map(|code| Value::Integer(code.into()))
+            .unwrap_or(Value::Nil)
+    } else {
+        Value::Nil
+    };
+
     Ok(msgpack_map! {
         "stdout" => stdout_val,
         "stderr" => stderr_val,
-        "exited" => exit_status.is_some(),
-        "exit_code" => exit_status.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        "exited" => exited,
+        "exit_code" => exit_code
     })
+}
+
+enum ReadResult {
+    Data(Vec<u8>),
+    Pending,
+    Eof,
+}
+
+impl ReadResult {
+    fn into_data(self) -> Vec<u8> {
+        match self {
+            Self::Data(data) => data,
+            Self::Pending | Self::Eof => Vec::new(),
+        }
+    }
+}
+
+fn poll_exit_status(managed: &mut ManagedProcess) -> std::io::Result<Option<ExitStatus>> {
+    if managed.exit_status.is_none() {
+        managed.exit_status = managed.child.try_wait()?;
+    }
+    Ok(managed.exit_status)
 }
 
 /// Try to read from an optional async reader with configurable timeout.
@@ -302,15 +360,19 @@ async fn try_read_optional_stream<R>(
     stream: Arc<Mutex<Option<R>>>,
     max_bytes: usize,
     timeout_ms: u64,
-) -> Vec<u8>
+) -> std::io::Result<ReadResult>
 where
     R: AsyncRead + Unpin,
 {
     let mut stream_guard = stream.lock().await;
     if let Some(reader) = stream_guard.as_mut() {
-        try_read_async_with_timeout(reader, max_bytes, timeout_ms).await
+        let result = try_read_async_with_timeout(reader, max_bytes, timeout_ms).await?;
+        if matches!(result, ReadResult::Eof) {
+            *stream_guard = None;
+        }
+        Ok(result)
     } else {
-        vec![]
+        Ok(ReadResult::Eof)
     }
 }
 
@@ -319,7 +381,7 @@ async fn try_read_async_with_timeout<R: AsyncRead + Unpin>(
     reader: &mut R,
     max_bytes: usize,
     timeout_ms: u64,
-) -> Vec<u8> {
+) -> std::io::Result<ReadResult> {
     let mut buf = vec![0u8; max_bytes];
     let timeout = if timeout_ms == 0 { 1 } else { timeout_ms };
 
@@ -329,14 +391,14 @@ async fn try_read_async_with_timeout<R: AsyncRead + Unpin>(
     )
     .await
     {
-        Ok(Ok(0)) => vec![], // EOF
+        Ok(Ok(0)) => Ok(ReadResult::Eof),
         Ok(Ok(n)) => {
             buf.truncate(n);
-            buf
+            Ok(ReadResult::Data(buf))
         }
-        Ok(Err(e)) if e.kind() == ErrorKind::WouldBlock => vec![],
-        Ok(Err(_)) => vec![],
-        Err(_) => vec![], // Timeout - no data available
+        Ok(Err(e)) if e.kind() == ErrorKind::WouldBlock => Ok(ReadResult::Pending),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Ok(ReadResult::Pending),
     }
 }
 
@@ -430,7 +492,8 @@ pub async fn status(params: Value) -> HandlerResult {
         .get_mut(&params.pid)
         .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
 
-    let exit_status = managed.child.try_wait().ok().flatten();
+    let exit_status = poll_exit_status(managed)
+        .map_err(|e| RpcError::process_error(format!("Failed to query process status: {e}")))?;
 
     Ok(msgpack_map! {
         "exited" => exit_status.is_some(),
@@ -445,7 +508,7 @@ pub async fn list(_params: Value) -> HandlerResult {
     let list: Vec<Value> = processes
         .iter_mut()
         .map(|(pid, managed)| {
-            let exited = managed.child.try_wait().ok().flatten();
+            let exited = poll_exit_status(managed).ok().flatten();
             msgpack_map! {
                 "pid" => *pid,
                 "os_pid" => managed.child.id().map(|id| Value::Integer((id as i64).into())).unwrap_or(Value::Nil),
@@ -1060,6 +1123,173 @@ mod tests {
                 .find(|(k, _)| k.as_str() == Some(key))
                 .map(|(_, v)| v)
         })
+    }
+
+    async fn start_pipe_process(script: &str) -> u32 {
+        let result = start(Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("/bin/sh".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![
+                    Value::String("-c".into()),
+                    Value::String(script.into()),
+                ]),
+            ),
+        ]))
+        .await
+        .expect("start pipe process");
+
+        map_get(&result, "pid")
+            .and_then(Value::as_u64)
+            .expect("process pid") as u32
+    }
+
+    async fn read_pipe_process(pid: u32, max_bytes: usize, timeout_ms: u64) -> Value {
+        read(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("max_bytes".into()),
+                Value::Integer((max_bytes as u64).into()),
+            ),
+            (
+                Value::String("timeout_ms".into()),
+                Value::Integer(timeout_ms.into()),
+            ),
+        ]))
+        .await
+        .expect("read pipe process")
+    }
+
+    async fn wait_for_child_exit(pid: u32) {
+        for _ in 0..100 {
+            let result = status(Value::Map(vec![(
+                Value::String("pid".into()),
+                Value::Integer(pid.into()),
+            )]))
+            .await
+            .expect("query pipe process status");
+            if map_get(&result, "exited").and_then(Value::as_bool) == Some(true) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        panic!("process {pid} did not exit");
+    }
+
+    async fn collect_pipe_output(pid: u32, max_bytes: usize) -> (Vec<u8>, Vec<u8>, i64) {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        for _ in 0..64 {
+            let result = read_pipe_process(pid, max_bytes, 500).await;
+            if let Some(Value::Binary(bytes)) = map_get(&result, "stdout") {
+                stdout.extend_from_slice(bytes);
+            }
+            if let Some(Value::Binary(bytes)) = map_get(&result, "stderr") {
+                stderr.extend_from_slice(bytes);
+            }
+
+            if map_get(&result, "exited").and_then(Value::as_bool) == Some(true) {
+                let exit_code = map_get(&result, "exit_code")
+                    .and_then(Value::as_i64)
+                    .expect("exit code");
+                get_process_map().lock().await.remove(&pid);
+                return (stdout, stderr, exit_code);
+            }
+        }
+
+        panic!("process {pid} did not reach EOF");
+    }
+
+    #[tokio::test]
+    async fn process_read_rejects_zero_max_bytes() {
+        let error = read(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(1.into())),
+            (Value::String("max_bytes".into()), Value::Integer(0.into())),
+        ]))
+        .await
+        .expect_err("zero max_bytes should be rejected");
+
+        assert_eq!(error.code, RpcError::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn process_read_drains_pipes_after_status_reports_exit() {
+        let pid = start_pipe_process("printf abc; printf XYZ >&2").await;
+        wait_for_child_exit(pid).await;
+
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 1).await;
+        assert_eq!(stdout, b"abc");
+        assert_eq!(stderr, b"XYZ");
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn process_read_waits_for_eof_after_child_exit() {
+        let pid = start_pipe_process("printf first; sleep 0.1; printf second").await;
+
+        // Ensure the first chunk is buffered before the long-polling read.  The
+        // stderr read then remains pending until the shell exits, reproducing
+        // the race where try_wait succeeds while stdout still contains data.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
+        assert_eq!(stdout, b"firstsecond");
+        assert!(stderr.is_empty());
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn process_read_drains_output_larger_than_max_bytes() {
+        let pid = start_pipe_process("printf 0123456789abcdef").await;
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 3).await;
+
+        assert_eq!(stdout, b"0123456789abcdef");
+        assert!(stderr.is_empty());
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn process_read_keeps_running_with_idle_stderr() {
+        let pid = start_pipe_process("printf stdout; sleep 0.2").await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let first = read_pipe_process(pid, 65_536, 25).await;
+        assert_eq!(
+            map_get(&first, "stdout"),
+            Some(&Value::Binary(b"stdout".to_vec()))
+        );
+        assert_eq!(map_get(&first, "stderr"), Some(&Value::Nil));
+        assert_eq!(
+            map_get(&first, "exited").and_then(Value::as_bool),
+            Some(false)
+        );
+
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn process_read_delivers_output_written_immediately_before_exit() {
+        let pid = start_pipe_process("sleep 0.05; printf final").await;
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
+
+        assert_eq!(stdout, b"final");
+        assert!(stderr.is_empty());
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn process_read_drains_stdout_and_stderr_separately() {
+        let pid = start_pipe_process("printf stdout; printf stderr >&2").await;
+        let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
+
+        assert_eq!(stdout, b"stdout");
+        assert_eq!(stderr, b"stderr");
+        assert_eq!(exit_code, 0);
     }
 
     #[tokio::test]

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -270,15 +270,8 @@ pub async fn read(params: Value) -> HandlerResult {
     // the Emacs client; holding that lock here makes concurrent
     // `process.write` calls wait behind the read timeout, which turns LSP
     // typing into a synchronous round-trip bottleneck.
-    let (stdout_result, stderr_result) = tokio::join!(
-        try_read_optional_stream(stdout, params.max_bytes, timeout),
-        try_read_optional_stream(stderr, params.max_bytes, timeout)
-    );
-
-    let stdout_result = stdout_result
-        .map_err(|e| RpcError::process_error(format!("Failed to read stdout: {e}")))?;
-    let stderr_result = stderr_result
-        .map_err(|e| RpcError::process_error(format!("Failed to read stderr: {e}")))?;
+    let (stdout_result, stderr_result) =
+        try_read_streams(stdout, stderr, params.max_bytes, timeout).await?;
 
     let stdout_eof = matches!(stdout_result, ReadResult::Eof);
     let stderr_eof = matches!(stderr_result, ReadResult::Eof);
@@ -355,18 +348,77 @@ fn poll_exit_status(managed: &mut ManagedProcess) -> std::io::Result<Option<Exit
     Ok(managed.exit_status)
 }
 
-/// Try to read from an optional async reader with configurable timeout.
+/// Read both output streams until either produces data or the shared timeout expires.
+async fn try_read_streams<ROut, RErr>(
+    stdout: Arc<Mutex<Option<ROut>>>,
+    stderr: Arc<Mutex<Option<RErr>>>,
+    max_bytes: usize,
+    timeout_ms: u64,
+) -> Result<(ReadResult, ReadResult), RpcError>
+where
+    ROut: AsyncRead + Unpin,
+    RErr: AsyncRead + Unpin,
+{
+    let stdout_read = async {
+        try_read_optional_stream(stdout, max_bytes)
+            .await
+            .map_err(|e| RpcError::process_error(format!("Failed to read stdout: {e}")))
+    };
+    let stderr_read = async {
+        try_read_optional_stream(stderr, max_bytes)
+            .await
+            .map_err(|e| RpcError::process_error(format!("Failed to read stderr: {e}")))
+    };
+    let deadline = tokio::time::sleep(std::time::Duration::from_millis(if timeout_ms == 0 {
+        1
+    } else {
+        timeout_ms
+    }));
+
+    tokio::pin!(stdout_read, stderr_read, deadline);
+
+    // AsyncReadExt::read is cancellation-safe: when one stream produces data,
+    // dropping the other branch cannot consume bytes from the idle stream.
+    tokio::select! {
+        stdout_result = &mut stdout_read => {
+            let stdout_result = stdout_result?;
+            if matches!(stdout_result, ReadResult::Data(_)) {
+                return Ok((stdout_result, ReadResult::Pending));
+            }
+
+            let stderr_result = tokio::select! {
+                stderr_result = &mut stderr_read => stderr_result?,
+                _ = &mut deadline => ReadResult::Pending,
+            };
+            Ok((stdout_result, stderr_result))
+        }
+        stderr_result = &mut stderr_read => {
+            let stderr_result = stderr_result?;
+            if matches!(stderr_result, ReadResult::Data(_)) {
+                return Ok((ReadResult::Pending, stderr_result));
+            }
+
+            let stdout_result = tokio::select! {
+                stdout_result = &mut stdout_read => stdout_result?,
+                _ = &mut deadline => ReadResult::Pending,
+            };
+            Ok((stdout_result, stderr_result))
+        }
+        _ = &mut deadline => Ok((ReadResult::Pending, ReadResult::Pending)),
+    }
+}
+
+/// Try to read from an optional async reader.
 async fn try_read_optional_stream<R>(
     stream: Arc<Mutex<Option<R>>>,
     max_bytes: usize,
-    timeout_ms: u64,
 ) -> std::io::Result<ReadResult>
 where
     R: AsyncRead + Unpin,
 {
     let mut stream_guard = stream.lock().await;
     if let Some(reader) = stream_guard.as_mut() {
-        let result = try_read_async_with_timeout(reader, max_bytes, timeout_ms).await?;
+        let result = try_read_async(reader, max_bytes).await?;
         if matches!(result, ReadResult::Eof) {
             *stream_guard = None;
         }
@@ -376,29 +428,21 @@ where
     }
 }
 
-/// Try to read from an async reader with configurable timeout.
-async fn try_read_async_with_timeout<R: AsyncRead + Unpin>(
+/// Try to read from an async reader.
+async fn try_read_async<R: AsyncRead + Unpin>(
     reader: &mut R,
     max_bytes: usize,
-    timeout_ms: u64,
 ) -> std::io::Result<ReadResult> {
     let mut buf = vec![0u8; max_bytes];
-    let timeout = if timeout_ms == 0 { 1 } else { timeout_ms };
 
-    match tokio::time::timeout(
-        std::time::Duration::from_millis(timeout),
-        reader.read(&mut buf),
-    )
-    .await
-    {
-        Ok(Ok(0)) => Ok(ReadResult::Eof),
-        Ok(Ok(n)) => {
+    match reader.read(&mut buf).await {
+        Ok(0) => Ok(ReadResult::Eof),
+        Ok(n) => {
             buf.truncate(n);
             Ok(ReadResult::Data(buf))
         }
-        Ok(Err(e)) if e.kind() == ErrorKind::WouldBlock => Ok(ReadResult::Pending),
-        Ok(Err(e)) => Err(e),
-        Err(_) => Ok(ReadResult::Pending),
+        Err(e) if e.kind() == ErrorKind::WouldBlock => Ok(ReadResult::Pending),
+        Err(e) => Err(e),
     }
 }
 
@@ -1251,11 +1295,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_read_keeps_running_with_idle_stderr() {
-        let pid = start_pipe_process("printf stdout; sleep 0.2").await;
+    async fn process_read_returns_stdout_before_idle_stderr_timeout() {
+        let pid = start_pipe_process("printf stdout; sleep 1").await;
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let first = read_pipe_process(pid, 65_536, 25).await;
+        let started = std::time::Instant::now();
+        let first = read_pipe_process(pid, 65_536, 500).await;
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(250),
+            "stdout was delayed behind the idle stderr timeout"
+        );
         assert_eq!(
             map_get(&first, "stdout"),
             Some(&Value::Binary(b"stdout".to_vec()))

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1775,6 +1775,25 @@ This matches the upstream `tramp-test28-process-file' test."
         (when (processp proc)
           (ignore-errors (delete-process proc)))))))
 
+(ert-deftest tramp-rpc-test13d-async-read-rpc-error-exits-process ()
+  "Test async read RPC errors terminate the local process state."
+  (let ((proc (make-pipe-process
+               :name "tramp-rpc-read-error-test"
+               :noquery t))
+        exit-code)
+    (unwind-protect
+        (progn
+          (puthash proc '(:vec mock :pid 12345)
+                   tramp-rpc--async-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--handle-process-exit)
+                     (lambda (_proc code)
+                       (setq exit-code code))))
+            (tramp-rpc--handle-async-read-response
+             proc '(:error (:code -32004 :message "read failed"))))
+          (should (= exit-code -1)))
+      (remhash proc tramp-rpc--async-processes)
+      (ignore-errors (delete-process proc)))))
+
 ;;; ============================================================================
 ;;; Test 14: Async Processes
 ;;; ============================================================================
@@ -1808,6 +1827,8 @@ This matches the upstream `tramp-test28-process-file' test."
          (proc (make-process
                 :name "test-make-proc"
                 :command '("cat")
+                :connection-type 'pipe
+                :file-handler t
                 :filter (lambda (_proc str) (setq output (concat output str))))))
     (unwind-protect
         (progn
@@ -1820,6 +1841,52 @@ This matches the upstream `tramp-test28-process-file' test."
               (accept-process-output proc 0.1)))
           (should (string-match-p "test-input" output)))
       (ignore-errors (delete-process proc)))))
+
+(ert-deftest tramp-rpc-test14-make-process-drains-output-after-exit ()
+  "Test `make-process' continues reading after remote child exit."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (output "")
+         (delay-first-read t)
+         (orig-call-async (symbol-function 'tramp-rpc--call-async))
+         proc)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call-async)
+                   (lambda (vec method params callback)
+                     (if (equal method "process.read")
+                         (let ((params (cons '(max_bytes . 1) params)))
+                           (if delay-first-read
+                               (progn
+                                 (setq delay-first-read nil)
+                                 ;; Let the short-lived child exit before the
+                                 ;; first bounded read.  The old server returned
+                                 ;; exited with the first byte and lost the rest.
+                                 (run-at-time 0.2 nil orig-call-async
+                                              vec method params callback))
+                             (funcall orig-call-async
+                                      vec method params callback)))
+                       (funcall orig-call-async
+                                vec method params callback)))))
+          (setq proc
+                (make-process
+                 :name "tramp-rpc-eof-race"
+                 :buffer nil
+                 :command '("/bin/sh" "-c" "printf firstsecond")
+                 :connection-type 'pipe
+                 :coding 'binary
+                 :noquery t
+                 :file-handler t
+                 :filter (lambda (_proc string)
+                           (setq output (concat output string)))))
+          (with-timeout (15 (error "Process output drain timeout"))
+            (while (process-live-p proc)
+              (accept-process-output proc 0.1)))
+          (should (= 0 (process-exit-status proc)))
+          (should (equal output "firstsecond")))
+      (when (processp proc)
+        (ignore-errors (delete-process proc))))))
 
 (ert-deftest tramp-rpc-test14-python-shell-make-comint ()
   "Test `python-shell-make-comint' on an existing TRAMP RPC connection."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -81,6 +81,8 @@
 
 (require 'tramp-rpc)
 
+(declare-function tramp-rpc--handle-async-read-response "tramp-rpc-process")
+
 ;;; ============================================================================
 ;;; Test Configuration
 ;;; ============================================================================


### PR DESCRIPTION
## Summary

- distinguish stdout/stderr data, pending reads, and EOF in `process.read`
- return as soon as either output stream has data instead of waiting on an idle pipe
- cache child exit status and report `exited=true` only after both output pipes reach EOF
- propagate stream read failures and terminate the Elisp async reader on RPC errors
- add server and `make-process :file-handler t` regression coverage

## Why

A child could exit after a bounded read returned data while more bytes were still buffered in stdout or stderr. The server reported `exited=true` from `try_wait()` alone, causing the Elisp client to stop issuing `process.read` calls and lose the remaining output.

## Testing

- `cargo fmt --all --check`
- `nix develop .#x86_64-unknown-linux-musl --command env RUSTFLAGS='-D warnings' cargo test --manifest-path server/Cargo.toml --locked` — 63 passed
- `nix develop .#x86_64-unknown-linux-musl --command cargo clippy --workspace --all-targets -- -D warnings`
- `./scripts/build-all.sh x86_64-unknown-linux-musl`
- byte-compiled all `lisp/*.el` with `byte-compile-error-on-warn`
- protocol ERT tests
- isolated localhost deployment: `tramp-rpc-test14-make-process` and `tramp-rpc-test14-make-process-drains-output-after-exit`
- verified the new ERT regression fails against the previous server binary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote process error handling so RPC failures reliably terminate the process with exit code `-1`.
  * Fixed stdout/stderr draining after exit, ensuring exit status is reported only after both streams fully reach end-of-file.
  * Rejected zero-byte (`max_bytes = 0`) read requests with an invalid-parameters response.
  * Improved handling of delayed, partial, and oversized output reads without losing data or blocking on the other stream.
* **Tests**
  * Added async read and post-exit draining regression coverage, including RPC error and race scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->