### PR TITLE
[2/11] Correct file and RPC semantics

### DIFF
--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -175,6 +175,7 @@ Returns the integer errno, or nil if not an IO error with errno."
 (defconst tramp-rpc-protocol-error-file-not-found -32001)
 (defconst tramp-rpc-protocol-error-permission-denied -32002)
 (defconst tramp-rpc-protocol-error-io -32003)
+(defconst tramp-rpc-protocol-error-process -32004)
 
 ;; ============================================================================
 ;; Length-prefixed framing support

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -692,7 +692,20 @@ Signals `remote-file-error' on compressed payload decode failures."
       content)))
 
 (defconst tramp-rpc--file-read-chunk-size (* 16 1024 1024)
-  "Maximum bytes requested by one `file.read' RPC.")
+  "Default maximum bytes requested by one `file.read' RPC.")
+
+(defun tramp-rpc--read-chunk-size (vec)
+  "Return the maximum `file.read' request size advertised for VEC.
+Never exceed `tramp-rpc--file-read-chunk-size', which remains the fallback and
+can be let-bound by tests and callers that need smaller requests.  Only the
+system.info cached at connection setup is consulted; this never issues an RPC,
+so a flushed cache simply falls back to the default."
+  (let ((advertised
+         (alist-get 'max_read_chunk_bytes
+                    (tramp-rpc--cached-system-info vec))))
+    (if (and (integerp advertised) (> advertised 0))
+        (min advertised tramp-rpc--file-read-chunk-size)
+      tramp-rpc--file-read-chunk-size)))
 
 (defun tramp-rpc--file-read-params (localname &optional force-uncompressed)
   "Build params for `file.read' on LOCALNAME.
@@ -706,37 +719,76 @@ FORCE-UNCOMPRESSED is non-nil."
 
 (defun tramp-rpc--read-file-bytes
     (vec localname &optional beg end force-uncompressed)
-  "Read bytes from LOCALNAME on VEC in bounded RPC chunks.
-BEG and END are byte offsets.  When END is nil, read through end of file.
+  "Read bytes from LOCALNAME on VEC in bounded, pipelined RPC chunks.
+BEG and END are byte offsets.  The total length is fixed by END, or by the
+`file_size' snapshot the server reports with the first chunk when END is nil
+\(one `file.stat' fallback for servers without that field).  Concurrent
+appends are excluded; concurrent truncation can yield a short result.  If no
+size can be determined, only the first chunk is returned.
 FORCE-UNCOMPRESSED is passed to `tramp-rpc--file-read-params'."
-  (let ((offset (or beg 0))
-        (remaining (and end (- end (or beg 0))))
-        done)
-    (when (and remaining (< remaining 0))
+  (let* ((offset (or beg 0))
+         (chunk-size (tramp-rpc--read-chunk-size vec))
+         (requested (if end (min (- end offset) chunk-size) chunk-size)))
+    (when (< requested 0)
       (signal 'args-out-of-range (list beg end)))
-    (with-temp-buffer
-      (set-buffer-multibyte nil)
-      (while (not done)
-        (let* ((requested (if remaining
-                              (min remaining tramp-rpc--file-read-chunk-size)
-                            tramp-rpc--file-read-chunk-size))
-               (params (tramp-rpc--file-read-params
-                        localname force-uncompressed)))
-          (if (= requested 0)
-              (setq done t)
-            (push `(offset . ,offset) params)
-            (push `(length . ,requested) params)
-            (let* ((result (tramp-rpc--call vec "file.read" params))
-                   (content (tramp-rpc--extract-file-read-content result))
-                   (received (length content)))
-              (insert content)
-              (setq offset (+ offset received))
-              (when remaining
-                (setq remaining (- remaining received)))
-              (when (or (< received requested)
-                        (and remaining (= remaining 0)))
-                (setq done t))))))
-      (buffer-string))))
+    (if (= requested 0)
+        ""
+      (let* ((params (tramp-rpc--file-read-params localname force-uncompressed))
+             (_ (push `(offset . ,offset) params))
+             (_ (push `(length . ,requested) params))
+             (first-result (tramp-rpc--call vec "file.read" params))
+             (first (tramp-rpc--extract-file-read-content first-result))
+             (received (length first)))
+        ;; Keep the common one-chunk path to one RPC.  Only discover the total
+        ;; length after a completely full first chunk indicates more may exist.
+        (if (< received requested)
+            first
+          (let* ((total (if end
+                            (- end offset)
+                          ;; Fix the END-nil read length to one size snapshot:
+                          ;; prefer the fstat `file_size' the server sent with
+                          ;; the first chunk (no extra RPC); fall back to one
+                          ;; `file.stat' for older servers.
+                          (max 0 (- (or (alist-get 'file_size first-result)
+                                        (alist-get 'size
+                                                   (tramp-rpc--call-file-stat
+                                                    vec localname))
+                                         received)
+                                    offset))))
+                 (next-offset (+ offset received))
+                 (remaining (max 0 (- total received)))
+                 (pieces (list first))
+                 done)
+            (while (and (> remaining 0) (not done))
+              (let (requests sizes)
+                (dotimes (_ 3)
+                  (when (> remaining 0)
+                    (let ((size (min remaining chunk-size))
+                          (chunk-params
+                           (tramp-rpc--file-read-params
+                            localname force-uncompressed)))
+                      (push `(offset . ,next-offset) chunk-params)
+                      (push `(length . ,size) chunk-params)
+                      (push (cons "file.read" chunk-params) requests)
+                      (push size sizes)
+                      (setq next-offset (+ next-offset size)
+                            remaining (- remaining size)))))
+                (cl-mapc
+                 (lambda (result size)
+                   ;; A short chunk means the file shrank, so later offsets
+                   ;; are stale.  Discard trailing responses already received
+                   ;; in this batch; `done' also prevents later batches.
+                   (unless done
+                     (when (tramp-rpc--batch-error-p result)
+                       (tramp-rpc--signal-batch-error
+                        "file.read" localname result))
+                     (let ((content (tramp-rpc--extract-file-read-content result)))
+                       (push content pieces)
+                       (when (< (length content) size)
+                         (setq done t)))))
+                 (tramp-rpc--call-batch vec (nreverse requests))
+                 (nreverse sizes))))
+            (apply #'concat (nreverse pieces))))))))
 
 ;; ============================================================================
 ;; Connection management
@@ -2856,6 +2908,9 @@ network round-trip."
   "Return file type string from STAT, or nil."
   (and stat (alist-get 'type stat)))
 
+(defconst tramp-rpc--invalid-params-error-code -32602
+  "JSON-RPC error code for invalid request parameters.")
+
 (defun tramp-rpc--batch-error-p (value)
   "Return non-nil when VALUE is an error object from `tramp-rpc--call-batch'."
   (and (consp value) (plist-get value :error)))
@@ -3459,7 +3514,7 @@ as a no-op, so ignore the server's ENOENT mapping as well."
       (let (large-files small-files)
         (dolist (item (nreverse regulars))
           (if (> (or (alist-get 'size (cadr item)) 0)
-                 tramp-rpc--file-read-chunk-size)
+                 (tramp-rpc--read-chunk-size vec))
               (push item large-files)
             (push item small-files)))
         ;; Preserve the low-latency batch path for files that fit in one RPC.
@@ -3481,13 +3536,22 @@ as a no-op, so ignore the server's ENOENT mapping as well."
                              chunk))))
                 (cl-mapc
                  (lambda (item result)
-                   (when (tramp-rpc--batch-error-p result)
-                     (tramp-rpc--signal-batch-error
-                      "file.read" (file-name-concat localname (car item)) result))
-                   (tramp-rpc--write-local-trash-file
-                    (expand-file-name (car item) (file-name-as-directory dest))
-                    (tramp-rpc--extract-file-read-content result)
-                    (cadr item)))
+                   (let* ((path (file-name-concat localname (car item)))
+                          (content
+                           (if (and (tramp-rpc--batch-error-p result)
+                                    (= (plist-get result :error)
+                                       tramp-rpc--invalid-params-error-code))
+                               ;; The file may have grown beyond the advertised
+                               ;; limit since dir.list supplied its size.
+                               (tramp-rpc--read-file-bytes vec path nil nil t)
+                             (when (tramp-rpc--batch-error-p result)
+                               (tramp-rpc--signal-batch-error
+                                "file.read" path result))
+                             (tramp-rpc--extract-file-read-content result))))
+                     (tramp-rpc--write-local-trash-file
+                      (expand-file-name (car item) (file-name-as-directory dest))
+                      content
+                      (cadr item))))
                  chunk reads)))))
         ;; Large files are read in bounded chunks instead of failing the
         ;; optimized trash path at the server's per-request limit.
@@ -4278,9 +4342,13 @@ round-trips for the common non-VISIT case."
           (tramp-set-connection-property vec (concat "~" user) home)))))
   info)
 
+(defun tramp-rpc--cached-system-info (vec)
+  "Return the system.info cached for VEC, or nil.  Never issues an RPC."
+  (tramp-get-connection-property vec tramp-rpc--system-info-property nil))
+
 (defun tramp-rpc--system-info (vec)
   "Return cached system.info for VEC, fetching it at most once per connection."
-  (or (tramp-get-connection-property vec tramp-rpc--system-info-property nil)
+  (or (tramp-rpc--cached-system-info vec)
       (progn
         ;; Establishing a new connection already performs and caches a
         ;; `system.info' call as its readiness ping.  Re-check the property after

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -691,6 +691,9 @@ Signals `remote-file-error' on compressed payload decode failures."
                           (format "Unsupported file.read compression: %s" compression))))))
       content)))
 
+(defconst tramp-rpc--file-read-chunk-size (* 16 1024 1024)
+  "Maximum bytes requested by one `file.read' RPC.")
+
 (defun tramp-rpc--file-read-params (localname &optional force-uncompressed)
   "Build params for `file.read' on LOCALNAME.
 When `tramp-rpc-compress-file-read' is non-nil, request compression unless
@@ -700,6 +703,40 @@ FORCE-UNCOMPRESSED is non-nil."
                (not force-uncompressed))
       (push '(compress . t) params))
     params))
+
+(defun tramp-rpc--read-file-bytes
+    (vec localname &optional beg end force-uncompressed)
+  "Read bytes from LOCALNAME on VEC in bounded RPC chunks.
+BEG and END are byte offsets.  When END is nil, read through end of file.
+FORCE-UNCOMPRESSED is passed to `tramp-rpc--file-read-params'."
+  (let ((offset (or beg 0))
+        (remaining (and end (- end (or beg 0))))
+        done)
+    (when (and remaining (< remaining 0))
+      (signal 'args-out-of-range (list beg end)))
+    (with-temp-buffer
+      (set-buffer-multibyte nil)
+      (while (not done)
+        (let* ((requested (if remaining
+                              (min remaining tramp-rpc--file-read-chunk-size)
+                            tramp-rpc--file-read-chunk-size))
+               (params (tramp-rpc--file-read-params
+                        localname force-uncompressed)))
+          (if (= requested 0)
+              (setq done t)
+            (push `(offset . ,offset) params)
+            (push `(length . ,requested) params)
+            (let* ((result (tramp-rpc--call vec "file.read" params))
+                   (content (tramp-rpc--extract-file-read-content result))
+                   (received (length content)))
+              (insert content)
+              (setq offset (+ offset received))
+              (when remaining
+                (setq remaining (- remaining received)))
+              (when (or (< received requested)
+                        (and remaining (= remaining 0)))
+                (setq done t))))))
+      (buffer-string))))
 
 ;; ============================================================================
 ;; Connection management
@@ -1804,10 +1841,11 @@ Returns the result or signals an error."
         (if (tramp-rpc-protocol-error-p response)
             (let ((code (tramp-rpc-protocol-error-code response))
                   (msg (tramp-rpc-protocol-error-message response))
+                  (data (tramp-rpc-protocol-error-data response))
                   (os-errno (tramp-rpc-protocol-error-errno response)))
               (tramp-rpc--debug "ERROR id=%s code=%s msg=%s errno=%s"
                                expected-id code msg os-errno)
-              (tramp-rpc--signal-rpc-error "RPC" msg code os-errno))
+              (tramp-rpc--signal-rpc-error "RPC" msg code os-errno nil data))
           (plist-get response :result))))))
 
 (defun tramp-rpc--call-batch (vec requests)
@@ -1970,7 +2008,14 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
             (tramp-rpc--debug "RECV-PIPE quit (user interrupted)")
             (keyboard-quit)))))
     (when remaining-ids
-      (tramp-rpc--debug "RECV-PIPE timeout, missing ids: %S" remaining-ids))
+      (tramp-rpc--debug "RECV-PIPE missing ids: %S" remaining-ids)
+      (signal
+       'remote-file-error
+       (list (if (process-live-p process)
+                 (format "Timeout waiting for pipelined RPC responses from %s (missing ids: %S)"
+                         (tramp-file-name-host vec) remaining-ids)
+               (format "RPC process died waiting for pipelined responses from %s (missing ids: %S)"
+                       (tramp-file-name-host vec) remaining-ids)))))
     ;; Convert hash table to alist in original order
     (mapcar (lambda (id)
               (cons id (gethash id responses)))
@@ -2062,6 +2107,24 @@ Returns an alist with PATH as an explicit MessagePack bin value."
 ;; File name handler operations
 ;; ============================================================================
 
+(defun tramp-rpc--mode-executable-p (mode-string remote-uid remote-gid attrs groups)
+  "Return non-nil when MODE-STRING permits the remote user to execute ATTRS."
+  (if (equal remote-uid tramp-root-id-integer)
+      ;; Root may execute only when some execute bit is set.
+      (or (memq (aref mode-string 3) '(?x ?s))
+          (memq (aref mode-string 6) '(?x ?s))
+          (memq (aref mode-string 9) '(?x ?t)))
+    (or
+     ;; World executable.
+     (memq (aref mode-string 9) '(?x ?t))
+     ;; Owner executable.
+     (and (memq (aref mode-string 3) '(?x ?s))
+          (equal remote-uid (file-attribute-user-id attrs)))
+     ;; Group executable and we are in that group.
+     (and (memq (aref mode-string 6) '(?x ?s))
+          (or (equal remote-gid (file-attribute-group-id attrs))
+              (member (file-attribute-group-id attrs) groups))))))
+
 (defun tramp-rpc-handle-file-executable-p (filename)
   "Like `file-executable-p' for TRAMP-RPC files.
 Checks execute permission from `file-attributes' mode string and
@@ -2078,18 +2141,9 @@ For symlinks, follows through to the target (like
           (when-let* ((mode-string (file-attribute-modes attrs))
                       (remote-uid (tramp-get-remote-uid v 'integer))
                       (remote-gid (tramp-get-remote-gid v 'integer)))
-            (or
-             ;; World executable.
-             (memq (aref mode-string 9) '(?x ?t))
-             ;; Owner executable and we are owner (or root).
-             (and (memq (aref mode-string 3) '(?x ?s))
-                  (or (equal remote-uid tramp-root-id-integer)
-                      (equal remote-uid (file-attribute-user-id attrs))))
-             ;; Group executable and we are in that group.
-             (and (memq (aref mode-string 6) '(?x ?s))
-                  (or (equal remote-gid (file-attribute-group-id attrs))
-                      (member (file-attribute-group-id attrs)
-                              (tramp-get-remote-groups v 'integer)))))))))))
+            (tramp-rpc--mode-executable-p
+             mode-string remote-uid remote-gid attrs
+             (tramp-get-remote-groups v 'integer))))))))
 
 (defun tramp-rpc--call-file-stat (vec localname &optional lstat)
   "Call file.stat for LOCALNAME on VEC, returning nil if file doesn't exist.
@@ -2584,6 +2638,14 @@ This is a lexical path check: the directories can be remote or not yet exist."
 ;; Directory operations
 ;; ============================================================================
 
+(defun tramp-rpc--apply-directory-count (entries count)
+  "Apply Emacs `directory-files' COUNT semantics to ENTRIES."
+  (when count
+    (unless (natnump count)
+      (signal 'wrong-type-argument (list 'wholenump count)))
+    (setq entries (seq-take entries count)))
+  entries)
+
 (defun tramp-rpc-handle-directory-files (directory &optional full match nosort count)
   "Like `directory-files' for TRAMP-RPC files.
 
@@ -2608,8 +2670,7 @@ so a single RPC can both validate and list the directory."
                     result)))
     (unless nosort
       (setq result (sort (copy-sequence result) #'string<)))
-    (when (and (natnump count) (> count 0))
-      (setq result (seq-take result count)))
+    (setq result (tramp-rpc--apply-directory-count result count))
     (if full
         (mapcar (lambda (name) (concat directory name)) result)
       result)))
@@ -2642,10 +2703,7 @@ so a single RPC can both validate and list the directory."
       ;; Sort unless nosort
       (unless nosort
         (setq entries (sort entries (lambda (a b) (string< (car a) (car b))))))
-      ;; Limit count
-      (when count
-        (setq entries (seq-take entries count)))
-      entries)))
+      (tramp-rpc--apply-directory-count entries count))))
 
 ;; Declared in ls-lisp.el; dynamically rebound for rpc dired formatting.
 (defvar ls-lisp-format-time-list)
@@ -2773,30 +2831,14 @@ network round-trip."
                             buffer-file-coding-system)
                        'utf-8-unix))
            (content-bytes (encode-coding-string content coding))
-           ;; When APPEND is an integer, it's a file offset.
-           ;; Read the existing file content first, then splice.
-           (real-append (cond
-                         ((integerp append)
-                          ;; Offset write: read file, truncate at offset, append new
-                          (let* ((existing (condition-case nil
-                                              (let ((r (tramp-rpc--call
-                                                        v "file.read"
-                                                        (tramp-rpc--encode-path localname))))
-                                                (tramp-rpc--binary-bytes
-                                                 (alist-get 'content r)))
-                                            (file-missing nil)))
-                                 (prefix (if existing
-                                             (substring existing 0 (min append (length existing)))
-                                           "")))
-                            ;; Combine prefix + new content
-                            (setq content-bytes (concat prefix content-bytes))
-                            ;; Not an append anymore, full overwrite
-                            nil))
-                         (append t)
-                         (t nil)))
+           ;; Integer APPEND is the offset understood by `file.write'; do not
+           ;; rewrite the remote prefix, which would discard its suffix.
+           (real-append (and append (not (integerp append))))
            (params (append (tramp-rpc--encode-path localname)
                            `((content . ,(msgpack-bin-make content-bytes))
-                             (append . ,(if real-append t :msgpack-false))))))
+                             (append . ,(if real-append t :msgpack-false))
+                             ,@(when (integerp append)
+                                 `((offset . ,append)))))))
 
       (let ((tramp-rpc--suppress-fs-notifications t))
         (tramp-rpc--call v "file.write" params))
@@ -2823,48 +2865,58 @@ network round-trip."
   (when-let* ((data (plist-get error :data)))
     (alist-get 'os_errno data)))
 
-(defun tramp-rpc--error-args (operation detail message filename)
-  "Build signal args for OPERATION, DETAIL, MESSAGE, and optional FILENAME."
-  (cond
-   ((and filename detail) (list operation detail filename message))
-   (filename (list operation filename message))
-   (detail (list operation detail message))
-   (t (list operation message))))
+(defun tramp-rpc--error-args (operation detail message filename &optional data)
+  "Build signal args for OPERATION, DETAIL, MESSAGE, FILENAME, and DATA."
+  (append
+   (cond
+    ((and filename detail) (list operation detail filename message))
+    (filename (list operation filename message))
+    (detail (list operation detail message))
+    (t (list operation message)))
+   (when data (list data))))
 
-(defun tramp-rpc--signal-rpc-error (operation message code os-errno &optional filename)
-  "Signal RPC error CODE/OS-ERRNO for OPERATION and optional FILENAME."
+(defun tramp-rpc--signal-rpc-error
+    (operation message code os-errno &optional filename data)
+  "Signal RPC error CODE/OS-ERRNO and optional structured DATA for OPERATION."
   (cond
    ((= code tramp-rpc-protocol-error-file-not-found)
     (signal 'file-missing
-            (tramp-rpc--error-args operation "No such file" message filename)))
+            (tramp-rpc--error-args operation "No such file" message filename data)))
    ((= code tramp-rpc-protocol-error-permission-denied)
     (signal 'permission-denied
-            (tramp-rpc--error-args operation "Permission denied" message filename)))
-   ((eql os-errno 2) ; ENOENT
+            (tramp-rpc--error-args operation "Permission denied" message filename data)))
+   ;; process.run can report ENOENT for its executable or its cwd.  Only the
+   ;; server's explicit marker represents command-not-found status 127.
+   ((and (= code tramp-rpc-protocol-error-process)
+         (eq (alist-get 'spawn_not_found data) t))
     (signal 'file-missing
-            (tramp-rpc--error-args operation "No such file" message filename)))
+            (tramp-rpc--error-args operation "No such file" message filename data)))
+   ((and (not (= code tramp-rpc-protocol-error-process))
+         (eql os-errno 2)) ; ENOENT
+    (signal 'file-missing
+            (tramp-rpc--error-args operation "No such file" message filename data)))
    ((eql os-errno 17) ; EEXIST
     (signal 'file-already-exists
-            (tramp-rpc--error-args operation nil message filename)))
+            (tramp-rpc--error-args operation nil message filename data)))
    ((eql os-errno 39) ; ENOTEMPTY
     (signal 'file-error
-            (tramp-rpc--error-args operation "Directory not empty" message filename)))
+            (tramp-rpc--error-args operation "Directory not empty" message filename data)))
    ((eql os-errno 20) ; ENOTDIR
     (signal 'file-error
-            (tramp-rpc--error-args operation "Not a directory" message filename)))
+            (tramp-rpc--error-args operation "Not a directory" message filename data)))
    ((eql os-errno 21) ; EISDIR
     (signal 'file-error
-            (tramp-rpc--error-args operation "Is a directory" message filename)))
+            (tramp-rpc--error-args operation "Is a directory" message filename data)))
    ((eql os-errno 40) ; ELOOP
     (signal 'file-error
             (tramp-rpc--error-args
-             operation "Too many levels of symbolic links" message filename)))
+             operation "Too many levels of symbolic links" message filename data)))
    ((= code tramp-rpc-protocol-error-io)
     (signal 'remote-file-error
-            (tramp-rpc--error-args operation nil message filename)))
+            (tramp-rpc--error-args operation nil message filename data)))
    (t
     (signal 'remote-file-error
-            (tramp-rpc--error-args operation nil message filename)))))
+            (tramp-rpc--error-args operation nil message filename data)))))
 
 (defun tramp-rpc--signal-batch-error (operation filename error)
   "Signal ERROR returned by a batched RPC for OPERATION on FILENAME."
@@ -2873,7 +2925,8 @@ network round-trip."
    (or (plist-get error :message) "RPC batch subrequest failed")
    (plist-get error :error)
    (tramp-rpc--batch-error-errno error)
-   filename))
+   filename
+   (plist-get error :data)))
 
 (defun tramp-rpc--batch-result-or-signal (operation filename result)
   "Return batched RESULT, or signal its embedded error for FILENAME."
@@ -3351,10 +3404,8 @@ as a no-op, so ignore the server's ENOENT mapping as well."
   "Copy remote LOCALNAME on VEC to local trash DEST using STAT metadata."
   (pcase (tramp-rpc--stat-type stat)
     ("file"
-     (let ((result (tramp-rpc--call vec "file.read"
-                                    (tramp-rpc--file-read-params localname t))))
-       (tramp-rpc--write-local-trash-file
-        dest (tramp-rpc--extract-file-read-content result) stat)))
+     (tramp-rpc--write-local-trash-file
+      dest (tramp-rpc--read-file-bytes vec localname nil nil t) stat))
     ("symlink"
      (make-symbolic-link
       (or (tramp-rpc--decode-string (alist-get 'link_target stat)) "") dest)
@@ -3405,32 +3456,48 @@ as a no-op, so ignore the server's ENOENT mapping as well."
     ;; recursively so the implementation stays small while avoiding the generic
     ;; TRAMP copy-file/stat/truename path for the common tiny test trees.
     (when regulars
-      (let ((remaining (nreverse regulars)))
-        (while remaining
-          (let ((chunk nil)
-                (count 0))
-            (while (and remaining (< count tramp-rpc--trash-read-batch-size))
-              (push (pop remaining) chunk)
-              (setq count (1+ count)))
-            (setq chunk (nreverse chunk))
-            (let ((reads (tramp-rpc--call-batch
-                          vec
-                          (mapcar
-                           (lambda (item)
-                             (cons "file.read"
-                                   (tramp-rpc--file-read-params
-                                    (file-name-concat localname (car item)) t)))
-                           chunk))))
-              (cl-mapc
-               (lambda (item result)
-                 (when (tramp-rpc--batch-error-p result)
-                   (tramp-rpc--signal-batch-error
-                    "file.read" (file-name-concat localname (car item)) result))
-                 (tramp-rpc--write-local-trash-file
-                  (expand-file-name (car item) (file-name-as-directory dest))
-                  (tramp-rpc--extract-file-read-content result)
-                  (cadr item)))
-               chunk reads))))))
+      (let (large-files small-files)
+        (dolist (item (nreverse regulars))
+          (if (> (or (alist-get 'size (cadr item)) 0)
+                 tramp-rpc--file-read-chunk-size)
+              (push item large-files)
+            (push item small-files)))
+        ;; Preserve the low-latency batch path for files that fit in one RPC.
+        (let ((remaining (nreverse small-files)))
+          (while remaining
+            (let ((chunk nil)
+                  (count 0))
+              (while (and remaining (< count tramp-rpc--trash-read-batch-size))
+                (push (pop remaining) chunk)
+                (setq count (1+ count)))
+              (setq chunk (nreverse chunk))
+              (let ((reads (tramp-rpc--call-batch
+                            vec
+                            (mapcar
+                             (lambda (item)
+                               (cons "file.read"
+                                     (tramp-rpc--file-read-params
+                                      (file-name-concat localname (car item)) t)))
+                             chunk))))
+                (cl-mapc
+                 (lambda (item result)
+                   (when (tramp-rpc--batch-error-p result)
+                     (tramp-rpc--signal-batch-error
+                      "file.read" (file-name-concat localname (car item)) result))
+                   (tramp-rpc--write-local-trash-file
+                    (expand-file-name (car item) (file-name-as-directory dest))
+                    (tramp-rpc--extract-file-read-content result)
+                    (cadr item)))
+                 chunk reads)))))
+        ;; Large files are read in bounded chunks instead of failing the
+        ;; optimized trash path at the server's per-request limit.
+        (dolist (item (nreverse large-files))
+          (let ((name (car item)))
+            (tramp-rpc--write-local-trash-file
+             (expand-file-name name (file-name-as-directory dest))
+             (tramp-rpc--read-file-bytes
+              vec (file-name-concat localname name) nil nil t)
+             (cadr item))))))
     (dolist (item (nreverse directories))
       (tramp-rpc--copy-remote-trash-directory-to-local
        vec
@@ -3890,7 +3957,7 @@ refresh), git commands are served from the prefetch cache when possible."
                                    (set-buffer-multibyte nil)
                                    (insert-file-contents-literally infile)
                                    (buffer-string))))
-               (result (condition-case _err
+               (result (condition-case nil
                            (tramp-rpc--call v "process.run"
                                             `((cmd . ,program)
                                               (args . ,(vconcat args))
@@ -3898,11 +3965,12 @@ refresh), git commands are served from the prefetch cache when possible."
                                               (env . ,env)
                                               ,@(when stdin-content
                                                   `((stdin . ,stdin-content)))))
-                         ;; When the binary doesn't exist or can't be
-                         ;; spawned, return exit code 127 (command not
-                         ;; found) instead of signaling an error.
-                         (remote-file-error nil))))
-          (if result
+                         ;; The server marks confirmed spawn ENOENT as
+                         ;; `file-missing'; other RPC failures must propagate.
+                         (file-missing 127))))
+          (if (eq result 127)
+              127
+            (if result
               (let ((exit-code (alist-get 'exit_code result))
                     (stdout (tramp-rpc--decode-output
                              (alist-get 'stdout result)
@@ -3952,8 +4020,8 @@ refresh), git commands are served from the prefetch cache when possible."
                     (let ((strings (tramp-rpc--get-signal-strings v)))
                       (aref strings (- exit-code 128)))
                   exit-code))
-            ;; Process spawn failed - return 127 (command not found)
-            127))))))
+            ;; A successful RPC result is always non-nil.
+            (signal 'remote-file-error (list "Empty process.run response")))))))))
 
 (defun tramp-rpc-handle-vc-registered (file)
   "Like `vc-registered' for TRAMP-RPC files.
@@ -4157,29 +4225,22 @@ round-trips for the common non-VISIT case."
     (let ((start (point))
           result)
       (with-parsed-tramp-file-name filename nil
-        (let* ((params (tramp-rpc--file-read-params localname)))
-          (when beg
-            (push `(offset . ,beg) params))
-          (when end
-            (push `(length . ,(- end (or beg 0))) params))
-          (let* ((rpc-result (tramp-rpc--call v "file.read" params))
-                 (content (tramp-rpc--extract-file-read-content rpc-result))
-                 (decoded-content
-                  (if enable-multibyte-characters
-                      (decode-coding-string
-                       content (or coding-system-for-read 'undecided))
-                    content)))
-            (insert decoded-content)
-            (setq result (list filename (- (point) start)))
-            (goto-char start))))
+        (let* ((content (tramp-rpc--read-file-bytes
+                         v localname beg end))
+               (decoded-content
+                (if enable-multibyte-characters
+                    (decode-coding-string
+                     content (or coding-system-for-read 'undecided))
+                  content)))
+          (insert decoded-content)
+          (setq result (list filename (- (point) start)))
+          (goto-char start)))
       result)))
 
 (defun tramp-rpc-handle-file-local-copy (filename)
   "Create a local copy of remote FILENAME using RPC."
   (tramp-skeleton-file-local-copy filename
-    (let* ((params (tramp-rpc--file-read-params localname))
-           (result (tramp-rpc--call v "file.read" params))
-           (content (tramp-rpc--extract-file-read-content result)))
+    (let ((content (tramp-rpc--read-file-bytes v localname)))
       (with-temp-file tmpfile
         (set-buffer-multibyte nil)
         (insert content)))))

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -17,6 +17,8 @@ use super::file::{bytes_to_path, map_io_error};
 
 use crate::protocol::path_or_bytes;
 
+const MAX_FILE_READ_CHUNK_BYTES: usize = 16 * 1024 * 1024;
+
 /// Read file contents
 pub async fn read(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
@@ -36,6 +38,15 @@ pub async fn read(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    if params
+        .length
+        .is_some_and(|length| length > MAX_FILE_READ_CHUNK_BYTES)
+    {
+        return Err(RpcError::invalid_params(format!(
+            "length exceeds maximum read size of {MAX_FILE_READ_CHUNK_BYTES} bytes"
+        )));
+    }
+
     let path = bytes_to_path(&params.path);
     let path_str = path.to_string_lossy().into_owned();
 
@@ -50,7 +61,7 @@ pub async fn read(params: Value) -> HandlerResult {
             .map_err(|e| map_io_error(e, &path_str))?;
     }
 
-    // Read the content
+    // Read the content.
     let content = if let Some(length) = params.length {
         // Read up to LENGTH bytes in a single pass. `take` keeps reads bounded.
         let mut buf = Vec::with_capacity(length);
@@ -61,19 +72,16 @@ pub async fn read(params: Value) -> HandlerResult {
             .map_err(|e| map_io_error(e, &path_str))?;
         buf
     } else {
-        // Pre-size from metadata to avoid repeated reallocations on large reads.
-        let mut buf = Vec::new();
-        if let Ok(metadata) = file.metadata().await {
-            let mut expected_len = metadata.len() as usize;
-            if let Some(offset) = params.offset {
-                expected_len = expected_len.saturating_sub(offset as usize);
-            }
-            buf.reserve(expected_len);
-        }
-        file.read_to_end(&mut buf)
+        let metadata = file
+            .metadata()
             .await
             .map_err(|e| map_io_error(e, &path_str))?;
-        buf
+        read_default_bounded(
+            &mut file,
+            metadata.len().saturating_sub(params.offset.unwrap_or(0)),
+            &path_str,
+        )
+        .await?
     };
 
     // Return binary content directly (no base64!). Compression is opt-in.
@@ -100,6 +108,30 @@ pub async fn read(params: Value) -> HandlerResult {
             "compression" => Value::Nil
         })
     }
+}
+
+async fn read_default_bounded(
+    file: &mut File,
+    expected_len: u64,
+    path: &str,
+) -> Result<Vec<u8>, RpcError> {
+    if expected_len > MAX_FILE_READ_CHUNK_BYTES as u64 {
+        return Err(RpcError::invalid_params(format!(
+            "file exceeds maximum read size of {MAX_FILE_READ_CHUNK_BYTES} bytes"
+        )));
+    }
+
+    let mut buf = Vec::with_capacity(expected_len as usize);
+    file.take(MAX_FILE_READ_CHUNK_BYTES as u64 + 1)
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| map_io_error(e, path))?;
+    if buf.len() > MAX_FILE_READ_CHUNK_BYTES {
+        return Err(RpcError::invalid_params(format!(
+            "file exceeds maximum read size of {MAX_FILE_READ_CHUNK_BYTES} bytes"
+        )));
+    }
+    Ok(buf)
 }
 
 /// Write file contents
@@ -136,7 +168,9 @@ pub async fn write(params: Value) -> HandlerResult {
     if params.append {
         options.append(true).create(true);
     } else if params.offset.is_some() {
-        options.write(true);
+        // Seeking past EOF then writing is the sparse, zero-filled behavior
+        // Emacs expects for an integer `write-region' offset.
+        options.write(true).create(true);
     } else {
         options.write(true).create(true).truncate(true);
     }
@@ -157,6 +191,8 @@ pub async fn write(params: Value) -> HandlerResult {
     file.write_all(&content)
         .await
         .map_err(|e| map_io_error(e, &path_str))?;
+    // Do not report success until Tokio has completed the pending file writes.
+    file.flush().await.map_err(|e| map_io_error(e, &path_str))?;
 
     // Set permissions if specified
     if let Some(mode) = params.mode {
@@ -451,6 +487,46 @@ async fn remove_path_for_overwrite(path: &Path) -> std::io::Result<()> {
     }
 }
 
+#[cfg(target_os = "linux")]
+async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let src = src.to_owned();
+    let dest = dest.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let src = CString::new(src.as_os_str().as_bytes())?;
+        let dest = CString::new(dest.as_os_str().as_bytes())?;
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_renameat2,
+                libc::AT_FDCWD,
+                src.as_ptr(),
+                libc::AT_FDCWD,
+                dest.as_ptr(),
+                libc::RENAME_NOREPLACE,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(dest).await {
+        Ok(_) => return Err(already_exists(dest)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    fs::rename(src, dest).await
+}
+
 /// Rename/move a file
 pub async fn rename(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
@@ -471,18 +547,18 @@ pub async fn rename(params: Value) -> HandlerResult {
     let dest_str = dest.to_string_lossy().into_owned();
     let src_str = src.to_string_lossy().into_owned();
 
-    // Check if destination exists and overwrite is false
-    if !params.overwrite && dest.exists() {
-        return Err(RpcError {
-            code: RpcError::IO_ERROR,
-            message: format!("Destination already exists: {}", dest_str),
-            data: None,
-        });
-    }
-
-    fs::rename(&src, &dest)
-        .await
-        .map_err(|e| map_io_error(e, &src_str))?;
+    let result = if params.overwrite {
+        fs::rename(&src, &dest).await
+    } else {
+        rename_no_overwrite(&src, &dest).await
+    };
+    result.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            map_io_error(already_exists(&dest), &dest_str)
+        } else {
+            map_io_error(e, &format!("{src_str} -> {dest_str}"))
+        }
+    })?;
 
     Ok(Value::Boolean(true))
 }
@@ -734,6 +810,103 @@ mod tests {
 
     fn path_value(path: &Path) -> Value {
         Value::Binary(path.as_os_str().as_bytes().to_vec())
+    }
+
+    #[tokio::test]
+    async fn write_offset_preserves_suffix() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("file");
+        fs::write(&path, b"abcdef").await.unwrap();
+
+        write(msgpack_map! {
+            "path" => path_value(&path),
+            "content" => Value::Binary(b"XY".to_vec()),
+            "offset" => 2u64,
+        })
+        .await
+        .expect("write at offset");
+
+        assert_eq!(fs::read(path).await.unwrap(), b"abXYef");
+    }
+
+    #[tokio::test]
+    async fn write_offset_creates_zero_filled_file() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("file");
+
+        write(msgpack_map! {
+            "path" => path_value(&path),
+            "content" => Value::Binary(b"XY".to_vec()),
+            "offset" => 4u64,
+        })
+        .await
+        .expect("write at offset creates file");
+
+        assert_eq!(fs::read(path).await.unwrap(), b"\0\0\0\0XY");
+    }
+
+    #[tokio::test]
+    async fn rename_no_overwrite_rejects_dangling_symlink() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        fs::write(&src, b"source").await.unwrap();
+        tokio::fs::symlink("missing-target", &dest).await.unwrap();
+
+        let error = rename(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+        })
+        .await
+        .expect_err("dangling symlink is an existing destination");
+
+        assert_eq!(error.code, RpcError::IO_ERROR);
+        let errno = error
+            .data
+            .as_ref()
+            .and_then(Value::as_map)
+            .and_then(|data| {
+                data.iter()
+                    .find(|(key, _)| key.as_str() == Some("os_errno"))
+            })
+            .and_then(|(_, value)| value.as_i64());
+        assert_eq!(errno, Some(i64::from(libc::EEXIST)));
+        assert!(fs::symlink_metadata(&dest).await.is_ok());
+        assert!(fs::metadata(&src).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn read_size_limit_rejects_oversized_request() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("file");
+        fs::write(&path, b"x").await.unwrap();
+
+        let error = read(msgpack_map! {
+            "path" => path_value(&path),
+            "length" => (MAX_FILE_READ_CHUNK_BYTES + 1) as u64,
+        })
+        .await
+        .expect_err("oversized read must fail before allocating");
+
+        assert_eq!(error.code, RpcError::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn default_read_rejects_file_that_grows_after_metadata() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("file");
+        fs::write(&path, b"x").await.unwrap();
+        let mut file = File::open(&path).await.unwrap();
+        let expected_len = file.metadata().await.unwrap().len();
+        fs::write(&path, vec![b'x'; MAX_FILE_READ_CHUNK_BYTES + 1])
+            .await
+            .unwrap();
+
+        let error = read_default_bounded(&mut file, expected_len, &path.to_string_lossy())
+            .await
+            .expect_err("grown file must remain bounded");
+
+        assert_eq!(error.code, RpcError::INVALID_PARAMS);
     }
 
     #[tokio::test]

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -17,7 +17,7 @@ use super::file::{bytes_to_path, map_io_error};
 
 use crate::protocol::path_or_bytes;
 
-const MAX_FILE_READ_CHUNK_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const MAX_FILE_READ_CHUNK_BYTES: usize = 16 * 1024 * 1024;
 
 /// Read file contents
 pub async fn read(params: Value) -> HandlerResult {
@@ -54,6 +54,14 @@ pub async fn read(params: Value) -> HandlerResult {
         .await
         .map_err(|e| map_io_error(e, &path_str))?;
 
+    // fstat on the open fd: lets chunked clients learn the total size from the
+    // first chunk response instead of spending a separate file.stat RPC.
+    let metadata = file
+        .metadata()
+        .await
+        .map_err(|e| map_io_error(e, &path_str))?;
+    let file_size = metadata.len();
+
     // Seek to offset if specified
     if let Some(offset) = params.offset {
         file.seek(SeekFrom::Start(offset))
@@ -72,13 +80,9 @@ pub async fn read(params: Value) -> HandlerResult {
             .map_err(|e| map_io_error(e, &path_str))?;
         buf
     } else {
-        let metadata = file
-            .metadata()
-            .await
-            .map_err(|e| map_io_error(e, &path_str))?;
         read_default_bounded(
             &mut file,
-            metadata.len().saturating_sub(params.offset.unwrap_or(0)),
+            file_size.saturating_sub(params.offset.unwrap_or(0)),
             &path_str,
         )
         .await?
@@ -97,6 +101,7 @@ pub async fn read(params: Value) -> HandlerResult {
         Ok(msgpack_map! {
             "content" => Value::Binary(compressed),
             "size" => size,
+            "file_size" => file_size,
             "compressed" => true,
             "compression" => "zlib"
         })
@@ -104,6 +109,7 @@ pub async fn read(params: Value) -> HandlerResult {
         Ok(msgpack_map! {
             "content" => Value::Binary(content),
             "size" => size,
+            "file_size" => file_size,
             "compressed" => false,
             "compression" => Value::Nil
         })
@@ -487,16 +493,29 @@ async fn remove_path_for_overwrite(path: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Portable check-then-rename for kernels and filesystems without
+/// `RENAME_NOREPLACE`.  `symlink_metadata` does not follow symlinks, so a
+/// dangling symlink still counts as an existing destination.  This is racy by
+/// construction, which is why it is only a fallback.
+async fn rename_no_overwrite_fallback(src: &Path, dest: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(dest).await {
+        Ok(_) => return Err(already_exists(dest)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    fs::rename(src, dest).await
+}
+
 #[cfg(target_os = "linux")]
 async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
-    let src = src.to_owned();
-    let dest = dest.to_owned();
-    tokio::task::spawn_blocking(move || {
-        let src = CString::new(src.as_os_str().as_bytes())?;
-        let dest = CString::new(dest.as_os_str().as_bytes())?;
+    let owned_src = src.to_owned();
+    let owned_dest = dest.to_owned();
+    let result = tokio::task::spawn_blocking(move || {
+        let src = CString::new(owned_src.as_os_str().as_bytes())?;
+        let dest = CString::new(owned_dest.as_os_str().as_bytes())?;
         let result = unsafe {
             libc::syscall(
                 libc::SYS_renameat2,
@@ -514,17 +533,31 @@ async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
         }
     })
     .await
-    .map_err(std::io::Error::other)?
+    .map_err(std::io::Error::other)?;
+
+    match result {
+        // Pre-3.15 kernels report ENOSYS, filesystems that do not implement
+        // the flag (NFS, many FUSE mounts, older overlayfs) report EINVAL or
+        // EOPNOTSUPP, and a seccomp filter can report EPERM.  Surfacing any of
+        // these verbatim would fail every no-overwrite rename on such a mount.
+        Err(error)
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::EINVAL)
+                    | Some(libc::ENOSYS)
+                    | Some(libc::EOPNOTSUPP)
+                    | Some(libc::EPERM)
+            ) =>
+        {
+            rename_no_overwrite_fallback(src, dest).await
+        }
+        result => result,
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
 async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
-    match fs::symlink_metadata(dest).await {
-        Ok(_) => return Err(already_exists(dest)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e),
-    }
-    fs::rename(src, dest).await
+    rename_no_overwrite_fallback(src, dest).await
 }
 
 /// Rename/move a file
@@ -556,7 +589,10 @@ pub async fn rename(params: Value) -> HandlerResult {
         if e.kind() == std::io::ErrorKind::AlreadyExists {
             map_io_error(already_exists(&dest), &dest_str)
         } else {
-            map_io_error(e, &format!("{src_str} -> {dest_str}"))
+            // Keep the reported name a real path: it lands in the FILENAME
+            // slot of the Lisp `file-error'/`file-missing' signal, where
+            // callers may feed it back to `expand-file-name'.
+            map_io_error(e, &src_str)
         }
     })?;
 
@@ -846,6 +882,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rename_no_overwrite_fallback_checks_destination_and_renames() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        fs::write(&src, b"source").await.unwrap();
+        tokio::fs::symlink("missing-target", &dest).await.unwrap();
+
+        let error = rename_no_overwrite_fallback(&src, &dest)
+            .await
+            .expect_err("dangling symlink is an existing destination");
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(fs::symlink_metadata(&dest).await.is_ok());
+        assert!(fs::metadata(&src).await.is_ok());
+
+        fs::remove_file(&dest).await.unwrap();
+        rename_no_overwrite_fallback(&src, &dest)
+            .await
+            .expect("missing destination is renamed");
+        assert_eq!(fs::read(&dest).await.unwrap(), b"source");
+        assert!(fs::metadata(&src).await.is_err());
+    }
+
+    #[tokio::test]
     async fn rename_no_overwrite_rejects_dangling_symlink() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let src = tmp.path().join("src");
@@ -873,6 +932,33 @@ mod tests {
         assert_eq!(errno, Some(i64::from(libc::EEXIST)));
         assert!(fs::symlink_metadata(&dest).await.is_ok());
         assert!(fs::metadata(&src).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn read_reports_total_file_size_with_partial_chunk() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("file");
+        fs::write(&path, b"0123456789").await.unwrap();
+
+        let result = read(msgpack_map! {
+            "path" => path_value(&path),
+            "offset" => 2u64,
+            "length" => 4u64,
+        })
+        .await
+        .expect("read partial chunk");
+
+        let field = |name: &str| {
+            result
+                .as_map()
+                .unwrap()
+                .iter()
+                .find(|(key, _)| key.as_str() == Some(name))
+                .map(|(_, value)| value.clone())
+        };
+        assert_eq!(field("content"), Some(Value::Binary(b"2345".to_vec())));
+        assert_eq!(field("size").and_then(|v| v.as_u64()), Some(4));
+        assert_eq!(field("file_size").and_then(|v| v.as_u64()), Some(10));
     }
 
     #[tokio::test]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -165,25 +165,60 @@ fn system_statvfs(params: Value) -> HandlerResult {
     })
 }
 
+fn supplementary_groups_with<F>(
+    initial_count: usize,
+    mut getgroups: F,
+) -> std::io::Result<Vec<libc::gid_t>>
+where
+    F: FnMut(&mut [libc::gid_t]) -> std::io::Result<usize>,
+{
+    let mut count = initial_count;
+    loop {
+        let mut groups = vec![0; count];
+        match getgroups(&mut groups) {
+            Ok(actual_count) => {
+                if actual_count > groups.len() {
+                    count = actual_count;
+                    continue;
+                }
+                groups.truncate(actual_count);
+                return Ok(groups);
+            }
+            // Group membership can change after the sizing call.  Retry with a
+            // larger buffer instead of relying on a fixed supplementary limit.
+            Err(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(libc::EINVAL) | Some(libc::ERANGE)
+                ) =>
+            {
+                count = count.saturating_mul(2).max(1);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn supplementary_groups() -> std::io::Result<Vec<libc::gid_t>> {
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    supplementary_groups_with(count as usize, |groups| {
+        let actual_count =
+            unsafe { libc::getgroups(groups.len() as libc::c_int, groups.as_mut_ptr()) };
+        if actual_count < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(actual_count as usize)
+        }
+    })
+}
+
 /// Get groups for the current user
 fn system_groups() -> HandlerResult {
-    // Query how many groups we need.  On Linux/macOS, getgroups(0, NULL)
-    // returns the count without writing.
-    let needed = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
-    if needed < 0 {
-        return Err(RpcError::io_error(std::io::Error::last_os_error()));
-    }
-
-    // Allocate at least 1 so a zero-length result still has a valid pointer.
-    let capacity = (needed as usize).max(1);
-    let mut groups: Vec<libc::gid_t> = vec![0; capacity];
-
-    let actual_count = unsafe { libc::getgroups(capacity as libc::c_int, groups.as_mut_ptr()) };
-    if actual_count < 0 {
-        return Err(RpcError::io_error(std::io::Error::last_os_error()));
-    }
-
-    groups.truncate(actual_count as usize);
+    let groups = supplementary_groups().map_err(RpcError::io_error)?;
 
     // Convert to group info with names
     let group_info: Vec<Value> = groups
@@ -372,6 +407,42 @@ async fn dispatch_inner(request: Request) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn groups_retry_after_erange() {
+        let mut calls = 0;
+        let groups = supplementary_groups_with(1, |buffer| {
+            calls += 1;
+            if calls == 1 {
+                return Err(std::io::Error::from_raw_os_error(libc::ERANGE));
+            }
+            assert!(buffer.len() >= 2);
+            buffer[..2].copy_from_slice(&[10, 20]);
+            Ok(2)
+        })
+        .expect("retry getgroups after ERANGE");
+
+        assert_eq!(groups, vec![10, 20]);
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn groups_retry_after_zero_length_sizing_call() {
+        let mut calls = 0;
+        let groups = supplementary_groups_with(0, |buffer| {
+            calls += 1;
+            if buffer.is_empty() {
+                return Ok(2);
+            }
+            buffer.copy_from_slice(&[10, 20]);
+            Ok(2)
+        })
+        .expect("retry getgroups after sizing call");
+
+        assert_eq!(groups, vec![10, 20]);
+        assert_eq!(calls, 2);
+    }
+
     use crate::msgpack_map;
     use std::os::unix::ffi::OsStrExt;
 

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -36,6 +36,7 @@ fn system_info() -> HandlerResult {
         "os" => std::env::consts::OS,
         "arch" => std::env::consts::ARCH,
         "watcher" => watcher_kind(),
+        "max_read_chunk_bytes" => io::MAX_FILE_READ_CHUNK_BYTES as u64,
         "hostname" => hostname(),
         "uid" => unsafe { libc::getuid() },
         "gid" => unsafe { libc::getgid() },

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
+use std::path::{Path, PathBuf};
 use std::process::{Command as StdCommand, ExitStatus, Stdio};
 use std::sync::{Arc, OnceLock};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -19,12 +20,104 @@ use tokio::sync::Mutex;
 
 use super::HandlerResult;
 
+const MAX_PROCESS_READ_BYTES: usize = 1024 * 1024;
+
+fn command_path(command: &str, cwd: Option<&str>) -> PathBuf {
+    let path = Path::new(command);
+    if path.is_relative() && command.contains('/') {
+        cwd.map_or_else(
+            || path.to_path_buf(),
+            |dir| PathBuf::from(super::expand_tilde(dir)).join(path),
+        )
+    } else {
+        path.to_path_buf()
+    }
+}
+
+fn executable_is_missing_sync(
+    command: &str,
+    cwd: Option<&str>,
+    env: Option<&HashMap<String, String>>,
+    clear_env: bool,
+) -> bool {
+    if cwd.is_some_and(|dir| !Path::new(&super::expand_tilde(dir)).is_dir()) {
+        return false;
+    }
+
+    if command.contains('/') {
+        return matches!(
+            std::fs::metadata(command_path(command, cwd)),
+            Err(error) if error.kind() == ErrorKind::NotFound
+        );
+    }
+
+    let path = env
+        .and_then(|variables| variables.get("PATH").cloned())
+        .or_else(|| (!clear_env).then(|| std::env::var("PATH").ok()).flatten())
+        .unwrap_or_else(|| "/usr/bin:/bin".to_string());
+    let cwd = cwd.map(|dir| PathBuf::from(super::expand_tilde(dir)));
+    std::env::split_paths(&path).all(|dir| {
+        let dir = if dir.is_relative() {
+            cwd.as_ref().map_or(dir.clone(), |cwd| cwd.join(dir))
+        } else {
+            dir
+        };
+        !dir.join(command).is_file()
+    })
+}
+
+async fn executable_is_missing(
+    command: &str,
+    cwd: Option<&str>,
+    env: Option<&HashMap<String, String>>,
+    clear_env: bool,
+) -> bool {
+    let command = command.to_owned();
+    let cwd = cwd.map(str::to_owned);
+    let env = env.cloned();
+    tokio::task::spawn_blocking(move || {
+        executable_is_missing_sync(&command, cwd.as_deref(), env.as_ref(), clear_env)
+    })
+    .await
+    .unwrap_or(false)
+}
+
+fn spawn_error(error: std::io::Error, executable_missing: bool) -> RpcError {
+    let mut data = Vec::new();
+    if let Some(errno) = error.raw_os_error() {
+        data.push((
+            Value::String("os_errno".into()),
+            Value::Integer(errno.into()),
+        ));
+    }
+    data.push((
+        Value::String("spawn_not_found".into()),
+        Value::Boolean(error.kind() == ErrorKind::NotFound && executable_missing),
+    ));
+    RpcError {
+        code: RpcError::PROCESS_ERROR,
+        message: format!("Failed to spawn process: {error}"),
+        data: Some(Value::Map(data)),
+    }
+}
+
 // ============================================================================
 // Process management for async processes
 // ============================================================================
 
 static PROCESS_MAP: OnceLock<Mutex<HashMap<u32, ManagedProcess>>> = OnceLock::new();
 static PID_COUNTER: OnceLock<Mutex<u32>> = OnceLock::new();
+
+#[cfg(test)]
+static PROCESS_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) async fn test_process_map_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    PROCESS_TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .await
+}
 
 fn get_process_map() -> &'static Mutex<HashMap<u32, ManagedProcess>> {
     PROCESS_MAP.get_or_init(|| Mutex::new(HashMap::new()))
@@ -101,9 +194,19 @@ pub async fn run(params: Value) -> HandlerResult {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| RpcError::process_error(format!("Failed to spawn process: {}", e)))?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let executable_missing = executable_is_missing(
+                &params.cmd,
+                params.cwd.as_deref(),
+                params.env.as_ref(),
+                params.clear_env,
+            )
+            .await;
+            return Err(spawn_error(error, executable_missing));
+        }
+    };
 
     // Write stdin if provided (no base64 decoding needed!)
     if let Some(stdin_data) = params.stdin
@@ -171,9 +274,19 @@ pub async fn start(params: Value) -> HandlerResult {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| RpcError::process_error(format!("Failed to spawn process: {}", e)))?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            let executable_missing = executable_is_missing(
+                &params.cmd,
+                params.cwd.as_deref(),
+                params.env.as_ref(),
+                params.clear_env,
+            )
+            .await;
+            return Err(spawn_error(error, executable_missing));
+        }
+    };
 
     let pid = get_next_pid().await;
 
@@ -249,10 +362,10 @@ pub async fn read(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    if params.max_bytes == 0 {
-        return Err(RpcError::invalid_params(
-            "max_bytes must be greater than zero",
-        ));
+    if params.max_bytes == 0 || params.max_bytes > MAX_PROCESS_READ_BYTES {
+        return Err(RpcError::invalid_params(format!(
+            "max_bytes must be between 1 and {MAX_PROCESS_READ_BYTES}"
+        )));
     }
 
     let timeout = params.timeout_ms.unwrap_or(0);
@@ -883,6 +996,12 @@ pub async fn read_pty(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    if params.max_bytes == 0 || params.max_bytes > MAX_PROCESS_READ_BYTES {
+        return Err(RpcError::invalid_params(format!(
+            "max_bytes must be between 1 and {MAX_PROCESS_READ_BYTES}"
+        )));
+    }
+
     let timeout = params.timeout_ms.unwrap_or(0);
     let mut buf = vec![0u8; params.max_bytes];
 
@@ -1225,7 +1344,7 @@ mod tests {
         .expect("read pipe process")
     }
 
-    async fn wait_for_child_exit(pid: u32) {
+    async fn child_has_exited(pid: u32) -> bool {
         for _ in 0..100 {
             let result = status(Value::Map(vec![(
                 Value::String("pid".into()),
@@ -1234,12 +1353,35 @@ mod tests {
             .await
             .expect("query pipe process status");
             if map_get(&result, "exited").and_then(Value::as_bool) == Some(true) {
-                return;
+                return true;
             }
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
 
-        panic!("process {pid} did not exit");
+        false
+    }
+
+    async fn wait_for_child_exit(pid: u32) {
+        assert!(child_has_exited(pid).await, "process {pid} did not exit");
+    }
+
+    async fn pipe_streams_at_eof(pid: u32) -> bool {
+        let (stdout, stderr) = {
+            let processes = get_process_map().lock().await;
+            let managed = processes.get(&pid).expect("pipe process");
+            (managed.stdout.clone(), managed.stderr.clone())
+        };
+        stdout.lock().await.is_none() && stderr.lock().await.is_none()
+    }
+
+    async fn remove_pipe_process(pid: u32) {
+        let managed = get_process_map().lock().await.remove(&pid);
+        if let Some(mut managed) = managed
+            && managed.exit_status.is_none()
+        {
+            let _ = managed.child.start_kill();
+            let _ = managed.child.wait().await;
+        }
     }
 
     async fn collect_pipe_output(pid: u32, max_bytes: usize) -> (Vec<u8>, Vec<u8>, i64) {
@@ -1259,11 +1401,20 @@ mod tests {
                 let exit_code = map_get(&result, "exit_code")
                     .and_then(Value::as_i64)
                     .expect("exit code");
-                get_process_map().lock().await.remove(&pid);
+                remove_pipe_process(pid).await;
                 return (stdout, stderr, exit_code);
+            }
+
+            if pipe_streams_at_eof(pid).await {
+                tokio::task::yield_now().await;
+                if !child_has_exited(pid).await {
+                    remove_pipe_process(pid).await;
+                    panic!("process {pid} did not exit after pipe EOF");
+                }
             }
         }
 
+        remove_pipe_process(pid).await;
         panic!("process {pid} did not reach EOF");
     }
 
@@ -1279,8 +1430,94 @@ mod tests {
         assert_eq!(error.code, RpcError::INVALID_PARAMS);
     }
 
+    #[test]
+    fn executable_lookup_resolves_relative_path_against_cwd() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let bin = tmp.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        std::fs::write(bin.join("tool"), b"").unwrap();
+        let env = HashMap::from([("PATH".to_string(), "bin".to_string())]);
+
+        assert!(!executable_is_missing_sync(
+            "tool",
+            tmp.path().to_str(),
+            Some(&env),
+            true
+        ));
+    }
+
+    #[tokio::test]
+    async fn process_spawn_not_found_preserves_errno() {
+        let error = run(Value::Map(vec![(
+            Value::String("cmd".into()),
+            Value::String("/definitely/not/a/tramp-rpc-command".into()),
+        )]))
+        .await
+        .expect_err("missing command should fail to spawn");
+
+        assert_eq!(error.code, RpcError::PROCESS_ERROR);
+        let errno = error
+            .data
+            .as_ref()
+            .and_then(Value::as_map)
+            .and_then(|data| {
+                data.iter()
+                    .find(|(key, _)| key.as_str() == Some("os_errno"))
+            })
+            .and_then(|(_, value)| value.as_i64());
+        assert_eq!(errno, Some(i64::from(libc::ENOENT)));
+        assert_eq!(
+            map_get(error.data.as_ref().unwrap(), "spawn_not_found"),
+            Some(&Value::Boolean(true))
+        );
+    }
+
+    #[tokio::test]
+    async fn process_spawn_missing_cwd_is_not_command_not_found() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let missing_cwd = tmp.path().join("missing");
+        let error = run(Value::Map(vec![
+            (
+                Value::String("cmd".into()),
+                Value::String("/bin/true".into()),
+            ),
+            (
+                Value::String("cwd".into()),
+                Value::String(missing_cwd.to_string_lossy().into_owned().into()),
+            ),
+        ]))
+        .await
+        .expect_err("missing cwd should fail to spawn");
+
+        assert_eq!(error.code, RpcError::PROCESS_ERROR);
+        assert_eq!(
+            map_get(error.data.as_ref().unwrap(), "os_errno").and_then(Value::as_i64),
+            Some(i64::from(libc::ENOENT))
+        );
+        assert_eq!(
+            map_get(error.data.as_ref().unwrap(), "spawn_not_found"),
+            Some(&Value::Boolean(false))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_size_limit_rejects_oversized_request() {
+        let error = read(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(1.into())),
+            (
+                Value::String("max_bytes".into()),
+                Value::Integer(((MAX_PROCESS_READ_BYTES + 1) as u64).into()),
+            ),
+        ]))
+        .await
+        .expect_err("oversized process read should be rejected");
+
+        assert_eq!(error.code, RpcError::INVALID_PARAMS);
+    }
+
     #[tokio::test]
     async fn process_read_drains_pipes_after_status_reports_exit() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("printf abc; printf XYZ >&2").await;
         wait_for_child_exit(pid).await;
 
@@ -1292,12 +1529,8 @@ mod tests {
 
     #[tokio::test]
     async fn process_read_waits_for_eof_after_child_exit() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("printf first; sleep 0.1; printf second").await;
-
-        // Ensure the first chunk is buffered before the long-polling read.  The
-        // stderr read then remains pending until the shell exits, reproducing
-        // the race where try_wait succeeds while stdout still contains data.
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
         assert_eq!(stdout, b"firstsecond");
@@ -1307,6 +1540,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_read_drains_output_larger_than_max_bytes() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("printf 0123456789abcdef").await;
         let (stdout, stderr, exit_code) = collect_pipe_output(pid, 3).await;
 
@@ -1317,8 +1551,8 @@ mod tests {
 
     #[tokio::test]
     async fn process_read_returns_stdout_before_idle_stderr_timeout() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("printf stdout; sleep 1").await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         let started = std::time::Instant::now();
         let first = read_pipe_process(pid, 65_536, 500).await;
@@ -1344,6 +1578,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_read_delivers_output_written_immediately_before_exit() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("sleep 0.05; printf final").await;
         let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
 
@@ -1354,12 +1589,28 @@ mod tests {
 
     #[tokio::test]
     async fn process_read_drains_stdout_and_stderr_separately() {
+        let _test_lock = test_process_map_lock().await;
         let pid = start_pipe_process("printf stdout; printf stderr >&2").await;
         let (stdout, stderr, exit_code) = collect_pipe_output(pid, 65_536).await;
 
         assert_eq!(stdout, b"stdout");
         assert_eq!(stderr, b"stderr");
         assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn read_pty_rejects_oversized_max_bytes() {
+        let error = read_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(1.into())),
+            (
+                Value::String("max_bytes".into()),
+                Value::Integer(((MAX_PROCESS_READ_BYTES + 1) as u64).into()),
+            ),
+        ]))
+        .await
+        .expect_err("oversized PTY read should be rejected");
+
+        assert_eq!(error.code, RpcError::INVALID_PARAMS);
     }
 
     #[tokio::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -167,6 +167,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_write_not_blocked_by_long_poll_read() {
+        let _test_lock = handlers::process::test_process_map_lock().await;
         let start_params = Value::Map(vec![
             (Value::String("cmd".into()), Value::String("cat".into())),
             (Value::String("cwd".into()), Value::String("/tmp".into())),

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -495,6 +495,8 @@ Returns the result or signals an error."
           (should (assoc 'uid result))
           (should (assoc 'gid result))
           (should (assoc 'home result))
+          (should (= (alist-get 'max_read_chunk_bytes result)
+                     (* 16 1024 1024)))
           (should (member (alist-get 'watcher result)
                           '("inotify" "fsevent" "kqueue" "poll"
                             "windows" "null" "unknown")))
@@ -596,27 +598,53 @@ Returns the result or signals an error."
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-file-read-chunks-past-rpc-limit ()
-  "File reads continue across the server's per-request byte limit."
+  "File reads pipeline chunks beyond the server's per-request byte limit."
   (let ((source "abcdefghij")
         (tramp-rpc--file-read-chunk-size 4)
         (tramp-rpc-compress-file-read nil)
-        calls)
-    (cl-letf (((symbol-function 'tramp-rpc--call)
-               (lambda (_vec method params &rest _)
-                 (should (equal method "file.read"))
+        (report-file-size t)
+        calls batch-sizes stat-calls)
+    (cl-labels ((read-result
+                 (params)
                  (let* ((offset (or (alist-get 'offset params) 0))
                         (requested (alist-get 'length params))
                         (end (min (length source) (+ offset requested))))
                    (push (cons offset requested) calls)
-                   `((content . ,(substring source offset end)))))))
-      (should (equal (tramp-rpc--read-file-bytes 'vec "/tmp/file")
-                     source))
-      (should (equal (nreverse calls) '((0 . 4) (4 . 4) (8 . 4))))
-      (setq calls nil)
-      (should (equal (tramp-rpc--read-file-bytes
-                      'vec "/tmp/file" 2 9)
-                     "cdefghi"))
-      (should (equal (nreverse calls) '((2 . 4) (6 . 3)))))))
+                   `((content . ,(substring source offset end))
+                     ,@(when report-file-size
+                         `((file_size . ,(length source))))))))
+      (cl-letf (((symbol-function 'tramp-rpc--cached-system-info)
+                 (lambda (_vec) '((max_read_chunk_bytes . 16))))
+                ;; Only the old-server fallback may stat; the primary path
+                ;; must plan chunks from the first response's `file_size'.
+                ((symbol-function 'tramp-rpc--call-file-stat)
+                 (lambda (&rest _)
+                   (setq stat-calls (1+ (or stat-calls 0)))
+                   `((size . ,(length source)))))
+                ((symbol-function 'tramp-rpc--call)
+                 (lambda (_vec method params &rest _)
+                   (should (equal method "file.read"))
+                   (read-result params)))
+                ((symbol-function 'tramp-rpc--call-batch)
+                 (lambda (_vec requests)
+                   (push (length requests) batch-sizes)
+                   (mapcar (lambda (request) (read-result (cdr request))) requests))))
+        (should (equal (tramp-rpc--read-file-bytes 'vec "/tmp/file") source))
+        (should (equal (nreverse calls) '((0 . 4) (4 . 4) (8 . 2))))
+        (should (equal (nreverse batch-sizes) '(2)))
+        (should-not stat-calls)
+        (setq calls nil batch-sizes nil)
+        (should (equal (tramp-rpc--read-file-bytes 'vec "/tmp/file" 2 9)
+                       "cdefghi"))
+        (should (equal (nreverse calls) '((2 . 4) (6 . 3))))
+        (should (equal (nreverse batch-sizes) '(1)))
+        (should-not stat-calls)
+        ;; Old servers omit `file_size'; one file.stat fallback plans the rest.
+        (setq calls nil batch-sizes nil report-file-size nil)
+        (should (equal (tramp-rpc--read-file-bytes 'vec "/tmp/file") source))
+        (should (equal (nreverse calls) '((0 . 4) (4 . 4) (8 . 2))))
+        (should (equal (nreverse batch-sizes) '(2)))
+        (should (equal stat-calls 1))))))
 
 (ert-deftest tramp-rpc-mock-test-server-rename-dangling-symlink-no-overwrite ()
   "No-overwrite rename treats a dangling symlink as an existing destination."
@@ -2959,6 +2987,43 @@ This matches the behavior expected by `tramp-test28-process-file'."
             (should (file-exists-p (expand-file-name name
                                                      (expand-file-name "dir" trash-root))))))
       (delete-directory trash-root t))))
+
+(ert-deftest tramp-rpc-mock-test-trash-small-file-growth-retries-chunked ()
+  "A small trash file that grows past the RPC limit is retried chunked."
+  :tags '(:delete)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dest (make-temp-file "tramp-rpc-trash-copy" t))
+         (tramp-rpc--file-read-chunk-size 4)
+         (dir-stat '((type . "directory") (mode . 16877)))
+         (file-stat '((type . "file") (size . 1) (mode . 33188)))
+         retry-called)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--cached-system-info)
+                   (lambda (_vec) '((max_read_chunk_bytes . 4))))
+                  ((symbol-function 'tramp-rpc--call-file-stat)
+                   (lambda (&rest _) '((size . 4))))
+                  ((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params &rest _)
+                     (pcase method
+                       ("dir.list"
+                        `(((name . "grown") (type . "file")
+                           (attrs . ,file-stat))))
+                       ("file.read"
+                        (setq retry-called t)
+                        '((content . "data")))
+                       (_ (error "Unexpected RPC method: %s" method)))))
+                  ((symbol-function 'tramp-rpc--call-batch)
+                   (lambda (_vec _requests)
+                     '((:error -32602 :message "file grew")))))
+          (tramp-rpc--copy-remote-trash-directory-to-local
+           'vec "/tmp/source" (expand-file-name "copied" dest) dir-stat)
+          (should retry-called)
+          (should (equal (with-temp-buffer
+                           (insert-file-contents-literally
+                            (expand-file-name "copied/grown" dest))
+                           (buffer-string))
+                         "data")))
+      (delete-directory dest t))))
 
 (ert-deftest tramp-rpc-mock-test-delete-file-trash-can-be-inhibited ()
   "Test `remote-file-name-inhibit-delete-by-moving-to-trash' forces unlink."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -473,7 +473,9 @@ Returns the result or signals an error."
         (unless response
           (error "Timeout waiting for RPC response"))
         (if (tramp-rpc-protocol-error-p response)
-            (list :error (tramp-rpc-protocol-error-message response))
+            (list :error (tramp-rpc-protocol-error-message response)
+                  :code (tramp-rpc-protocol-error-code response)
+                  :data (tramp-rpc-protocol-error-data response))
           (plist-get response :result))))))
 
 ;;; Server tests (require server to be available)
@@ -550,6 +552,92 @@ Returns the result or signals an error."
           (let ((result (tramp-rpc-mock-test--rpc-call
                          "file.stat" `((path . ,(encode-coding-string test-file 'utf-8))))))
             (should (not result)))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-write-offset-preserves-suffix ()
+  "The file.write offset field replaces bytes without truncating the suffix."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((path (expand-file-name "offset" tramp-rpc-mock-test-temp-dir)))
+          (tramp-rpc-mock-test--rpc-call
+           "file.write" `((path . ,(encode-coding-string path 'utf-8))
+                          (content . "abcdef")))
+          (tramp-rpc-mock-test--rpc-call
+           "file.write" `((path . ,(encode-coding-string path 'utf-8))
+                          (content . "XY")
+                          (offset . 2)))
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "file.read" `((path . ,(encode-coding-string path 'utf-8)))))
+                 (content (alist-get 'content result)))
+            (should (equal (msgpack-bin-string content) "abXYef")))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-server-write-offset-creates-zero-filled-file ()
+  "An offset write creates a missing file with its leading hole zero-filled."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((path (expand-file-name "offset-missing" tramp-rpc-mock-test-temp-dir)))
+          (tramp-rpc-mock-test--rpc-call
+           "file.write" `((path . ,(encode-coding-string path 'utf-8))
+                          (content . "XY")
+                          (offset . 4)))
+          (let* ((result (tramp-rpc-mock-test--rpc-call
+                          "file.read" `((path . ,(encode-coding-string path 'utf-8)))))
+                 (content (alist-get 'content result)))
+            (should (equal (msgpack-bin-string content) "\0\0\0\0XY")))))
+    (tramp-rpc-mock-test--stop-server)))
+
+(ert-deftest tramp-rpc-mock-test-file-read-chunks-past-rpc-limit ()
+  "File reads continue across the server's per-request byte limit."
+  (let ((source "abcdefghij")
+        (tramp-rpc--file-read-chunk-size 4)
+        (tramp-rpc-compress-file-read nil)
+        calls)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params &rest _)
+                 (should (equal method "file.read"))
+                 (let* ((offset (or (alist-get 'offset params) 0))
+                        (requested (alist-get 'length params))
+                        (end (min (length source) (+ offset requested))))
+                   (push (cons offset requested) calls)
+                   `((content . ,(substring source offset end)))))))
+      (should (equal (tramp-rpc--read-file-bytes 'vec "/tmp/file")
+                     source))
+      (should (equal (nreverse calls) '((0 . 4) (4 . 4) (8 . 4))))
+      (setq calls nil)
+      (should (equal (tramp-rpc--read-file-bytes
+                      'vec "/tmp/file" 2 9)
+                     "cdefghi"))
+      (should (equal (nreverse calls) '((2 . 4) (6 . 3)))))))
+
+(ert-deftest tramp-rpc-mock-test-server-rename-dangling-symlink-no-overwrite ()
+  "No-overwrite rename treats a dangling symlink as an existing destination."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((src (expand-file-name "rename-src" tramp-rpc-mock-test-temp-dir))
+              (dest (expand-file-name "rename-dest" tramp-rpc-mock-test-temp-dir)))
+          (with-temp-file src (insert "source"))
+          (make-symbolic-link "missing-target" dest)
+          (let ((result (tramp-rpc-mock-test--rpc-call
+                         "file.rename"
+                         `((src . ,(encode-coding-string src 'utf-8))
+                           (dest . ,(encode-coding-string dest 'utf-8))))))
+            (should (= (plist-get result :code) -32003))
+            (should (= (alist-get 'os_errno (plist-get result :data)) 17))
+            (should (file-symlink-p dest))
+            (should (file-exists-p src)))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-directory-operations ()
@@ -808,6 +896,30 @@ Returns the result or signals an error."
             (should (string-match-p "hello world" (msgpack-bin-string stdout))))))
     (tramp-rpc-mock-test--stop-server)))
 
+(ert-deftest tramp-rpc-mock-test-server-process-spawn-enoent-is-classified ()
+  "Local process.run distinguishes a missing executable from a missing cwd."
+  :tags '(:server :process)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (unwind-protect
+      (progn
+        (tramp-rpc-mock-test--start-server)
+        (let ((missing-command
+               (tramp-rpc-mock-test--rpc-call
+                "process.run" `((cmd . "/definitely/not/tramp-rpc-command"))))
+              (missing-cwd
+               (tramp-rpc-mock-test--rpc-call
+                "process.run" `((cmd . "/bin/true")
+                                 (cwd . ,(expand-file-name "missing-cwd"
+                                                            tramp-rpc-mock-test-temp-dir))))))
+          (should (= (plist-get missing-command :code) -32004))
+          (should (= (alist-get 'os_errno (plist-get missing-command :data)) 2))
+          (should (alist-get 'spawn_not_found (plist-get missing-command :data)))
+          (should (= (plist-get missing-cwd :code) -32004))
+          (should (= (alist-get 'os_errno (plist-get missing-cwd :data)) 2))
+          (should-not (alist-get 'spawn_not_found (plist-get missing-cwd :data)))))
+    (tramp-rpc-mock-test--stop-server)))
+
 (ert-deftest tramp-rpc-mock-test-server-process-signal-exit ()
   "Test process.run returns 128+signal for signal-killed processes.
 This matches the behavior expected by `tramp-test28-process-file'."
@@ -863,6 +975,44 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (require 'tramp-rpc)
 (defconst tramp-rpc-mock-test--tramp-rpc-loaded t
   "The full TRAMP-RPC backend was loaded successfully.")
+
+(ert-deftest tramp-rpc-mock-test-file-executable-root ()
+  "Root requires an execute bit, rather than bypassing all mode checks."
+  (let ((attrs '(nil 1 1 1 0 0 0 0 "----------")))
+    (should-not (tramp-rpc--mode-executable-p "----------" 0 0 attrs nil))
+    (should (tramp-rpc--mode-executable-p "------x---" 0 0 attrs nil))))
+
+(ert-deftest tramp-rpc-mock-test-directory-count-semantics ()
+  "Both directory handlers share Emacs COUNT semantics."
+  (let ((entries '("a" "b" "c")))
+    (should (equal (tramp-rpc--apply-directory-count entries nil) entries))
+    (should (equal (tramp-rpc--apply-directory-count entries 2) '("a" "b")))
+    (should-not (tramp-rpc--apply-directory-count entries 0))
+    (dolist (count '(-1 "invalid"))
+      (should-error (tramp-rpc--apply-directory-count entries count)
+                    :type 'wrong-type-argument))))
+
+(ert-deftest tramp-rpc-mock-test-pipelined-timeout-signals-error ()
+  "A live connection with no response reaches the pipeline timeout branch."
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-pipeline-test*"))
+         (process (start-process "tramp-rpc-pipeline-test" buffer "sh" "-c" "sleep 2"))
+         (vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
+         (timeout 0.15)
+         (started (float-time)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                   (lambda (_vec) (list :process process :buffer buffer))))
+          (should (process-live-p process))
+          (condition-case err
+              (progn
+                (tramp-rpc--receive-responses vec '(1) timeout)
+                (error "Expected pipelined response timeout"))
+            (remote-file-error
+             (should (string-match-p "Timeout" (error-message-string err)))))
+          (should (>= (- (float-time) started) (* timeout 0.8)))
+          (should (process-live-p process)))
+      (when (process-live-p process) (delete-process process))
+      (kill-buffer buffer))))
 
 (declare-function tramp-rpc-magit--file-exists-in-ancestor-scan
                   "tramp-rpc-magit" (filename scan))
@@ -3964,6 +4114,45 @@ discard it for being unreadable."
       (should (equal (alist-get 'args captured-params) ["pattern"]))
       (should (equal (assoc "PATH" (alist-get 'env captured-params))
                      '("PATH" . "/home/user/.cargo/bin:/usr/bin:/bin"))))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-not-found-returns-127 ()
+  "Only a structured spawn ENOENT becomes process-file status 127."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/"))
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (_vec) '("/usr/bin")))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+               (lambda (&rest _) nil))
+               ((symbol-function 'tramp-rpc--call)
+                (lambda (&rest _)
+                  (tramp-rpc--signal-rpc-error
+                   "RPC" "missing executable" tramp-rpc-protocol-error-process 2
+                   nil '((spawn_not_found . t))))))
+       (should (= (tramp-rpc-handle-process-file "missing" nil nil nil) 127)))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-preserves-other-rpc-errors ()
+  "A process cwd ENOENT remains a remote-file-error, not status 127."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/"))
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (_vec) '("/usr/bin")))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+               (lambda (&rest _) nil))
+               ((symbol-function 'tramp-rpc--call)
+                (lambda (&rest _)
+                  (tramp-rpc--signal-rpc-error
+                   "RPC" "missing cwd" tramp-rpc-protocol-error-process 2 nil
+                   '((os_errno . 2) (spawn_not_found . :msgpack-false))))))
+       (should-error (tramp-rpc-handle-process-file "broken" nil nil nil)
+                     :type 'remote-file-error))))
 
 (ert-deftest tramp-rpc-mock-test-process-file-passes-tramp-remote-environment ()
   "Test `process-file' forwards dynamic TRAMP remote process env vars."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -379,6 +379,12 @@ The directory is deleted after BODY completes."
     (should (file-directory-p dir))
     (should (file-writable-p dir))))
 
+(ert-deftest tramp-rpc-test00-remote-groups-dynamic-sizing ()
+  "The server returns the remote user's complete supplementary group list."
+  (skip-unless (tramp-rpc-test-enabled))
+  (let ((vec (tramp-dissect-file-name (tramp-rpc-test--remote-directory))))
+    (should (listp (tramp-get-remote-groups vec 'integer)))))
+
 ;;; ============================================================================
 ;;; Test 01: File Name Syntax
 ;;; ============================================================================
@@ -621,6 +627,30 @@ The directory is deleted after BODY completes."
                                    (buffer-string)))))
       (ignore-errors (delete-file file)))))
 
+(ert-deftest tramp-rpc-test05-write-region-offset-preserves-suffix ()
+  "Writing at an integer offset leaves the remaining remote bytes intact."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-file file "abcdef"
+    (write-region "XY" nil file 2)
+    (should (equal (with-temp-buffer
+                     (insert-file-contents file)
+                     (buffer-string))
+                   "abXYef"))))
+
+(ert-deftest tramp-rpc-test05-write-region-offset-creates-zero-filled-file ()
+  "An integer offset write creates a missing remote file with a zero-filled hole."
+  (skip-unless (tramp-rpc-test-enabled))
+  (let ((file (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (write-region "XY" nil file 4)
+          (should (equal (with-temp-buffer
+                           (set-buffer-multibyte nil)
+                           (insert-file-contents-literally file)
+                           (buffer-string))
+                         "\0\0\0\0XY")))
+      (ignore-errors (delete-file file)))))
+
 (ert-deftest tramp-rpc-test05-write-region-multiline ()
   "Test `write-region' with multiline content."
   (skip-unless (tramp-rpc-test-enabled))
@@ -752,10 +782,11 @@ This tests Issue #13: Chinese characters decode incorrectly."
   (skip-unless (tramp-rpc-test-enabled))
 
   (tramp-rpc-test--with-temp-file tmp "0123456789"
-    ;; Read bytes 2-5
+    ;; Read bytes 2-5 across two bounded RPC chunks.
     (with-temp-buffer
-      (tramp-rpc-test--with-call-count 1
-        (insert-file-contents tmp nil 2 6))
+      (let ((tramp-rpc--file-read-chunk-size 2))
+        (tramp-rpc-test--with-call-count 2
+          (insert-file-contents tmp nil 2 6)))
       (should (equal (buffer-string) "2345")))))
 
 ;;; ============================================================================
@@ -1218,6 +1249,22 @@ signal `file-already-exists'.  With trailing slash (via
       (ignore-errors (delete-file src))
       (ignore-errors (delete-file dest)))))
 
+(ert-deftest tramp-rpc-test06-rename-dangling-symlink-no-overwrite ()
+  "No-overwrite rename rejects a dangling symlink destination."
+  (skip-unless (tramp-rpc-test-enabled))
+  (let ((src (tramp-rpc-test--make-temp-name))
+        (dest (tramp-rpc-test--make-temp-name)))
+    (unwind-protect
+        (progn
+          (write-region "source" nil src)
+          (make-symbolic-link "missing-target" dest)
+          (should-error (rename-file src dest)
+                        :type 'file-already-exists)
+          (should (file-symlink-p dest))
+          (should (file-exists-p src)))
+      (ignore-errors (delete-file src))
+      (ignore-errors (delete-file dest)))))
+
 (ert-deftest tramp-rpc-test06-delete-file ()
   "Test `delete-file' for TRAMP RPC files."
   (skip-unless (tramp-rpc-test-enabled))
@@ -1376,6 +1423,33 @@ This exercises copy-then-delete for cross-remote renames."
       (should (= (length txt-files) 2))
       (should (member "file1.txt" txt-files))
       (should (member "file2.txt" txt-files)))))
+
+(ert-deftest tramp-rpc-test07-directory-files-count ()
+  "Directory COUNT accepts natural numbers and rejects other values."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir dir
+    (dolist (name '("a" "b" "c"))
+      (write-region name nil (expand-file-name name dir)))
+    (let ((all (directory-files dir)))
+      (should (equal (directory-files dir nil nil nil 2) (seq-take all 2)))
+      (should-not (directory-files dir nil nil nil 0))
+      (dolist (count '(-1 "invalid"))
+        (should-error (directory-files dir nil nil nil count)
+                      :type 'wrong-type-argument)))))
+
+(ert-deftest tramp-rpc-test07-directory-files-and-attributes-count ()
+  "Attribute directory listings implement the same COUNT contract."
+  (skip-unless (tramp-rpc-test-enabled))
+  (tramp-rpc-test--with-temp-dir dir
+    (dolist (name '("a" "b" "c"))
+      (write-region name nil (expand-file-name name dir)))
+    (let ((all (directory-files-and-attributes dir)))
+      (should (equal (directory-files-and-attributes dir nil nil nil nil 2)
+                     (seq-take all 2)))
+      (should-not (directory-files-and-attributes dir nil nil nil nil 0))
+      (dolist (count '(-1 "invalid"))
+        (should-error (directory-files-and-attributes dir nil nil nil nil count)
+                      :type 'wrong-type-argument)))))
 
 (ert-deftest tramp-rpc-test07-directory-files-and-attributes ()
   "Test `directory-files-and-attributes' for TRAMP RPC files."


### PR DESCRIPTION
## Summary

Fix offset writes, directory counts, executable checks, error mapping, dangling symlinks, dynamic groups, and bounded reads.

## Stack

Part **2 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/01-validation`
- Next PRs build on `remediation/02-file-rpc-semantics`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded, chunked remote file reads (range-aware/pipelined) with server-exposed `max_read_chunk_bytes`.
  * Added a new TRAMP-RPC protocol error code for process-related failures.

* **Bug Fixes**
  * Stricter validation for remote `file.read`, `process.read`, and PTY reads; improved chunked fallback on oversized-range rejection.
  * Improved RPC error robustness with structured `code`/`data`, better timeout/error signaling, and hardened spawn/result handling.
  * Offset `file.write` flushes reliably, supports creating missing targets, and preserves suffix bytes; improved rename no-overwrite and grouped COUNT semantics.

* **Tests**
  * Extended coverage for chunking, trash growth retry, offset write/rename edge cases, groups, COUNT handling, and process spawn/pipe/timeout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->