### PR TITLE
[6/11] Clean asynchronous state when transports close

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -43,7 +43,8 @@
                   (vec pid data &optional owner-process))
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process"
                   (vec pid &optional owner-process))
-(declare-function tramp-rpc--kill-remote-process "tramp-rpc-process")
+(declare-function tramp-rpc--kill-remote-process "tramp-rpc-process"
+                  (vec pid &optional signal connection))
 (declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
 
 ;; Functions from tramp-rpc.el

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -39,6 +39,7 @@
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")
+(declare-function tramp-rpc--get-connection "tramp-rpc" (vec))
 (declare-function tramp-rpc--call-batch "tramp-rpc")
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
@@ -156,7 +157,9 @@ must still report symlink type for lstat."
           (setq entries (cdr entries)))))))
 
 (defvar tramp-rpc-magit--ancestors-cache)
+(defvar tramp-rpc-magit--prefetch-directory)
 (defvar tramp-rpc-magit--ancestor-scan-caches)
+(defvar tramp-rpc-magit--prefetch-directory)
 
 (defun tramp-rpc-magit--clear-ancestor-caches ()
   "Clear cached ancestor marker scans."
@@ -164,9 +167,30 @@ must still report symlink type for lstat."
     (clrhash tramp-rpc-magit--ancestor-scan-caches))
   (setq tramp-rpc-magit--ancestors-cache nil))
 
+(defun tramp-rpc-magit--clear-ancestor-caches-for-connection (vec)
+  "Clear ancestor caches belonging to the connection identified by VEC."
+  (let ((connection-key (format "%S" (tramp-rpc--connection-key vec)))
+        ancestor-keys)
+    (maphash
+     (lambda (key _entry)
+       (when (and (consp key) (equal (car key) connection-key))
+         (push key ancestor-keys)))
+     tramp-rpc-magit--ancestor-scan-caches)
+    (dolist (key ancestor-keys)
+      (remhash key tramp-rpc-magit--ancestor-scan-caches))
+    (when tramp-rpc-magit--prefetch-directory
+      (with-parsed-tramp-file-name tramp-rpc-magit--prefetch-directory nil
+        (when (equal (format "%S" (tramp-rpc--connection-key v)) connection-key)
+          (setq tramp-rpc-magit--ancestors-cache nil
+                tramp-rpc-magit--prefetch-directory nil))))))
+
 (defun tramp-rpc--invalidate-cache-for-path (filename)
   "Invalidate cache entries for FILENAME."
-  (tramp-rpc-magit--clear-ancestor-caches)
+  ;; Ancestor scans are keyed by connection.  A mutation on one remote must
+  ;; not evict Magit's repository discovery results for every other remote.
+  (when (tramp-tramp-file-p filename)
+    (with-parsed-tramp-file-name filename nil
+      (tramp-rpc-magit--clear-ancestor-caches-for-connection v)))
   (cl-labels ((drop (candidate)
                 (remhash candidate tramp-rpc--file-exists-cache)
                 (remhash candidate tramp-rpc--file-truename-cache)
@@ -203,7 +227,6 @@ must still report symlink type for lstat."
 
 (defun tramp-rpc--invalidate-cache-for-subtree (directory)
   "Invalidate cache entries for DIRECTORY and all cached descendants."
-  (tramp-rpc-magit--clear-ancestor-caches)
   (let* ((expanded-dir (file-name-as-directory (expand-file-name directory)))
          (expanded-file (directory-file-name expanded-dir)))
     (tramp-rpc--invalidate-cache-for-path expanded-file)
@@ -278,7 +301,7 @@ must still report symlink type for lstat."
   "Clear file-exists and file-truename cache entries for connection VEC.
 Entries are keyed by expanded TRAMP filenames; this removes those
 matching the remote prefix of VEC."
-  (tramp-rpc-magit--clear-ancestor-caches)
+  (tramp-rpc-magit--clear-ancestor-caches-for-connection vec)
   (ignore-errors (tramp-flush-directory-properties vec "/"))
   (let ((prefix (tramp-make-tramp-file-name vec "/")))
     ;; Match the prefix up to the colon-slash that starts the localname.
@@ -401,10 +424,12 @@ DIRECTORY itself returns the empty string.  Descendants can contain slashes."
     (when events
       (tramp-rpc--debug "fs.events: %d events" (length events))
       (tramp-message process 6 "%s" events)
-      (when-let* ((vec (process-get process :tramp-rpc-vec)))
+      (when-let* ((vec (process-get process :tramp-rpc-vec))
+                  (connection (tramp-rpc--get-connection vec))
+                  ((eq process (plist-get connection :process))))
         (unless tramp-rpc--suppress-fs-notifications
-          ;; Also clear the magit process-file cache since git state may have changed.
-          (tramp-rpc-magit--clear-status-cache))
+          ;; Git state changed on this transport, not every remote connection.
+          (tramp-rpc-magit--clear-status-cache-for-connection vec))
         (let (renamed-pairs)
           ;; Linux/inotify can report the same rename as both a combined pair
           ;; and as cookie-tracked from/to events in one debounce batch.  Emacs'
@@ -472,8 +497,10 @@ When RECURSIVE is non-nil, watch subdirectories too."
             (plist-put file-notify-entry :owned nil)
             (puthash watch-key
                      (list :recursive t
-                           :directory directory
-                           :canonical-directory canonical-directory)
+                         :directory directory
+                         :canonical-directory canonical-directory
+                         :connection-process (plist-get (tramp-rpc--get-connection v)
+                                                        :process))
                      tramp-rpc--watched-directories))
         (let* ((result (tramp-rpc--call
                         v "watch.add"
@@ -484,8 +511,10 @@ When RECURSIVE is non-nil, watch subdirectories too."
           (puthash watch-key
                    (list :recursive (or recursive
                                         (tramp-rpc--watch-entry-recursive-p entry))
-                         :directory directory
-                         :canonical-directory canonical-directory)
+                           :directory directory
+                           :canonical-directory canonical-directory
+                           :connection-process (plist-get (tramp-rpc--get-connection v)
+                                                          :process))
                    tramp-rpc--watched-directories))))
     (tramp-rpc--debug "Watching: %s (recursive=%s)" localname recursive)))
 
@@ -524,12 +553,16 @@ When RECURSIVE is non-nil, watch subdirectories too."
                       localname))))))
     (tramp-rpc--debug "Unwatched: %s" localname)))
 
-(defun tramp-rpc--cleanup-watches-for-connection (vec)
-  "Remove all watched directory entries for connection VEC."
+(defun tramp-rpc--cleanup-watches-for-connection (vec &optional connection-process)
+  "Remove watched directory entries for VEC's CONNECTION-PROCESS."
   (let ((conn-key (tramp-rpc--connection-key-string vec))
         (keys-to-remove nil))
-    (maphash (lambda (key _value)
-               (when (string-prefix-p (concat conn-key ":") key)
+    (maphash (lambda (key value)
+               (when (and (string-prefix-p (concat conn-key ":") key)
+                          (or (null connection-process)
+                              (null (plist-get value :connection-process))
+                              (eq connection-process
+                                  (plist-get value :connection-process))))
                  (push key keys-to-remove)))
              tramp-rpc--watched-directories)
     (dolist (key keys-to-remove)
@@ -632,6 +665,12 @@ run normally instead of using a possibly stale status snapshot.")
 (defvar tramp-rpc-magit--status-setup-prefetch-active nil
   "Non-nil while a status setup prefetch covers nested refresh calls.")
 
+
+(defun tramp-rpc-magit--file-connection-key (filename)
+  "Return the normalized connection key for remote FILENAME, or nil."
+  (when (file-remote-p filename)
+    (with-parsed-tramp-file-name filename nil
+      (tramp-rpc--connection-key-string v))))
 
 (defun tramp-rpc-magit--get-cache-key (vec directory)
   "Build a cache key for VEC and DIRECTORY.
@@ -1392,7 +1431,8 @@ the server scans the entire tree in one operation."
 
 (defun tramp-rpc-magit--ancestor-scan-cache-key (directory)
   "Return cache key for ancestor scan rooted at DIRECTORY."
-  (cons (file-remote-p directory) (tramp-file-local-name directory)))
+  (cons (tramp-rpc-magit--file-connection-key directory)
+        (tramp-file-local-name directory)))
 
 (defun tramp-rpc-magit--ancestor-scan-for-directory (directory)
   "Return cached ancestor marker scan for DIRECTORY, fetching it if needed."
@@ -1451,7 +1491,8 @@ Returns t, nil, or \\='not-cached if not in cache."
       (maphash
        (lambda (key scan)
          (when (and (eq answer 'not-cached)
-                    (equal (car key) (file-remote-p expanded))
+                    (equal (car key)
+                           (tramp-rpc-magit--file-connection-key expanded))
                     (tramp-rpc-magit--ancestor-cache-covers-p
                      (cdr key) file-dir))
            (setq answer
@@ -1461,6 +1502,9 @@ Returns t, nil, or \\='not-cached if not in cache."
       (when (and (eq answer 'not-cached)
                  tramp-rpc-magit--ancestors-cache
                  tramp-rpc-magit--prefetch-directory
+                 (equal (tramp-rpc-magit--file-connection-key expanded)
+                        (tramp-rpc-magit--file-connection-key
+                         tramp-rpc-magit--prefetch-directory))
                  (tramp-rpc-magit--ancestor-cache-covers-p
                   (tramp-file-local-name tramp-rpc-magit--prefetch-directory)
                   file-dir))
@@ -1473,8 +1517,9 @@ Returns t, nil, or \\='not-cached if not in cache."
       ;; a real cached answer, not as "try the next fallback".
       (when (and (eq answer 'not-cached)
                  tramp-rpc-magit--prefetch-directory
-                 (equal (file-remote-p expanded)
-                        (file-remote-p tramp-rpc-magit--prefetch-directory))
+                 (equal (tramp-rpc-magit--file-connection-key expanded)
+                        (tramp-rpc-magit--file-connection-key
+                         tramp-rpc-magit--prefetch-directory))
                  (string-prefix-p
                   (file-name-as-directory
                    (directory-file-name
@@ -1492,8 +1537,32 @@ Returns t, nil, or \\='not-cached if not in cache."
 ;; ============================================================================
 
 (defun tramp-rpc-magit--clear-status-cache ()
-  "Clear only the status cache (git state that changes frequently)."
+  "Clear all status caches (git state that changes frequently)."
   (clrhash tramp-rpc-magit--process-caches))
+
+(defun tramp-rpc-magit--clear-status-cache-for-connection (vec)
+  "Clear status caches belonging to the connection identified by VEC."
+  (let ((connection-key (tramp-rpc--connection-key-string vec))
+        process-keys)
+    (maphash
+     (lambda (key _entry)
+       (when (and (consp key) (equal (car key) connection-key))
+         (push key process-keys)))
+     tramp-rpc-magit--process-caches)
+    (dolist (key process-keys)
+      (remhash key tramp-rpc-magit--process-caches))))
+
+(defun tramp-rpc-magit--clear-cache-for-connection (vec)
+  "Clear Magit caches belonging to the connection identified by VEC."
+  (tramp-rpc-magit--clear-status-cache-for-connection vec)
+  (tramp-rpc-magit--clear-ancestor-caches-for-connection vec))
+
+(defun tramp-rpc-magit--clear-caches-for-directory (directory)
+  "Clear Magit and file metadata caches for remote DIRECTORY only."
+  (when (file-remote-p directory)
+    (with-parsed-tramp-file-name directory nil
+      (tramp-rpc-magit--clear-cache-for-connection v)
+      (tramp-rpc--clear-file-caches-for-connection v))))
 
 (defun tramp-rpc-magit--clear-cache ()
   "Clear all magit-related caches."
@@ -1561,20 +1630,13 @@ clearing caches mid-refresh."
               nil
             (and (boundp 'magit-diff-adjust-tab-width)
                  magit-diff-adjust-tab-width))))
-    (tramp-rpc-magit--clear-status-cache)
-    ;; Drop stale metadata before refresh.  Fresh metadata prefetched during the
-    ;; refresh must survive so lazy Magit section expansion can reuse it.
-    (let ((default-directory (if (directory-name-p directory)
-                                 directory
-                               (concat directory "/"))))
-      (tramp-rpc--clear-file-metadata-caches))
+    ;; Drop only this connection's stale Magit and metadata state.  Fresh
+    ;; metadata prefetched during the refresh must survive for lazy sections.
+    (tramp-rpc-magit--clear-caches-for-directory directory)
     (condition-case err
         (tramp-run-real-handler 'magit-status-setup-buffer (list directory))
       (error
-       (let ((default-directory (if (directory-name-p directory)
-                                    directory
-                                  (concat directory "/"))))
-         (tramp-rpc--clear-file-metadata-caches))
+       (tramp-rpc-magit--clear-caches-for-directory directory)
        (signal (car err) (cdr err))))))
 
 (defun tramp-rpc-handle-magit-status-refresh-buffer ()
@@ -1582,7 +1644,7 @@ clearing caches mid-refresh."
 Suppresses fs.events cache handling during refresh to prevent
 inotify events from clearing caches mid-refresh."
   (unless tramp-rpc-magit--status-setup-prefetch-active
-    (tramp-rpc-magit--clear-status-cache))
+    (tramp-rpc-magit--clear-caches-for-directory default-directory))
   (let ((tramp-rpc--suppress-fs-notifications t)
         (tramp-rpc-magit--allow-process-cache t)
         (magit-diff-adjust-tab-width
@@ -1592,13 +1654,12 @@ inotify events from clearing caches mid-refresh."
              nil
            (and (boundp 'magit-diff-adjust-tab-width)
                 magit-diff-adjust-tab-width))))
-    ;; Drop stale metadata before refresh.  Fresh metadata prefetched during the
-    ;; refresh must survive so lazy Magit section expansion can reuse it.
-    (tramp-rpc--clear-file-metadata-caches)
+    ;; The scoped clear above drops stale metadata.  Fresh metadata prefetched
+    ;; during the refresh must survive so lazy Magit sections can reuse it.
     (condition-case err
         (tramp-run-real-handler 'magit-status-refresh-buffer nil)
       (error
-       (tramp-rpc--clear-file-metadata-caches)
+       (tramp-rpc-magit--clear-caches-for-directory default-directory)
        (signal (car err) (cdr err))))))
 
 ;;;###autoload

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -79,7 +79,8 @@
 
 (defvar tramp-rpc--async-processes (make-hash-table :test 'eq)
   "Hash table mapping local relay processes to their remote process info.
-Value is a plist with :vec, :pid, :connection-process, :timer, :stderr-buffer.")
+Value is a plist with :vec, :pid, :connection-process, :delivery-timer,
+:poll-timer, :stderr-buffer.")
 
 (defvar tramp-rpc--pty-processes (make-hash-table :test 'eq)
   "Hash table mapping local relay processes to their remote PTY process info.
@@ -94,6 +95,35 @@ Value is a plist with :vec, :connection, :connection-process, :owner-process,
   "Seconds to wait for queued process writes before signaling an error."
   :type 'number
   :group 'tramp-rpc)
+
+(defun tramp-rpc--schedule-process-timer (table process timer-key function &rest args)
+  "Schedule FUNCTION in PROCESS's TIMER-KEY slot in TABLE.
+A callback that runs after cleanup sees no tracking entry and cannot
+reschedule itself.  Delivery and polling use independent slots, so scheduling
+the next read cannot discard output waiting for relay delivery."
+  (when-let* ((info (gethash process table)))
+    (when-let* ((old (plist-get info timer-key)))
+      (cancel-timer old))
+    (let (timer)
+      (setq timer
+            (run-at-time
+             0 nil
+             (lambda ()
+               (when-let* ((current (gethash process table))
+                           ((eq timer (plist-get current timer-key))))
+                 (puthash process (plist-put current timer-key nil) table)
+                 (apply function args)))))
+      (puthash process (plist-put info timer-key timer) table)
+      timer)))
+
+(defun tramp-rpc--cancel-process-timers (table process)
+  "Cancel and clear PROCESS's delivery and polling timers in TABLE."
+  (when-let* ((info (gethash process table)))
+    (dolist (timer-key '(:delivery-timer :poll-timer))
+      (when-let* ((timer (plist-get info timer-key)))
+        (cancel-timer timer)
+        (setq info (plist-put info timer-key nil))))
+    (puthash process info table)))
 
 (define-error 'tramp-rpc-process-write-error
   "TRAMP-RPC process write failed" 'remote-file-error)
@@ -359,11 +389,12 @@ The queue remains bound to OWNER-PROCESS's original connection generation."
        (unless (equal (tramp-rpc--process-error-kind err) "not_found")
          (signal (car err) (cdr err)))))))
 
-(defun tramp-rpc--kill-remote-process (vec pid &optional signal)
-  "Send SIGNAL to remote process PID on VEC."
+(defun tramp-rpc--kill-remote-process (vec pid &optional signal connection)
+  "Send SIGNAL to remote process PID on VEC through CONNECTION."
   (tramp-rpc--call vec "process.kill"
                    `((pid . ,pid)
-                     (signal . ,(or signal 15))))) ; SIGTERM
+                     (signal . ,(or signal 15)))
+                   connection)) ; SIGTERM
 
 ;; ============================================================================
 ;; Async Callback-based Process Reading (for LSP and interactive processes)
@@ -419,45 +450,65 @@ STDERR-BUFFER is the separate stderr buffer, or nil to mix with stdout."
            (t
             (process-send-string local-process stderr))))))))
 
-(defun tramp-rpc--pipe-process-sentinel (proc event user-sentinel)
-  "Sentinel for pipe relay processes.
-PROC is the local cat process, EVENT is the event string.
-USER-SENTINEL is the user's original sentinel function.
+(defun tramp-rpc--deliver-pending-process-output (local-process)
+  "Deliver all queued output chunks for LOCAL-PROCESS in response order."
+  (when-let* ((info (gethash local-process tramp-rpc--async-processes)))
+    (let ((pending (plist-get info :pending-output)))
+      (puthash local-process (plist-put info :pending-output nil)
+               tramp-rpc--async-processes)
+      (dolist (chunk pending)
+        (apply #'tramp-rpc--deliver-process-output local-process chunk)))))
 
-This sentinel fires in two scenarios:
-1. Cat died unexpectedly (signal/crash) - kill the remote process.
-2. Cat exited after EOF from `tramp-rpc--handle-process-exit' -
-   the remote process already exited, cat flushed remaining data
-   and exited naturally.
+(defun tramp-rpc--queue-process-output (local-process stdout stderr stderr-buffer)
+  "Queue one non-exit output chunk and schedule its exact delivery once."
+  (when-let* ((info (gethash local-process tramp-rpc--async-processes)))
+    (setq info (plist-put info :pending-output
+                          (append (plist-get info :pending-output)
+                                  (list (list stdout stderr stderr-buffer)))))
+    (puthash local-process info tramp-rpc--async-processes)
+    (unless (plist-get info :delivery-timer)
+      (tramp-rpc--schedule-process-timer
+       tramp-rpc--async-processes local-process :delivery-timer
+       #'tramp-rpc--deliver-pending-process-output local-process))))
 
-In both cases, use the remote exit code (if known) to construct the
-event string for the user's sentinel, so that it sees the remote
-process's exit status rather than cat's."
+(defun tramp-rpc--call-user-sentinel-once (process sentinel event)
+  "Call SENTINEL for PROCESS once, recording that it was called."
+  (when (and sentinel
+             (not (process-get process :tramp-rpc-user-sentinel-called)))
+    (process-put process :tramp-rpc-user-sentinel-called t)
+    (funcall sentinel process event)))
+
+(defun tramp-rpc--pipe-process-sentinel (proc event &optional user-sentinel)
+  "Sentinel for pipe relay PROC, preserving USER-SENTINEL exactly once.
+The relay remains tracked while its sentinel runs; cleanup removes it after
+that chain has completed."
   (when (and (memq (process-status proc) '(exit signal))
              (gethash proc tramp-rpc--async-processes))
     (let* ((info (gethash proc tramp-rpc--async-processes))
            (vec (plist-get info :vec))
-           (pid (plist-get info :pid)))
-      ;; Kill remote process if still running (unexpected cat death)
-      (unless (process-get proc :tramp-rpc-exited)
+           (pid (plist-get info :pid))
+           (connection (plist-get info :connection-process)))
+      (tramp-rpc--cancel-process-timers tramp-rpc--async-processes proc)
+      (unless (or (process-get proc :tramp-rpc-exited)
+                  (process-get proc :tramp-rpc-transport-cleanup)
+                  (and (processp connection)
+                       (process-get connection :tramp-rpc-transport-dead)))
         (when (and vec pid)
           (ignore-errors
-            (tramp-rpc--kill-remote-process vec pid 9))))
-      ;; Clean up stderr relay process
+            (tramp-rpc--kill-remote-process
+             vec pid 9 (process-get proc :tramp-rpc-connection)))))
       (when-let* ((stderr-process (plist-get info :stderr-process)))
         (when (process-live-p stderr-process)
           (ignore-errors (delete-process stderr-process))))
-      ;; Remove from tracking
-      (remhash proc tramp-rpc--async-processes)))
-  ;; Use the remote exit code for the event string when available,
-  ;; so the user's sentinel sees the remote process status.
-  (when-let* ((remote-exit (process-get proc :tramp-rpc-exit-code)))
-    (setq event (if (= remote-exit 0)
-                    "finished\n"
-                  (format "exited abnormally with code %d\n" remote-exit))))
-  ;; Call user's sentinel if provided
-  (when user-sentinel
-    (funcall user-sentinel proc event)))
+      (let ((remote-exit (process-get proc :tramp-rpc-exit-code)))
+        (tramp-rpc--call-user-sentinel-once
+         proc user-sentinel
+         (if remote-exit
+             (if (= remote-exit 0)
+                 "finished\n"
+               (format "exited abnormally with code %d\n" remote-exit))
+           event)))
+      (remhash proc tramp-rpc--async-processes))))
 
 (defun tramp-rpc--handle-async-read-response (local-process response)
   "Handle async read response for LOCAL-PROCESS.
@@ -492,14 +543,18 @@ RESPONSE is the decoded RPC response plist."
             ;; data immediately before sending EOF to the local relay; otherwise
             ;; the deferred delivery can race with relay shutdown and lose output.
             (if exited
-                (when (or stdout stderr)
-                  (tramp-rpc--deliver-process-output
-                   local-process stdout stderr stderr-buffer))
-              ;; Keep deferred delivery for the non-exit hot path so
-              ;; accept-process-output observes normal I/O activity.
+                (progn
+                  ;; Drain earlier non-exit chunks before EOF can close the
+                  ;; relay, then synchronously flush this final chunk.
+                  (tramp-rpc--deliver-pending-process-output local-process)
+                  (when (or stdout stderr)
+                    (tramp-rpc--deliver-process-output
+                     local-process stdout stderr stderr-buffer)))
+              ;; Queue rather than replace deferred chunks: a later read must
+              ;; never cancel output that is still waiting for relay delivery.
               (when (or stdout stderr)
-                (run-at-time 0 nil #'tramp-rpc--deliver-process-output
-                             local-process stdout stderr stderr-buffer)))
+                (tramp-rpc--queue-process-output
+                 local-process stdout stderr stderr-buffer)))
 
             ;; Handle process exit or chain next read
             (if exited
@@ -510,11 +565,15 @@ RESPONSE is the decoded RPC response plist."
                 ;; process and run one extra iteration.
                 (tramp-rpc--handle-process-exit local-process exit-code)
               ;; Chain another read - use run-at-time to avoid stack overflow
-              (run-at-time 0 nil #'tramp-rpc--start-async-read local-process)))
+              (tramp-rpc--schedule-process-timer
+               tramp-rpc--async-processes local-process :poll-timer
+               #'tramp-rpc--start-async-read local-process)))
         (error
          (tramp-rpc--debug "ASYNC-READ-ERROR: %S" err)
          ;; On error, clean up
-         (run-at-time 0 nil #'tramp-rpc--handle-process-exit local-process -1))))))
+         (tramp-rpc--schedule-process-timer
+          tramp-rpc--async-processes local-process :poll-timer
+          #'tramp-rpc--handle-process-exit local-process -1))))))
 
 (defun tramp-rpc--handle-process-exit (local-process exit-code)
   "Handle exit of remote process associated with LOCAL-PROCESS.
@@ -530,6 +589,7 @@ before the cat relay drains its pipe causes a stale FD that makes
 `input-pending-p' return t permanently, starving keyboard input."
   (let ((info (gethash local-process tramp-rpc--async-processes)))
     (when info
+      (tramp-rpc--cancel-process-timers tramp-rpc--async-processes local-process)
       ;; Clean up only this connection's write queue for this process.
       (when-let* ((pid (plist-get info :pid))
                    (vec (plist-get info :vec)))
@@ -591,8 +651,17 @@ update is still running."
            process
            (lambda (proc event)
              (when sentinel
-               (funcall sentinel proc event))
+               (funcall sentinel proc event)
+               ;; The deferred installer may have captured a caller sentinel
+               ;; that replaced our wrapper.  Only a terminal notification
+               ;; satisfies its exactly-once exit contract; stop/continue
+               ;; events must not suppress the later exit notification.
+               (when (memq (process-status proc) '(exit signal))
+                 (process-put proc :tramp-rpc-user-sentinel-called t)))
              (when (memq (process-status proc) '(exit signal))
+               ;; Keep our tracking cleanup in the chain even when the caller
+               ;; replaced the sentinel after process creation.
+               (tramp-rpc--pipe-process-sentinel proc event nil)
                ;; Defer deletion so the full sentinel chain completes first.
                (cleanup proc)))))))
      ((processp process)
@@ -799,12 +868,14 @@ Resolves program path and loads direnv environment from working directory."
 
               (when filter
                 (set-process-filter local-process filter))
-              (when sentinel
-                ;; Wrap sentinel to handle our cleanup.
-                (set-process-sentinel
-                 local-process
-                 (lambda (proc event)
-                   (tramp-rpc--pipe-process-sentinel proc event sentinel))))
+              ;; Keep our wrapper even when the caller supplied no sentinel;
+              ;; normal exits must still remove tracking.
+              (process-put local-process :tramp-rpc-user-sentinel sentinel)
+              (set-process-sentinel
+               local-process
+               (lambda (proc event)
+                 (tramp-rpc--pipe-process-sentinel
+                  proc event (process-get proc :tramp-rpc-user-sentinel))))
 
               ;; Store process info.
               (puthash local-process
@@ -813,7 +884,10 @@ Resolves program path and loads direnv environment from working directory."
                              :connection-process
                              (process-get local-process :tramp-rpc-connection-process)
                              :stderr-buffer stderr-buffer
-                             :stderr-process stderr-process)
+                             :stderr-process stderr-process
+                             :pending-output nil
+                             :delivery-timer nil
+                             :poll-timer nil)
                        tramp-rpc--async-processes)
 
               (tramp-rpc--debug
@@ -875,6 +949,30 @@ interactive terminal use.  Otherwise, uses the RPC-based PTY implementation."
     ;; Use RPC-based PTY
     (tramp-rpc--make-rpc-pty-process
      vec name buffer command coding noquery filter sentinel localname direnv-env)))
+
+(defun tramp-rpc--direct-ssh-pty-sentinel (process event)
+  "Remove direct SSH PTY PROCESS and invoke its user sentinel once."
+  (when (memq (process-status process) '(exit signal))
+    (remhash process tramp-rpc--pty-processes)
+    (tramp-rpc--call-user-sentinel-once
+     process (process-get process :tramp-rpc-user-sentinel) event)))
+
+(defun tramp-rpc--install-direct-ssh-pty-sentinel (process)
+  "Reinstall direct SSH PTY tracking after callers finish setup.
+Callers may replace PROCESS's sentinel after `make-process' returns.  Capture
+that sentinel on the next event-loop turn, preserve it once, and keep the
+tracking cleanup wrapper in the chain."
+  (when (processp process)
+    (if (process-live-p process)
+        (let ((sentinel (process-sentinel process)))
+          (unless (eq sentinel #'tramp-rpc--direct-ssh-pty-sentinel)
+            (set-process-sentinel
+             process
+             (lambda (proc event)
+               (tramp-rpc--call-user-sentinel-once proc sentinel event)
+               (tramp-rpc--direct-ssh-pty-sentinel proc event)))))
+      ;; Its existing sentinel already observed the exit; only release tracking.
+      (remhash process tramp-rpc--pty-processes))))
 
 (defun tramp-rpc--make-direct-ssh-pty-process (vec name buffer command coding noquery
                                                     filter sentinel localname &optional direnv-env)
@@ -965,11 +1063,19 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
     (when filter
       (set-process-filter process filter))
 
-    ;; Set up sentinel
-    (when sentinel
-      (set-process-sentinel process sentinel))
+    ;; Always retain a wrapper so normal exits remove PTY tracking.
+    (set-process-sentinel process #'tramp-rpc--direct-ssh-pty-sentinel)
 
     ;; Store tramp-rpc metadata for compatibility with other code
+    (let ((connection (tramp-rpc--get-connection vec)))
+      (process-put process :tramp-rpc-connection-process
+                   (plist-get connection :process)))
+    (puthash process
+             (list :vec vec
+                   :connection-process
+                   (process-get process :tramp-rpc-connection-process)
+                   :direct-ssh t)
+             tramp-rpc--pty-processes)
     (process-put process :tramp-rpc-pty t)
     (process-put process :tramp-rpc-direct-ssh t)
     (process-put process :tramp-rpc-vec vec)
@@ -978,6 +1084,13 @@ DIRENV-ENV is an optional alist of environment variables from direnv."
     ;; Standard tramp property expected by tests and upstream code
     (process-put process 'remote-command command)
     (process-put process 'tramp-vector vec)
+
+    ;; Match pipe relays: callers can replace the sentinel while their process
+    ;; setup still owns the stack, so reinstall tracking after that setup.
+    (let ((proc process))
+      (run-at-time 0 nil
+                   (lambda ()
+                     (tramp-rpc--install-direct-ssh-pty-sentinel proc))))
 
     process))
 
@@ -1048,10 +1161,19 @@ DIRENV-ENV is an optional alist of environment variables for the process."
     (process-put local-process 'adjust-window-size-function
                  #'tramp-rpc--adjust-pty-window-size)
 
-    ;; Track the PTY process
-    (puthash local-process
-             (list :vec vec :pid remote-pid)
-             tramp-rpc--pty-processes)
+    ;; Track the PTY process and its exact transport generation.
+    (let ((connection (tramp-rpc--get-connection vec)))
+      (puthash local-process
+               (list :vec vec :pid remote-pid
+                     :connection-process (plist-get connection :process)
+                     :rpc-pty t
+                     :poll-timer nil)
+               tramp-rpc--pty-processes)
+      ;; Preserve the connection plist itself: PTY exit uses it to send its
+      ;; close request through the exact transport generation that created it.
+      (process-put local-process :tramp-rpc-connection connection)
+      (process-put local-process :tramp-rpc-connection-process
+                   (plist-get connection :process)))
 
     ;; Start async read loop
     (tramp-rpc--pty-start-async-read local-process)
@@ -1132,56 +1254,57 @@ RESPONSE is the decoded RPC response plist."
           ;; Handle process exit or chain next read
           (if exited
               (tramp-rpc--handle-pty-exit local-process exit-code)
-            ;; Chain another read immediately
-            (tramp-rpc--pty-start-async-read local-process)))
+            ;; Chain via a tracked timer so cleanup can cancel it.
+            (tramp-rpc--schedule-process-timer
+             tramp-rpc--pty-processes local-process :poll-timer
+             #'tramp-rpc--pty-start-async-read local-process)))
       (error
        ;; On error, clean up
        (tramp-rpc--handle-pty-exit local-process nil)))))
 
 (defun tramp-rpc--handle-pty-exit (local-process exit-code)
   "Handle exit of PTY process associated with LOCAL-PROCESS."
-  ;; Clean up PTY on remote
-  (when-let* ((vec (process-get local-process :tramp-rpc-vec))
-             (pid (process-get local-process :tramp-rpc-pid)))
-    (ignore-errors
-      (tramp-rpc--call vec "process.close_pty" `((pid . ,pid)))))
-
-  ;; Remove from tracking
-  (remhash local-process tramp-rpc--pty-processes)
-
-  ;; Store exit info
-  (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
-  (process-put local-process :tramp-rpc-exited t)
-
-  ;; Get user sentinel
-  (let ((user-sentinel (process-get local-process :tramp-rpc-user-sentinel))
-        (event (if (and exit-code (= exit-code 0))
-                   "finished\n"
-                 (format "exited abnormally with code %d\n" (or exit-code -1)))))
-    ;; Delete the local process
+  (when (gethash local-process tramp-rpc--pty-processes)
+    (tramp-rpc--cancel-process-timers tramp-rpc--pty-processes local-process)
+    ;; Close the remote PTY while the transport is still available.  Keep the
+    ;; local entry until delete-process dispatches its wrapped sentinel.
+    (when-let* ((vec (process-get local-process :tramp-rpc-vec))
+               (pid (process-get local-process :tramp-rpc-pid))
+               (connection (process-get local-process :tramp-rpc-connection)))
+      (ignore-errors
+        (tramp-rpc--call vec "process.close_pty" `((pid . ,pid)) connection)))
+    (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
+    (process-put local-process :tramp-rpc-exited t)
     (when (process-live-p local-process)
-      (delete-process local-process))
-    ;; Call user sentinel
-    (when user-sentinel
-      (funcall user-sentinel local-process event))))
+      (delete-process local-process))))
 
 (defun tramp-rpc--pty-sentinel (process event)
-  "Sentinel for PTY relay processes.
-PROCESS is the local relay process, EVENT is the process event."
-  ;; Handle local process termination (e.g., user killed it)
+  "Sentinel for PTY relay PROCESS, preserving its user sentinel once."
   (when (memq (process-status process) '(exit signal))
-    ;; Clean up remote PTY if still tracked
-    (when (gethash process tramp-rpc--pty-processes)
-      (when-let* ((vec (process-get process :tramp-rpc-vec))
-                 (pid (process-get process :tramp-rpc-pid)))
-        (ignore-errors
-          (tramp-rpc--call vec "process.kill_pty"
-                           `((pid . ,pid) (signal . 9)))))
-      ;; Remove from tracking
-      (remhash process tramp-rpc--pty-processes))
-    ;; Call user sentinel
-    (when-let* ((user-sentinel (process-get process :tramp-rpc-user-sentinel)))
-      (funcall user-sentinel process event))))
+    (when-let* ((info (gethash process tramp-rpc--pty-processes)))
+      (tramp-rpc--cancel-process-timers tramp-rpc--pty-processes process)
+      ;; A transport cleanup already requested/closed the remote PTY.
+      (unless (or (process-get process :tramp-rpc-exited)
+                  (process-get process :tramp-rpc-transport-cleanup)
+                  (and (processp (plist-get info :connection-process))
+                       (process-get (plist-get info :connection-process)
+                                    :tramp-rpc-transport-dead)))
+        (when-let* ((vec (plist-get info :vec))
+                    (pid (plist-get info :pid)))
+          (ignore-errors
+            (tramp-rpc--call vec "process.kill_pty"
+                             `((pid . ,pid) (signal . 9))
+                             (process-get process :tramp-rpc-connection)))))
+      (let ((exit-code (process-get process :tramp-rpc-exit-code)))
+        (tramp-rpc--call-user-sentinel-once
+         process (process-get process :tramp-rpc-user-sentinel)
+         (if exit-code
+             (if (= exit-code 0)
+                 "finished\n"
+               (format "exited abnormally with code %d\n" exit-code))
+           event)))
+      ;; Run after the wrapped/user sentinel has observed the exit.
+      (remhash process tramp-rpc--pty-processes))))
 
 ;; ============================================================================
 ;; PTY window resize support
@@ -1308,23 +1431,46 @@ For direct SSH PTY, let the original function handle it (SSH handles resize)."
 ;; Process cleanup
 ;; ============================================================================
 
-(defun tramp-rpc--cleanup-pty-processes (&optional vec)
-  "Clean up PTY processes, optionally only those for VEC."
+(defun tramp-rpc--terminate-pty-processes (vec connection-process connection)
+  "Terminate remote PTYs for VEC and CONNECTION-PROCESS using CONNECTION.
+Collect targets before issuing RPCs because processing a response may run
+callbacks that mutate the process registry."
+  (let (targets)
+    (maphash
+     (lambda (_local-process info)
+       (when (and (plist-get info :rpc-pty)
+                  (equal (tramp-rpc--connection-key (plist-get info :vec))
+                         (tramp-rpc--connection-key vec))
+                  (eq connection-process (plist-get info :connection-process)))
+         (push (cons (plist-get info :vec) (plist-get info :pid)) targets)))
+     tramp-rpc--pty-processes)
+    (dolist (target targets)
+      (ignore-errors
+        (tramp-rpc--call (car target) "process.kill_pty"
+                         `((pid . ,(cdr target)) (signal . 9)) connection)))))
+
+(defun tramp-rpc--cleanup-pty-processes (&optional vec connection-process remote-cleanup)
+  "Clean up PTY processes for VEC and CONNECTION-PROCESS.
+When REMOTE-CLEANUP is non-nil, request remote PTY termination before local
+state is removed."
+  (when (and remote-cleanup vec connection-process
+             (process-live-p connection-process))
+    (when-let* ((connection (tramp-rpc--get-connection vec)))
+      (when (eq connection-process (plist-get connection :process))
+        (tramp-rpc--terminate-pty-processes vec connection-process connection))))
   (maphash
    (lambda (local-process info)
-     (when (or (null vec)
-               (equal (tramp-rpc--connection-key (plist-get info :vec))
-                      (tramp-rpc--connection-key vec)))
-       ;; Kill remote PTY
-       (when-let* ((pv (plist-get info :vec))
-                   (pid (plist-get info :pid)))
-         (ignore-errors
-           (tramp-rpc--call pv "process.kill_pty"
-                            `((pid . ,pid) (signal . 9)))))
-       ;; Kill local process
+     (when (and (or (null vec)
+                    (equal (tramp-rpc--connection-key (plist-get info :vec))
+                           (tramp-rpc--connection-key vec)))
+                (or (null connection-process)
+                    (eq connection-process (plist-get info :connection-process))))
+       ;; Keep tracking through delete-process so the wrapped sentinel and
+       ;; user's sentinel are not suppressed.  The final remhash is idempotent.
+       (process-put local-process :tramp-rpc-transport-cleanup t)
+       (process-put local-process :tramp-rpc-transport-dead t)
        (when (process-live-p local-process)
          (delete-process local-process))
-       ;; Remove from tracking
        (remhash local-process tramp-rpc--pty-processes)))
    tramp-rpc--pty-processes))
 
@@ -1346,12 +1492,32 @@ generation.  With VEC nil, remove all queues."
     (dolist (key stale)
       (remhash key tramp-rpc--process-write-queues))))
 
-(defun tramp-rpc--cleanup-async-processes (&optional vec connection-process)
+(defun tramp-rpc--terminate-async-processes (vec connection-process connection)
+  "Terminate remote pipe processes for VEC and CONNECTION-PROCESS.
+CONNECTION is the captured transport generation and remains usable after that
+generation has been detached from global connection lookup."
+  (let (targets)
+    (maphash
+     (lambda (_local-process info)
+       (when (and (equal (tramp-rpc--connection-key (plist-get info :vec))
+                         (tramp-rpc--connection-key vec))
+                  (eq connection-process (plist-get info :connection-process)))
+         (push (cons (plist-get info :vec) (plist-get info :pid)) targets)))
+     tramp-rpc--async-processes)
+    (dolist (target targets)
+      (ignore-errors
+        (tramp-rpc--call (car target) "process.kill"
+                         `((pid . ,(cdr target)) (signal . 9)) connection)))))
+
+(defun tramp-rpc--cleanup-async-processes (&optional vec connection-process remote-cleanup)
   "Clean up async processes for VEC and CONNECTION-PROCESS.
-When CONNECTION-PROCESS is non-nil, clean only that exact connection
-generation.  With VEC nil, clean all async processes."
-  ;; Remove queues even when the local relay has already disappeared.
-  (tramp-rpc--cleanup-process-write-queues vec connection-process)
+When REMOTE-CLEANUP is non-nil, request remote process termination while the
+transport is live."
+  (when (and remote-cleanup vec connection-process
+             (process-live-p connection-process))
+    (when-let* ((connection (tramp-rpc--get-connection vec)))
+      (when (eq connection-process (plist-get connection :process))
+        (tramp-rpc--terminate-async-processes vec connection-process connection))))
   (maphash
    (lambda (local-process info)
      (when (and (or (null vec)
@@ -1360,19 +1526,18 @@ generation.  With VEC nil, clean all async processes."
                 (or (null connection-process)
                     (eq (plist-get info :connection-process)
                         connection-process)))
-       ;; Cancel timer
-       (when-let* ((timer (plist-get info :timer)))
-         (cancel-timer timer))
-       ;; Kill stderr relay process
+       (tramp-rpc--cancel-process-timers tramp-rpc--async-processes local-process)
        (when-let* ((stderr-process (plist-get info :stderr-process)))
          (when (process-live-p stderr-process)
            (ignore-errors (delete-process stderr-process))))
-       ;; Kill local process
+       ;; Keep tracking while delete-process dispatches the wrapped sentinel.
+       (process-put local-process :tramp-rpc-transport-cleanup t)
+       (process-put local-process :tramp-rpc-transport-dead t)
        (when (process-live-p local-process)
          (delete-process local-process))
-       ;; Remove from tracking
        (remhash local-process tramp-rpc--async-processes)))
-   tramp-rpc--async-processes))
+   tramp-rpc--async-processes)
+  (tramp-rpc--cleanup-process-write-queues vec connection-process))
 
 ;; Forward declare for cleanup
 (declare-function tramp-rpc--connection-key "tramp-rpc")

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -508,12 +508,23 @@ proxy hops remain."
 (declare-function tramp-rpc-clear-file-truename-cache "tramp-rpc-magit")
 (declare-function tramp-rpc-clear-file-stat-cache "tramp-rpc-magit")
 (declare-function tramp-rpc--clear-file-metadata-caches "tramp-rpc-magit")
-(declare-function tramp-rpc--cleanup-watches-for-connection "tramp-rpc-magit")
+(declare-function tramp-rpc--cleanup-watches-for-connection "tramp-rpc-magit"
+                  (vec &optional connection-process))
+(declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
+(declare-function tramp-rpc--cleanup-pty-processes "tramp-rpc-process")
+(declare-function tramp-rpc--cleanup-process-write-queues "tramp-rpc-process")
+(declare-function tramp-rpc--terminate-async-processes "tramp-rpc-process")
+(declare-function tramp-rpc--terminate-pty-processes "tramp-rpc-process")
 (declare-function tramp-rpc--clear-file-caches-for-connection "tramp-rpc-magit")
+(declare-function tramp-rpc-magit--clear-cache "tramp-rpc-magit")
+(declare-function tramp-rpc-magit--clear-cache-for-connection
+                  "tramp-rpc-magit" (vec))
 (declare-function tramp-rpc-magit--process-cache-lookup "tramp-rpc-magit")
 (declare-function tramp-rpc-magit--process-cache-store "tramp-rpc-magit")
 (declare-function tramp-rpc-magit--file-exists-p "tramp-rpc-magit")
 (declare-function tramp-rpc-magit--clear-status-cache "tramp-rpc-magit")
+(declare-function tramp-rpc-magit--clear-status-cache-for-connection
+                  "tramp-rpc-magit" (vec))
 (declare-function tramp-rpc-magit--prefetch "tramp-rpc-magit")
 (declare-function tramp-rpc-magit--strip-git-prefix-args "tramp-rpc-magit")
 (declare-function tramp-rpc-magit--git-cache-safe-environment-p "tramp-rpc-magit")
@@ -805,6 +816,9 @@ and optional :stderr-buffer.")
 
 (defvar tramp-rpc--async-callbacks (make-hash-table :test 'eql)
   "Hash table mapping request IDs to callback functions for async RPC calls.")
+
+(defvar tramp-rpc--async-callback-processes (make-hash-table :test 'eql)
+  "Hash table mapping async request IDs to their transport process.")
 
 (defvar tramp-rpc--pending-responses (make-hash-table :test 'eq)
   "Hash table mapping buffers to their pending response hash tables.
@@ -1179,23 +1193,154 @@ hop."
   (gethash (tramp-rpc--connection-key vec) tramp-rpc--connections))
 
 (defun tramp-rpc--set-connection (vec process buffer &optional stderr-buffer)
-  "Store the RPC connection for VEC."
-  (puthash (tramp-rpc--connection-key vec)
-           (list :process process :buffer buffer :stderr-buffer stderr-buffer)
-           tramp-rpc--connections))
+  "Store the RPC connection for VEC.
+Caches keyed only by the TRAMP connection spelling are invalidated before a
+new generation is made visible."
+  (tramp-rpc--clear-direnv-cache vec)
+  (tramp-rpc--clear-file-caches-for-connection vec)
+  (tramp-rpc-magit--clear-cache-for-connection vec)
+  (let ((connection
+         (list :process process :buffer buffer :stderr-buffer stderr-buffer
+               :vec vec :generation process)))
+    ;; Retain the exact generation and vector on its transport so late cleanup
+    ;; cannot accidentally route RPCs through a replacement connection.
+    (process-put process :tramp-rpc-vec vec)
+    (process-put process :tramp-rpc-connection connection)
+    (puthash (tramp-rpc--connection-key vec) connection
+             tramp-rpc--connections)))
 
-(defun tramp-rpc--remove-connection (vec)
-  "Remove the RPC connection for VEC.
+(defun tramp-rpc--remove-connection (vec &optional process)
+  "Remove VEC's connection, optionally only when PROCESS is current.
 Also clears the executable, exec-path, and login shell caches."
   (let* ((key (tramp-rpc--connection-key vec))
-         (conn (gethash key tramp-rpc--connections))
-         (process (plist-get conn :process)))
-    (when process
-      (tramp-rpc-protocol--clear-deferred-polls-for-target process))
-    (remhash key tramp-rpc--connections)
-    (remhash key tramp-rpc--exec-path-cache)
-    (remhash key tramp-rpc--login-shell-cache))
-  (tramp-rpc--clear-executable-cache vec))
+         (current (gethash key tramp-rpc--connections)))
+    (when (and current
+               (or (null process) (eq process (plist-get current :process))))
+      (when-let* ((transport (plist-get current :process)))
+        (tramp-rpc-protocol--clear-deferred-polls-for-target transport))
+      (remhash key tramp-rpc--connections)
+      (remhash key tramp-rpc--exec-path-cache)
+      (remhash key tramp-rpc--login-shell-cache)
+      (tramp-rpc--clear-executable-cache vec))))
+
+(defun tramp-rpc--connection-error-response (vec event)
+  "Return an RPC error response for a transport failure on VEC."
+  (list :error
+        (list :code -32098
+              :type 'remote-file-error
+              :message (format "RPC transport closed for %s%s"
+                               (tramp-file-name-host vec)
+                               (if event (format " (%s)" (string-trim event)) "")))))
+
+(defun tramp-rpc--track-pending-request (process id)
+  "Record synchronous request ID ID as pending on PROCESS."
+  (process-put process :tramp-rpc-pending-ids
+               (cons id (delete id (process-get process :tramp-rpc-pending-ids)))))
+
+(defun tramp-rpc--untrack-pending-request (process id)
+  "Forget synchronous request ID ID on PROCESS."
+  (when (processp process)
+    (process-put process :tramp-rpc-pending-ids
+                 (delete id (process-get process :tramp-rpc-pending-ids)))))
+
+(defun tramp-rpc--cleanup-connection-generation
+    (process vec event reason &optional remote-cleanup)
+  "Clean up one PROCESS generation for VEC.
+REASON and EVENT are retained on PROCESS and used for both explicit disconnect
+and unexpected transport death.  REMOTE-CLEANUP requests termination before
+local relay deletion when PROCESS is still live."
+  (when (and (processp process)
+             (not (process-get process :tramp-rpc-cleanup-started)))
+    (process-put process :tramp-rpc-cleanup-started t)
+    (process-put process :tramp-rpc-cleanup-reason reason)
+    (process-put process :tramp-rpc-cleanup-event event)
+    (let* ((current-connection (tramp-rpc--get-connection vec))
+           (current-p (or (null current-connection)
+                          (eq process (plist-get current-connection :process))))
+           (conn (or (process-get process :tramp-rpc-connection)
+                     (and current-p current-connection)))
+           (generation-buffer (or (process-get process :tramp-rpc-buffer)
+                                  (and current-p conn
+                                       (plist-get conn :buffer))))
+           (error-response (tramp-rpc--connection-error-response vec event))
+           callbacks)
+      ;; Detach the generation before any relay sentinel can reenter connection
+      ;; lookup.  Explicit cleanup retains CONN locally for its final kill RPCs.
+      (when current-p
+        (tramp-rpc--clear-direnv-cache vec)
+        (tramp-rpc--clear-file-caches-for-connection vec)
+        (tramp-rpc-magit--clear-cache-for-connection vec)
+        (tramp-rpc--remove-connection vec process))
+      ;; Kill acknowledgements must still be accepted by the live transport.
+      ;; Mark it dead only after these captured-generation calls complete.
+      (when (and remote-cleanup conn (process-live-p process))
+        (tramp-rpc--terminate-async-processes vec process conn)
+        (tramp-rpc--terminate-pty-processes vec process conn))
+      (process-put process :tramp-rpc-transport-cleaned t)
+      (process-put process :tramp-rpc-transport-dead t)
+      ;; Wake synchronous callers after remote cleanup, before removing any
+      ;; remaining generation-local state.
+      (dolist (id (process-get process :tramp-rpc-pending-ids))
+        (when (buffer-live-p generation-buffer)
+          (puthash id error-response
+                   (tramp-rpc--get-pending-responses generation-buffer))))
+      ;; Detach callbacks before invoking them, so callback code cannot observe
+      ;; or recreate a callback belonging to this dead generation.
+      (maphash
+       (lambda (id callback-process)
+         (when (eq callback-process process)
+           (when-let* ((callback (gethash id tramp-rpc--async-callbacks)))
+             (push callback callbacks))
+           (remhash id tramp-rpc--async-callbacks)
+           (remhash id tramp-rpc--async-callback-processes)))
+       tramp-rpc--async-callback-processes)
+      ;; These functions keep local relays tracked through delete-process so
+      ;; their wrapped sentinels can preserve the user's sentinel.  Remote
+      ;; termination was completed above using the captured connection.
+      (tramp-rpc--cleanup-async-processes vec process nil)
+      (tramp-rpc--cleanup-pty-processes vec process nil)
+      (tramp-rpc--cleanup-watches-for-connection vec process)
+      (tramp-rpc--cleanup-file-notify-for-connection vec process)
+      (dolist (callback callbacks)
+        (condition-case callback-error
+            (funcall callback error-response)
+          (error
+           (tramp-rpc--debug "transport cleanup callback failed: %S"
+                             callback-error))))
+      (process-put process :tramp-rpc-pending-ids nil)
+      ;; Explicit disconnect owns transport deletion; unexpected death is
+      ;; already dispatched by Emacs and this is harmlessly idempotent.
+      (when (and remote-cleanup (process-live-p process))
+        (delete-process process)))))
+
+(defun tramp-rpc--connection-transport-death (process vec event)
+  "Clean up unexpected death of PROCESS generation for VEC."
+  (tramp-rpc--cleanup-connection-generation
+   process vec event :transport-death nil))
+
+(defun tramp-rpc--remove-connection-requests (process)
+  "Remove asynchronous request callbacks belonging to PROCESS."
+  (let (ids)
+    (maphash (lambda (id callback-process)
+               (when (eq callback-process process)
+                 (push id ids)))
+             tramp-rpc--async-callback-processes)
+    (dolist (id ids)
+      (remhash id tramp-rpc--async-callbacks)
+      (remhash id tramp-rpc--async-callback-processes))))
+
+(defun tramp-rpc--install-connection-sentinel (process vec)
+  "Install the transport sentinel on PROCESS for VEC's generation."
+  (unless (process-get process :tramp-rpc-connection-sentinel-installed)
+    (process-put process :tramp-rpc-connection-sentinel-installed t)
+    (let ((sentinel (process-sentinel process)))
+      (set-process-sentinel
+       process
+       (lambda (proc event)
+         (when sentinel
+           (funcall sentinel proc event))
+         (when (memq (process-status proc) '(exit signal))
+           (tramp-rpc--connection-transport-death proc vec event)))))))
 
 (defun tramp-rpc--ensure-connection (vec)
   "Ensure we have an active RPC connection to VEC.
@@ -1533,8 +1678,11 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
     (tramp-rpc--set-connection vec process buffer stderr-buffer)
 
     ;; Store vec on the process so notifications can identify the connection
+    ;; and install the generation sentinel before the first RPC can be sent.
     (process-put process :tramp-rpc-vec vec)
+    (process-put process :tramp-rpc-buffer buffer)
     (process-put process 'tramp-vector vec)
+    (tramp-rpc--install-connection-sentinel process vec)
 
     ;; Wait for server to be ready by sending a ping, and seed the
     ;; connection-local system.info cache for later uid/gid/home/shell lookups.
@@ -1650,22 +1798,12 @@ accidentally routing file operations through tramp-sh."
          (tramp-rpc--start-server-process vec binary-path sudo-password)))))))
 
 (defun tramp-rpc--disconnect (vec)
-  "Disconnect the RPC connection to VEC."
-  (let* ((conn (tramp-rpc--get-connection vec))
-         (connection-process (plist-get conn :process)))
-    ;; A reconnect can replace VEC's connection before old cleanup runs.
-    ;; Keep this cleanup scoped to the captured connection generation.
-    (when conn
-      (tramp-rpc--cleanup-async-processes vec connection-process))
-    (tramp-rpc--cleanup-pty-processes vec)
-    ;; Clean up watched directory entries for this connection.
-    (tramp-rpc--cleanup-watches-for-connection vec)
-    (tramp-rpc--cleanup-file-notify-for-connection vec)
-    (when conn
-      (when (process-live-p connection-process)
-        (delete-process connection-process))
-      (tramp-rpc--remove-connection vec)))
-  ;; Flush TRAMP caches so a reconnect gets fresh data (home dir, uid, etc.)
+  "Disconnect the RPC connection to VEC explicitly."
+  (when-let* ((conn (tramp-rpc--get-connection vec))
+              (connection-process (plist-get conn :process)))
+    (tramp-rpc--cleanup-connection-generation
+     connection-process vec "explicit disconnect\n" :explicit-disconnect t))
+  ;; Flush TRAMP caches so a reconnect gets fresh data (home dir, uid, etc.).
   (tramp-flush-directory-properties vec "/")
   (tramp-flush-connection-properties vec))
 
@@ -1739,6 +1877,7 @@ Uses length-prefixed binary framing: <4-byte BE length><msgpack payload>."
                     (progn
                       (tramp-rpc--debug "FILTER dispatching async id=%s" id)
                       (remhash id tramp-rpc--async-callbacks)
+                      (remhash id tramp-rpc--async-callback-processes)
                       (funcall callback response))
                   ;; Not an async response - store for sync code
                   (tramp-rpc--debug "FILTER storing sync response id=%s" id)
@@ -1757,8 +1896,9 @@ Returns the request ID."
          (id (car id-and-request))
          (request (cdr id-and-request)))
     (tramp-rpc--debug "SEND-ASYNC id=%s method=%s" id method)
-    ;; Register callback
+    ;; Register callback with its exact transport generation.
     (puthash id callback tramp-rpc--async-callbacks)
+    (puthash id process tramp-rpc--async-callback-processes)
     ;; Send request (binary data with length prefix, no newline)
     (process-send-string process request)
     id))
@@ -1782,6 +1922,8 @@ Returns the response plist if found and removes it from pending, nil otherwise."
          (response (gethash expected-id pending)))
     (when response
       (remhash expected-id pending)
+      (tramp-rpc--untrack-pending-request
+       (get-buffer-process (current-buffer)) expected-id)
       response)))
 
 (defun tramp-rpc--process-accessible-p (process)
@@ -1830,6 +1972,7 @@ Returns the result or signals an error."
          (request (cdr id-and-request)))
 
     (tramp-rpc--debug "SEND id=%s method=%s" expected-id method)
+    (tramp-rpc--track-pending-request process expected-id)
 
     ;; Send request (binary data with length prefix, no newline)
     (process-send-string process request)
@@ -1884,20 +2027,25 @@ Returns the result or signals an error."
               (keyboard-quit))))
 
         (unless response
-          (let ((elapsed (- (float-time) start-time))
-                (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
-            (tramp-rpc--debug
-             "TIMEOUT id=%s method=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
-             expected-id method elapsed (buffer-size) (process-live-p process)
-             stderr-tail)
-            (signal
-	     'remote-file-error
-	     (list (concat
-                    (format
-		     "Timeout waiting for RPC response from %s (id=%s, method=%s, waited %.1fs)"
-                     (tramp-file-name-host vec) expected-id method elapsed)
-                    (when stderr-tail
-                      (format "; SSH stderr: %s" stderr-tail)))))))
+          (if (or (process-get process :tramp-rpc-transport-dead)
+                  (not (process-live-p process)))
+              (signal 'remote-file-error
+                      (list (format "RPC transport disconnected from %s"
+                                    (tramp-file-name-host vec))))
+            (let ((elapsed (- (float-time) start-time))
+                  (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
+              (tramp-rpc--debug
+               "TIMEOUT id=%s method=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
+               expected-id method elapsed (buffer-size) (process-live-p process)
+               stderr-tail)
+              (signal
+               'remote-file-error
+               (list (concat
+                      (format
+                       "Timeout waiting for RPC response from %s (id=%s, method=%s, waited %.1fs)"
+                       (tramp-file-name-host vec) expected-id method elapsed)
+                      (when stderr-tail
+                        (format "; SSH stderr: %s" stderr-tail))))))))
 
         (tramp-rpc--debug "RECV id=%s (found)" expected-id)
         (if (tramp-rpc-protocol-error-p response)
@@ -1935,6 +2083,7 @@ Returns:
          (request (cdr id-and-request)))
 
     (tramp-rpc--debug "SEND-BATCH id=%s count=%d" expected-id (length requests))
+    (tramp-rpc--track-pending-request process expected-id)
 
     ;; Send batch request (binary data with length prefix, no newline)
     (process-send-string process request)
@@ -1971,20 +2120,25 @@ Returns:
               (keyboard-quit))))
 
         (unless response
-          (let ((elapsed (- (float-time) start-time))
-                (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
-            (tramp-rpc--debug
-             "TIMEOUT-BATCH id=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
-             expected-id elapsed (buffer-size) (process-live-p process)
-             stderr-tail)
-            (signal
-	     'remote-file-error
-	     (list (concat
-                    (format
-		     "Timeout waiting for batch RPC response from %s (id=%s, waited %.1fs)"
-		     (tramp-file-name-host vec) expected-id elapsed)
-                    (when stderr-tail
-                      (format "; SSH stderr: %s" stderr-tail)))))))
+          (if (or (process-get process :tramp-rpc-transport-dead)
+                  (not (process-live-p process)))
+              (signal 'remote-file-error
+                      (list (format "RPC transport disconnected from %s"
+                                    (tramp-file-name-host vec))))
+            (let ((elapsed (- (float-time) start-time))
+                  (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
+              (tramp-rpc--debug
+               "TIMEOUT-BATCH id=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
+               expected-id elapsed (buffer-size) (process-live-p process)
+               stderr-tail)
+              (signal
+               'remote-file-error
+               (list (concat
+                      (format
+                       "Timeout waiting for batch RPC response from %s (id=%s, waited %.1fs)"
+                       (tramp-file-name-host vec) expected-id elapsed)
+                      (when stderr-tail
+                        (format "; SSH stderr: %s" stderr-tail))))))))
 
         (tramp-rpc--debug "RECV-BATCH id=%s (found)" expected-id)
         (if (tramp-rpc-protocol-error-p response)
@@ -2016,6 +2170,7 @@ Returns a list of request IDs in the same order."
              (bytes (cdr id-and-bytes)))
         (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
         (push id ids)
+        (tramp-rpc--track-pending-request process id)
         ;; Send binary data with length prefix, no newline
         (process-send-string process bytes)))
     (nreverse ids)))
@@ -4072,7 +4227,7 @@ refresh), git commands are served from the prefetch cache when possible."
                   (let ((core-args (tramp-rpc-magit--strip-git-prefix-args args)))
                     (when (and (equal (car core-args) "update-index")
                                (member "--refresh" core-args))
-                      (tramp-rpc-magit--clear-status-cache)
+                      (tramp-rpc-magit--clear-status-cache-for-connection v)
                       (tramp-rpc-magit--prefetch default-directory))))
 
                 ;; Handle destination
@@ -4600,25 +4755,34 @@ Both explicit watch entries and file-notify watch entries count as owners."
        tramp-rpc--file-notify-watch-counts))
     active))
 
-(defun tramp-rpc--cleanup-file-notify-for-connection (&optional vec)
-  "Remove TRAMP-RPC file notification state for VEC.
-When VEC is nil, remove all TRAMP-RPC file notification state.  This also
-removes matching descriptors from Emacs' global `file-notify-descriptors'
-table when it is loaded, so `file-notify-valid-p' cannot retain stale
-descriptors after connection cleanup."
+(defun tramp-rpc--cleanup-file-notify-for-connection
+    (&optional vec connection-process)
+  "Remove file notification state for VEC's CONNECTION-PROCESS.
+When VEC is nil, remove all state."
   (let* ((prefix (and vec (concat (tramp-rpc--connection-key-string vec) ":")))
          (descriptors-to-remove nil)
          (watch-keys-to-remove nil))
     (maphash
      (lambda (descriptor data)
-       (let ((watch-key (plist-get data :watch-key)))
-         (when (or (null prefix)
-                   (and watch-key (string-prefix-p prefix watch-key)))
+       (let* ((watch-key (plist-get data :watch-key))
+              (entry (and watch-key
+                          (gethash watch-key tramp-rpc--file-notify-watch-counts)))
+              (owner (or (plist-get data :connection-process)
+                         (plist-get entry :connection-process))))
+         (when (and (or (null prefix)
+                        (and watch-key (string-prefix-p prefix watch-key)))
+                    (or (null connection-process)
+                        (null owner)
+                        (eq connection-process owner)))
            (push descriptor descriptors-to-remove))))
      tramp-rpc--file-notify-descriptors)
     (maphash
-     (lambda (watch-key _data)
-       (when (or (null prefix) (string-prefix-p prefix watch-key))
+     (lambda (watch-key data)
+       (when (and (or (null prefix) (string-prefix-p prefix watch-key))
+                  (or (null connection-process)
+                      (null (plist-get data :connection-process))
+                      (eq connection-process
+                          (plist-get data :connection-process))))
          (push watch-key watch-keys-to-remove)))
      tramp-rpc--file-notify-watch-counts)
     (dolist (descriptor descriptors-to-remove)
@@ -4894,7 +5058,9 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                          :owned (and (not preexisting) (not synthetic))
                          :synthetic synthetic
                          :directory directory
-                         :canonical-directory canonical-directory)
+                         :canonical-directory canonical-directory
+                         :connection-process (plist-get (tramp-rpc--get-connection v)
+                                                        :process))
                    tramp-rpc--file-notify-watch-counts)))
       (let ((watch-entry (gethash watch-key tramp-rpc--file-notify-watch-counts)))
         (puthash descriptor
@@ -4903,7 +5069,9 @@ DIRECTORY is the remote directory passed by `file-notify-add-watch'."
                                                        :canonical-directory)
                        :flags flags
                        :localname localname
-                       :watch-key watch-key)
+                       :watch-key watch-key
+                       :connection-process (plist-get (tramp-rpc--get-connection v)
+                                                      :process))
                  tramp-rpc--file-notify-descriptors))
       descriptor)))
 
@@ -5209,42 +5377,38 @@ file-truename)."
   "Clean up all TRAMP-RPC connections.
 Called from `tramp-cleanup-all-connections-hook' after TRAMP's generic
 cleanup of all connections has run."
-  ;; Collect vecs before clearing connections hash so we can close
-  ;; their ControlMaster sockets afterward.
-  (let ((vecs nil))
+  ;; Snapshot actual generations, then run the same explicit cleanup core for
+  ;; each live transport.  In particular, do not pass a nil process to the
+  ;; per-process cleanup helpers: that would allow one generation to clean
+  ;; another and would skip remote termination ordering.
+  (let (generations)
     (maphash (lambda (_key conn)
-               (when-let* ((proc (plist-get conn :process))
-                           (v (process-get proc :tramp-rpc-vec)))
-                 (push v vecs)))
+               (when-let* ((process (plist-get conn :process))
+                           (vec (plist-get conn :vec)))
+                 (push (cons vec process) generations)))
              tramp-rpc--connections)
-    ;; Clean up all async and PTY processes (no vec = all connections).
-    (tramp-rpc--cleanup-async-processes)
-    (tramp-rpc--cleanup-pty-processes)
-    ;; Clean up all filesystem watches.
+    (dolist (generation generations)
+      (let ((vec (car generation))
+            (process (cdr generation)))
+        (when (processp process)
+          (tramp-rpc--cleanup-connection-generation
+           process vec "explicit global disconnect\n" :explicit-disconnect t)
+          (tramp-rpc--cleanup-controlmaster vec))))
     (clrhash tramp-rpc--watched-directories)
     (tramp-rpc--cleanup-file-notify-for-connection)
-    ;; Kill any remaining RPC server processes and clear connections hash.
-    (maphash (lambda (_key conn)
-               (let ((process (plist-get conn :process)))
-                 (when (process-live-p process)
-                   (delete-process process))))
-             tramp-rpc--connections)
-    (clrhash tramp-rpc--connections)
-    ;; Close ControlMaster sockets and kill auth processes/buffers.
-    (dolist (vec vecs)
-      (tramp-rpc--cleanup-controlmaster vec))
-    ;; Also kill any orphaned auth buffers not associated with a
-    ;; tracked connection (e.g. from a failed connection attempt).
+    ;; Also kill orphaned auth buffers from failed connection attempts.
     (dolist (buf (buffer-list))
       (when (string-match-p "\\` \\*tramp-rpc-auth " (buffer-name buf))
         (when-let* ((proc (get-buffer-process buf)))
           (when (process-live-p proc)
             (delete-process proc)))
-        (kill-buffer buf))))
+        (kill-buffer buf)))
+    (clrhash tramp-rpc--connections))
   ;; Clear all RPC-specific caches.
   (clrhash tramp-rpc--pending-responses)
   (clrhash tramp-rpc--async-callbacks)
   (tramp-rpc-protocol--clear-deferred-polls)
+  (clrhash tramp-rpc--async-callback-processes)
   (clrhash tramp-rpc--executable-cache)
   (tramp-rpc--clear-direnv-cache)
   (tramp-rpc--clear-file-metadata-caches)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -25,6 +25,72 @@
 (require 'cl-lib)
 (require 'subr-x)
 
+(defvar tramp-rpc-mock-test--network-guard nil
+  "Non-nil while mock selectors must not create network processes.")
+
+(defun tramp-rpc-mock-test--guard-network (orig &rest args)
+  "Reject network APIs while a mock selector is running."
+  (if tramp-rpc-mock-test--network-guard
+      (error "mock test attempted network creation: %S" args)
+    (apply orig args)))
+
+(defun tramp-rpc-mock-test--network-program-p (program)
+  "Return non-nil when PROGRAM is an SSH-family network launcher."
+  (member (downcase (file-name-nondirectory (format "%s" program)))
+          '("ssh" "ssh.exe" "scp" "scp.exe")))
+
+(defun tramp-rpc-mock-test--ssh-or-scp-remote-p ()
+  "Return non-nil when `default-directory' uses an SSH or scp method."
+  (when (and (fboundp 'tramp-tramp-file-p)
+             (tramp-tramp-file-p default-directory))
+    (member (tramp-file-name-method
+             (tramp-dissect-file-name default-directory))
+            '("ssh" "scp"))))
+
+(defun tramp-rpc-mock-test--guard-process-program (program)
+  "Reject guarded SSH/scp execution, without affecting local commands."
+  (when (and tramp-rpc-mock-test--network-guard
+             (or (tramp-rpc-mock-test--network-program-p program)
+                 (tramp-rpc-mock-test--ssh-or-scp-remote-p)))
+    (error "mock test attempted SSH/scp execution: %S" program)))
+
+(defun tramp-rpc-mock-test--guard-ssh-process (orig name buffer program &rest args)
+  "Reject SSH/scp process creation while a mock selector is running."
+  (tramp-rpc-mock-test--guard-process-program program)
+  (apply orig name buffer program args))
+
+(defun tramp-rpc-mock-test--guard-make-process (orig &rest args)
+  "Reject SSH/scp commands passed to `make-process' in mock selectors."
+  (let ((command (plist-get args :command)))
+    (when (consp command)
+      (tramp-rpc-mock-test--guard-process-program (car command)))
+    (apply orig args)))
+
+(defun tramp-rpc-mock-test--guard-call-process (orig program &rest args)
+  "Reject synchronous SSH/scp process execution in mock selectors."
+  (tramp-rpc-mock-test--guard-process-program program)
+  (apply orig program args))
+
+(defun tramp-rpc-mock-test--guard-call-process-region
+    (orig start end program &optional delete buffer display &rest args)
+  "Reject synchronous SSH/scp region process execution in mock selectors."
+  (tramp-rpc-mock-test--guard-process-program program)
+  (apply orig start end program delete buffer display args))
+
+(defun tramp-rpc-mock-test--guard-process-file
+    (orig program &optional infile destination display &rest args)
+  "Reject synchronous SSH/scp file process execution in mock selectors."
+  (tramp-rpc-mock-test--guard-process-program program)
+  (apply orig program infile destination display args))
+
+(advice-add 'open-network-stream :around #'tramp-rpc-mock-test--guard-network)
+(advice-add 'make-network-process :around #'tramp-rpc-mock-test--guard-network)
+(advice-add 'start-process :around #'tramp-rpc-mock-test--guard-ssh-process)
+(advice-add 'make-process :around #'tramp-rpc-mock-test--guard-make-process)
+(advice-add 'call-process :around #'tramp-rpc-mock-test--guard-call-process)
+(advice-add 'call-process-region :around #'tramp-rpc-mock-test--guard-call-process-region)
+(advice-add 'process-file :around #'tramp-rpc-mock-test--guard-process-file)
+
 ;; Compute project root at load time
 (defvar tramp-rpc-mock-test--project-root
   (expand-file-name "../" (file-name-directory
@@ -1058,11 +1124,14 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (declare-function tramp-rpc-handle-file-regular-p "tramp-rpc" (filename))
 (declare-function tramp-rpc--clear-file-caches-for-connection "tramp-rpc-magit" (vec))
 (declare-function tramp-rpc--invalidate-cache-for-subtree "tramp-rpc-magit" (directory))
+(declare-function tramp-rpc-magit--clear-status-cache-for-connection
+                  "tramp-rpc-magit" (vec))
 (defvar tramp-rpc-magit-disable-remote-diff-tab-width-detection)
 (defvar tramp-rpc-magit--allow-process-cache)
 (defvar tramp-rpc-magit--prefetch-directory)
 (defvar tramp-rpc-magit--process-caches)
 (defvar tramp-rpc-magit--ancestors-cache)
+(defvar tramp-rpc-magit--ancestors-cache-timestamp)
 (defvar tramp-rpc-magit--ancestor-scan-caches)
 
 (defconst tramp-rpc-mock-test--tramp-rpc-magit-loaded
@@ -1444,6 +1513,526 @@ This matches the behavior expected by `tramp-test28-process-file'."
         (when (process-live-p process)
           (delete-process process))))))
 
+(ert-deftest tramp-rpc-mock-test-transport-death-cleans-one-generation ()
+  "A dead RPC transport wakes waiters and removes only its generation."
+  (let* ((vec (tramp-dissect-file-name "/rpc:death:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-death*"))
+         (replacement-buffer (generate-new-buffer " *tramp-rpc-death-new*"))
+         (connection (start-process "tramp-rpc-death" buffer "sleep" "10"))
+         (replacement (start-process "tramp-rpc-death-new" replacement-buffer "sleep" "10"))
+         (relay (start-process "tramp-rpc-death-relay" nil "cat"))
+         (stderr (start-process "tramp-rpc-death-stderr" nil "cat"))
+         (pty (make-pipe-process :name "tramp-rpc-death-pty" :noquery t))
+         (timer (run-at-time 60 nil #'ignore))
+         (conn (list :process connection :buffer buffer))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--async-callbacks (make-hash-table :test 'eql))
+         (tramp-rpc--async-callback-processes (make-hash-table :test 'eql))
+         (tramp-rpc--pending-responses (make-hash-table :test 'eq))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         (callbacks 0))
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec) conn tramp-rpc--connections)
+          (process-put connection :tramp-rpc-vec vec)
+          (process-put connection :tramp-rpc-buffer buffer)
+          (tramp-rpc--track-pending-request connection 9)
+          (puthash 10 (lambda (_response) (setq callbacks (1+ callbacks)))
+                   tramp-rpc--async-callbacks)
+          (puthash 10 connection tramp-rpc--async-callback-processes)
+          (puthash relay (list :vec vec :pid 1 :connection-process connection
+                               :stderr-process stderr :timer timer)
+                   tramp-rpc--async-processes)
+          (puthash pty (list :vec vec :pid 2 :connection-process connection)
+                   tramp-rpc--pty-processes)
+          (puthash (list connection 1)
+                   (list :vec vec :pid 1 :connection-process connection
+                         :pending (list (list :data "queued")))
+                   tramp-rpc--process-write-queues)
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process replacement :buffer replacement-buffer)
+                   tramp-rpc--connections)
+          (tramp-rpc--install-connection-sentinel connection vec)
+          (delete-process connection)
+          ;; A duplicate sentinel/event must not invoke callbacks or touch NEW.
+          (tramp-rpc--connection-transport-death connection vec "again")
+          (should (= callbacks 1))
+          (should (gethash 9 (tramp-rpc--get-pending-responses buffer)))
+          (should-not (gethash 10 tramp-rpc--async-callbacks))
+          (should-not (gethash relay tramp-rpc--async-processes))
+          (should-not (gethash pty tramp-rpc--pty-processes))
+          (should-not (gethash (list connection 1)
+                               tramp-rpc--process-write-queues))
+          (should-not (process-live-p relay))
+          (should-not (process-live-p stderr))
+          (should-not (process-live-p pty))
+          (should (gethash (tramp-rpc--connection-key vec)
+                           tramp-rpc--connections)))
+      (when (timerp timer) (cancel-timer timer))
+      (dolist (process (list connection replacement relay stderr pty))
+        (when (process-live-p process) (delete-process process)))
+      (dolist (buf (list buffer replacement-buffer))
+        (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest tramp-rpc-mock-test-transport-death-wakes-sync-call ()
+  "A synchronous call reports transport death without waiting for timeout."
+  (let* ((vec (tramp-dissect-file-name "/rpc:sync-death:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-sync-death*"))
+         (process (start-process "tramp-rpc-sync-death" buffer "sh" "-c"
+                                 "sleep 0.05"))
+         (conn (list :process process :buffer buffer))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (started (float-time)))
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec) conn tramp-rpc--connections)
+          (process-put process :tramp-rpc-vec vec)
+          (process-put process :tramp-rpc-buffer buffer)
+          (tramp-rpc--install-connection-sentinel process vec)
+          (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                     (lambda (_vec) conn)))
+            (should-error (tramp-rpc--call-with-timeout
+                           vec "noop" nil 1 0.01)
+                          :type 'remote-file-error))
+          (should (< (- (float-time) started) 0.8)))
+      (when (process-live-p process) (delete-process process))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-pty-constructor-keeps-owning-generation ()
+  "RPC PTY construction retains the transport generation used at exit."
+  (let* ((connection-process
+          (make-pipe-process :name "tramp-rpc-old-generation-mock" :noquery t))
+         (connection (list :process connection-process
+                           :generation connection-process))
+         (vec (tramp-dissect-file-name "/rpc:pty-generation:/tmp/"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         local-process captured-connection)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method params &optional captured)
+                     (pcase method
+                       ("process.start_pty" '((pid . 42) (tty_name . "/dev/pts/42")))
+                       ("process.close_pty"
+                        (should (equal params '((pid . 42))))
+                        (setq captured-connection captured)
+                        '((ok . t))))))
+                  ((symbol-function 'tramp-rpc--get-connection)
+                   (lambda (_vec) connection))
+                  ((symbol-function 'tramp-rpc--pty-start-async-read) #'ignore))
+          (setq local-process
+                (tramp-rpc--make-rpc-pty-process
+                 vec "tramp-rpc-pty-generation-mock" nil '("true") nil t
+                 nil nil "/tmp/"))
+          (should (eq (process-get local-process :tramp-rpc-connection)
+                      connection))
+          (tramp-rpc--handle-pty-exit local-process 0)
+          (should (eq captured-connection connection)))
+      (when (and local-process (process-live-p local-process))
+        (delete-process local-process))
+      (when (process-live-p connection-process)
+        (delete-process connection-process)))))
+
+(ert-deftest tramp-rpc-mock-test-exit-sentinels-use-captured-connections ()
+  "Relay exit cleanup cannot route remote kills through a replacement."
+  (let* ((vec (tramp-dissect-file-name "/rpc:sentinel-generation:/tmp/"))
+         (transport (make-pipe-process :name "tramp-rpc-sentinel-transport"
+                                       :noquery t))
+         (connection (list :process transport :generation transport))
+         (pipe (make-pipe-process :name "tramp-rpc-sentinel-pipe" :noquery t))
+         (pty (make-pipe-process :name "tramp-rpc-sentinel-pty" :noquery t))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         pipe-connection pty-connection)
+    (unwind-protect
+        (progn
+          (process-put pipe :tramp-rpc-connection connection)
+          (process-put pty :tramp-rpc-connection connection)
+          (puthash pipe (list :vec vec :pid 11 :connection-process transport)
+                   tramp-rpc--async-processes)
+          (puthash pty (list :vec vec :pid 12 :connection-process transport)
+                   tramp-rpc--pty-processes)
+          (cl-letf (((symbol-function 'process-status)
+                     (lambda (process)
+                       (if (memq process (list pipe pty)) 'exit 'open)))
+                    ((symbol-function 'tramp-rpc--kill-remote-process)
+                     (lambda (_vec _pid &optional _signal captured)
+                       (setq pipe-connection captured)))
+                    ((symbol-function 'tramp-rpc--call)
+                     (lambda (_vec method _params &optional captured)
+                       (when (equal method "process.kill_pty")
+                         (setq pty-connection captured)))))
+            (tramp-rpc--pipe-process-sentinel pipe "killed\n")
+            (tramp-rpc--pty-sentinel pty "killed\n"))
+          (should (eq pipe-connection connection))
+          (should (eq pty-connection connection)))
+      (dolist (process (list transport pipe pty))
+        (when (process-live-p process) (delete-process process))))))
+
+(ert-deftest tramp-rpc-mock-test-explicit-disconnect-kills-owned-processes-once ()
+  "Explicit disconnect requests remote termination before local cleanup."
+  (let* ((vec (tramp-dissect-file-name "/rpc:disconnect:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-disconnect*"))
+         (connection (start-process "tramp-rpc-disconnect" buffer "sleep" "10"))
+         (relay (start-process "tramp-rpc-disconnect-relay" nil "cat"))
+         (pty (make-pipe-process :name "tramp-rpc-disconnect-pty" :noquery t))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         calls sentinel-connection)
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process connection :buffer buffer)
+                   tramp-rpc--connections)
+          (puthash relay (list :vec vec :pid 3 :connection-process connection)
+                   tramp-rpc--async-processes)
+          (puthash pty (list :vec vec :pid 4 :connection-process connection :rpc-pty t)
+                   tramp-rpc--pty-processes)
+          (set-process-sentinel
+           relay
+           (lambda (_process _event)
+             (setq sentinel-connection (tramp-rpc--get-connection vec))))
+          (cl-letf (((symbol-function 'tramp-rpc--call)
+                     (lambda (_vec method _params &optional captured-connection)
+                       ;; Cleanup RPCs use the detached generation while its
+                       ;; filter still accepts their acknowledgements.
+                       (should-not (tramp-rpc--get-connection vec))
+                       (should (eq connection (plist-get captured-connection :process)))
+                       (should-not (process-get connection :tramp-rpc-transport-dead))
+                       (should-not (process-get connection :tramp-rpc-transport-cleaned))
+                       (push method calls) '((ok . t))))
+                    ((symbol-function 'tramp-flush-directory-properties) #'ignore)
+                    ((symbol-function 'tramp-flush-connection-properties) #'ignore))
+            (tramp-rpc--disconnect vec)
+            (tramp-rpc--disconnect vec))
+          (should (equal (sort calls #'string<)
+                         '("process.kill" "process.kill_pty")))
+          (should-not (gethash relay tramp-rpc--async-processes))
+          (should-not (gethash pty tramp-rpc--pty-processes))
+          (should-not (gethash (tramp-rpc--connection-key vec)
+                               tramp-rpc--connections))
+          (should-not sentinel-connection))
+      (dolist (process (list connection relay pty))
+        (when (process-live-p process) (delete-process process)))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-explicit-disconnect-fails-callbacks-and-wakes-waiters ()
+  "Explicit disconnect uses the transport-closed failure path too."
+  (let* ((vec (tramp-dissect-file-name "/rpc:disconnect-callback:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-disconnect-callback*"))
+         (process (start-process "tramp-rpc-disconnect-callback" buffer "sleep" "10"))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--pending-responses (make-hash-table :test 'eq))
+         (tramp-rpc--async-callbacks (make-hash-table :test 'eql))
+         (tramp-rpc--async-callback-processes (make-hash-table :test 'eql))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (callback-response nil))
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process process :buffer buffer)
+                   tramp-rpc--connections)
+          (process-put process :tramp-rpc-vec vec)
+          (process-put process :tramp-rpc-buffer buffer)
+          (tramp-rpc--track-pending-request process 41)
+          (puthash 42 (lambda (response) (setq callback-response response))
+                   tramp-rpc--async-callbacks)
+          (puthash 42 process tramp-rpc--async-callback-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--call) (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-flush-directory-properties) #'ignore)
+                    ((symbol-function 'tramp-flush-connection-properties) #'ignore))
+            (tramp-rpc--disconnect vec))
+          (should (plist-get (cadr callback-response) :message))
+          (should (string-match-p "closed" (plist-get (cadr callback-response) :message)))
+          (should (gethash 41 (tramp-rpc--get-pending-responses buffer)))
+          (should-not (gethash 42 tramp-rpc--async-callbacks)))
+      (when (process-live-p process) (delete-process process))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-process-timers-cancelled-after-cleanup ()
+  "Cleanup cancels independent delivery and polling timers without rescheduling."
+  (let* ((vec (tramp-dissect-file-name "/rpc:timer-cleanup:/tmp/"))
+         (process (start-process "tramp-rpc-timer-cleanup" nil "cat"))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         (fired nil))
+    (unwind-protect
+        (progn
+          (puthash process (list :vec vec :pid 1
+                                 :delivery-timer nil :poll-timer nil)
+                   tramp-rpc--async-processes)
+          (tramp-rpc--schedule-process-timer
+           tramp-rpc--async-processes process :delivery-timer
+           (lambda () (setq fired t)))
+          (tramp-rpc--schedule-process-timer
+           tramp-rpc--async-processes process :poll-timer
+           (lambda () (setq fired t)))
+          (let ((info (gethash process tramp-rpc--async-processes)))
+            (should (timerp (plist-get info :delivery-timer)))
+            (should (timerp (plist-get info :poll-timer))))
+          (tramp-rpc--cleanup-async-processes vec nil)
+          (sleep-for 0.05)
+          (should-not fired)
+          (should-not (gethash process tramp-rpc--async-processes)))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-async-read-delivers-output-while-polling ()
+  "A non-exit read delivers its chunk exactly once while queuing the next read."
+  (let* ((vec (tramp-dissect-file-name "/rpc:async-output:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-async-output*"))
+         (process (let ((process-connection-type nil))
+                    (start-process "tramp-rpc-async-output" buffer "cat")))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (next-reads 0))
+    (unwind-protect
+        (progn
+          (set-process-filter
+           process
+           (lambda (_process output)
+             (with-current-buffer buffer
+               (goto-char (point-max))
+               (insert output))))
+          (puthash process (list :vec vec :pid 1
+                                 :delivery-timer nil :poll-timer nil)
+                   tramp-rpc--async-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--call-async)
+                     (lambda (&rest _) (cl-incf next-reads))))
+            (tramp-rpc--handle-async-read-response
+             process '(:result ((stdout . "chunk-a") (exited . nil))))
+            ;; A second response before timers run must append, not replace,
+            ;; the first queued delivery.
+            (tramp-rpc--handle-async-read-response
+             process '(:result ((stdout . "chunk-b") (exited . nil))))
+            (let ((deadline (+ (float-time) 1.0)))
+              (while (and (< (float-time) deadline)
+                          (or (= next-reads 0)
+                              (with-current-buffer buffer
+                                (not (equal (buffer-string) "chunk-achunk-b")))))
+                (accept-process-output nil 0.01)))
+            (should (= next-reads 1))
+            (with-current-buffer buffer
+              (should (equal (buffer-string) "chunk-achunk-b")))))
+      (when (process-live-p process) (delete-process process))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-direct-pty-normal-exit-calls-sentinel-once ()
+  "Direct SSH PTY normal exits remove tracking and preserve the sentinel."
+  (let* ((process (start-process "tramp-rpc-direct-pty-test" nil "cat"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (calls 0))
+    (unwind-protect
+        (progn
+          (process-put process :tramp-rpc-user-sentinel
+                       (lambda (_ _event) (cl-incf calls)))
+          (puthash process '(:direct-ssh t) tramp-rpc--pty-processes)
+          (set-process-sentinel process #'tramp-rpc--direct-ssh-pty-sentinel)
+          (delete-process process)
+          (sleep-for 0.02)
+          (should-not (gethash process tramp-rpc--pty-processes))
+          (should (= calls 1)))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-direct-pty-deferred-sentinel-preserves-replacement ()
+  "Deferred direct-PTY wrapping retains a caller replacement sentinel once."
+  (let* ((process (start-process "tramp-rpc-direct-pty-deferred" nil "cat"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (calls 0))
+    (unwind-protect
+        (progn
+          (process-put process :tramp-rpc-user-sentinel #'ignore)
+          (puthash process '(:direct-ssh t) tramp-rpc--pty-processes)
+          (set-process-sentinel process #'tramp-rpc--direct-ssh-pty-sentinel)
+          ;; Simulate a caller replacing the sentinel before the deferred
+          ;; installer runs at the end of `make-process' setup.
+          (set-process-sentinel process (lambda (_process _event) (cl-incf calls)))
+          (tramp-rpc--install-direct-ssh-pty-sentinel process)
+          (delete-process process)
+          (sleep-for 0.02)
+          (should-not (gethash process tramp-rpc--pty-processes))
+          (should (= calls 1)))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-direct-pty-exits-before-deferred-installer ()
+  "A direct PTY that exits before sentinel installation releases tracking."
+  (let* ((process (start-process "tramp-rpc-direct-pty-early-exit" nil "cat"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (calls 0))
+    (unwind-protect
+        (progn
+          (puthash process '(:direct-ssh t) tramp-rpc--pty-processes)
+          ;; Simulate a caller replacing our sentinel before the timer runs.
+          (set-process-sentinel process (lambda (_process _event) (cl-incf calls)))
+          (delete-process process)
+          (let ((deadline (+ (float-time) 1.0)))
+            (while (and (< (float-time) deadline)
+                        (or (process-live-p process) (= calls 0)))
+              (accept-process-output nil 0.01)))
+          (ert-info ((format "process status: %S" (process-status process)))
+            (should-not (process-live-p process))
+            (should (= calls 1)))
+          (tramp-rpc--install-direct-ssh-pty-sentinel process)
+          (should-not (gethash process tramp-rpc--pty-processes))
+          (should (= calls 1)))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-global-cleanup-uses-live-generations ()
+  "Global cleanup sends remote termination before deleting each transport."
+  (let* ((vec (tramp-dissect-file-name "/rpc:global-cleanup:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-global-cleanup*"))
+         (connection (start-process "tramp-rpc-global-cleanup" buffer "cat"))
+         (relay (start-process "tramp-rpc-global-relay" nil "cat"))
+         (pty (make-pipe-process :name "tramp-rpc-global-pty" :noquery t))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         calls)
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process connection :buffer buffer :vec vec)
+                   tramp-rpc--connections)
+          (puthash relay (list :vec vec :pid 7 :connection-process connection)
+                   tramp-rpc--async-processes)
+          (puthash pty (list :vec vec :pid 8 :connection-process connection
+                              :rpc-pty t)
+                   tramp-rpc--pty-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--call)
+                     (lambda (_vec method _params &optional _connection)
+                       (push method calls) nil))
+                    ((symbol-function 'tramp-flush-directory-properties) #'ignore)
+                    ((symbol-function 'tramp-flush-connection-properties) #'ignore)
+                    ((symbol-function 'tramp-rpc--cleanup-controlmaster) #'ignore))
+            (tramp-rpc-cleanup-all-connections))
+          (should (member "process.kill" calls))
+          (should (member "process.kill_pty" calls))
+          (should-not (gethash (tramp-rpc--connection-key vec)
+                               tramp-rpc--connections)))
+      (dolist (process (list connection relay pty))
+        (when (process-live-p process) (delete-process process)))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-connection-setup-preserves-unrelated-magit-caches ()
+  "Starting one connection invalidates only that connection's Magit state."
+  (let* ((vec-a (tramp-dissect-file-name "/rpc:cache-a:/tmp/"))
+         (vec-b (tramp-dissect-file-name "/rpc:cache-b:/tmp/"))
+         (key-a (cons (tramp-rpc--connection-key-string vec-a) "/repo-a/"))
+         (key-b (cons (tramp-rpc--connection-key-string vec-b) "/repo-b/"))
+         (ancestor-a (cons (tramp-rpc--connection-key-string vec-a) "/repo-a/"))
+         (ancestor-b (cons (tramp-rpc--connection-key-string vec-b) "/repo-b/"))
+         (buffer (generate-new-buffer " *tramp-rpc-cache-connection*"))
+         (process (start-process "tramp-rpc-cache-connection" buffer "cat"))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc-magit--process-caches (make-hash-table :test 'equal))
+         (tramp-rpc-magit--ancestor-scan-caches (make-hash-table :test 'equal))
+         (tramp-rpc-magit--prefetch-directory
+          (tramp-make-tramp-file-name vec-b "/repo-b/"))
+         (tramp-rpc-magit--ancestors-cache '((".git" . "/repo-b")))
+         (tramp-rpc-magit--ancestors-cache-timestamp (float-time)))
+    (unwind-protect
+        (progn
+          (puthash key-a 'cache-a tramp-rpc-magit--process-caches)
+          (puthash key-b 'cache-b tramp-rpc-magit--process-caches)
+          (puthash ancestor-a 'scan-a tramp-rpc-magit--ancestor-scan-caches)
+          (puthash ancestor-b 'scan-b tramp-rpc-magit--ancestor-scan-caches)
+          (cl-letf (((symbol-function 'tramp-rpc--clear-direnv-cache) #'ignore)
+                    ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
+                     #'ignore))
+            (tramp-rpc--set-connection vec-a process buffer))
+          (should (equal (plist-get (tramp-rpc--get-connection vec-a) :vec)
+                         vec-a))
+          (should (equal (process-get process :tramp-rpc-vec) vec-a))
+          (should-not (gethash key-a tramp-rpc-magit--process-caches))
+          (should-not (gethash ancestor-a tramp-rpc-magit--ancestor-scan-caches))
+          (should (eq (gethash key-b tramp-rpc-magit--process-caches) 'cache-b))
+          (should (eq (gethash ancestor-b tramp-rpc-magit--ancestor-scan-caches)
+                      'scan-b))
+          (should tramp-rpc-magit--ancestors-cache)
+          (should (equal tramp-rpc-magit--prefetch-directory
+                         (tramp-make-tramp-file-name vec-b "/repo-b/"))))
+      (when (process-live-p process) (delete-process process))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-cache-clearing-does-not-hit-replacement ()
+  "An old transport death cannot clear replacement-generation Magit state."
+  (let* ((vec (tramp-dissect-file-name "/rpc:cache-generation:/tmp/"))
+         (buffer-a (generate-new-buffer " *tramp-rpc-cache-a*"))
+         (buffer-b (generate-new-buffer " *tramp-rpc-cache-b*"))
+         (process-a (start-process "tramp-rpc-cache-a" buffer-a "cat"))
+         (process-b (start-process "tramp-rpc-cache-b" buffer-b "cat"))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc-magit--process-caches (make-hash-table :test 'equal))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal)))
+    (unwind-protect
+        (progn
+          (process-put process-a :tramp-rpc-vec vec)
+          (process-put process-b :tramp-rpc-vec vec)
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process process-b :buffer buffer-b)
+                   tramp-rpc--connections)
+          (puthash 'replacement 'present tramp-rpc-magit--process-caches)
+          (tramp-rpc--connection-transport-death process-a vec "stale")
+          (should (equal (gethash 'replacement tramp-rpc-magit--process-caches)
+                         'present)))
+      (dolist (process (list process-a process-b))
+        (when (process-live-p process) (delete-process process)))
+      (dolist (buffer (list buffer-a buffer-b))
+        (when (buffer-live-p buffer) (kill-buffer buffer))))))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-callback-reconnect-preserves-new-caches ()
+  "Cache clearing precedes a cleanup callback that reconnects and repopulates."
+  (let* ((vec (tramp-dissect-file-name "/rpc:cache-callback:/tmp/"))
+         (buffer-a (generate-new-buffer " *tramp-rpc-cache-callback-a*"))
+         (buffer-b (generate-new-buffer " *tramp-rpc-cache-callback-b*"))
+         (process-a (start-process "tramp-rpc-cache-callback-a" buffer-a "cat"))
+         (process-b (start-process "tramp-rpc-cache-callback-b" buffer-b "cat"))
+         (filename (tramp-make-tramp-file-name vec "/new"))
+         (stat-key (cons filename nil))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--async-callbacks (make-hash-table :test 'eql))
+         (tramp-rpc--async-callback-processes (make-hash-table :test 'eql))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         (tramp-rpc--file-exists-cache (make-hash-table :test 'equal))
+         (tramp-rpc--file-truename-cache (make-hash-table :test 'equal))
+         (tramp-rpc--file-stat-cache (make-hash-table :test 'equal))
+         (tramp-rpc-magit--process-caches (make-hash-table :test 'equal)))
+    (unwind-protect
+        (progn
+          (process-put process-a :tramp-rpc-vec vec)
+          (process-put process-a :tramp-rpc-buffer buffer-a)
+          (puthash (tramp-rpc--connection-key vec)
+                   (list :process process-a :buffer buffer-a)
+                   tramp-rpc--connections)
+          (puthash 1
+                   (lambda (_response)
+                     (tramp-rpc--set-connection vec process-b buffer-b)
+                     (puthash filename 'new tramp-rpc--file-exists-cache)
+                     (puthash filename 'new tramp-rpc--file-truename-cache)
+                     (puthash stat-key 'new tramp-rpc--file-stat-cache)
+                     (puthash 'new 'present tramp-rpc-magit--process-caches))
+                   tramp-rpc--async-callbacks)
+          (puthash 1 process-a tramp-rpc--async-callback-processes)
+          (cl-letf (((symbol-function 'tramp-flush-directory-properties) #'ignore))
+            (tramp-rpc--connection-transport-death process-a vec "dead"))
+          (should (eq process-b
+                      (plist-get (tramp-rpc--get-connection vec) :process)))
+          (should (eq (gethash filename tramp-rpc--file-exists-cache) 'new))
+          (should (eq (gethash filename tramp-rpc--file-truename-cache) 'new))
+          (should (eq (gethash stat-key tramp-rpc--file-stat-cache) 'new))
+          (should (eq (gethash 'new tramp-rpc-magit--process-caches) 'present)))
+      (dolist (process (list process-a process-b))
+        (when (process-live-p process) (delete-process process)))
+      (dolist (buffer (list buffer-a buffer-b))
+        (when (buffer-live-p buffer) (kill-buffer buffer))))))
+
 (defvar tramp-rpc-mock-test--isolate-tests nil
   "Non-nil while a TRAMP-RPC mock selector is running.")
 
@@ -1452,14 +2041,33 @@ This matches the behavior expected by `tramp-test28-process-file'."
   (if (and tramp-rpc-mock-test--isolate-tests
            (string-prefix-p "tramp-rpc-mock-test"
                             (symbol-name (ert-test-name test))))
-      (unwind-protect
-          (progn
-            (tramp-rpc-mock-test--reset-state)
-            (funcall run-test test))
-        (tramp-rpc-mock-test--reset-state))
+      (let ((tramp-rpc-mock-test--network-guard t))
+        (unwind-protect
+            (progn
+              (tramp-rpc-mock-test--reset-state)
+              (funcall run-test test))
+          (tramp-rpc-mock-test--reset-state)))
     (funcall run-test test)))
 
 (advice-add 'ert-run-test :around #'tramp-rpc-mock-test--run-isolated)
+
+(ert-deftest tramp-rpc-mock-test-network-guard-rejects-all-network-creation ()
+  "Mock selectors fail immediately instead of opening network transports."
+  (let ((tramp-rpc-mock-test--network-guard t))
+    (should-error (open-network-stream "mock" nil "127.0.0.1" 1))
+    (should-error (make-network-process :name "mock" :host "127.0.0.1" :service 1))
+    (should-error (start-process "mock-ssh" nil "ssh" "host"))
+    (should-error (make-process :name "mock-scp" :command '("scp" "x" "host:y")))
+    (should-error (call-process "ssh" nil nil nil "host"))
+    (should-error (process-file "scp" nil nil nil "x" "host:y"))
+    (with-temp-buffer
+      (should-error (call-process-region (point-min) (point-max)
+                                         "ssh" nil nil "host")))
+    ;; A remote SSH method is network-backed even when the requested command
+    ;; itself is ordinary; a local command remains available to mock tests.
+    (let ((default-directory "/ssh:mock:/tmp/"))
+      (should-error (process-file "true" nil nil nil)))
+    (should (= 0 (call-process "true" nil nil nil)))))
 
 (ert-deftest tramp-rpc-mock-test-reset-state-cleans-file-notify-resources ()
   "State reset removes descriptors before clearing their tracking tables."
@@ -1485,7 +2093,12 @@ This matches the behavior expected by `tramp-test28-process-file'."
                     "/rpc:mock:/tmp/" nil
                     (lambda (event) (push event stopped)))
                    file-notify-descriptors)
-          (tramp-rpc-mock-test--reset-state)
+          ;; `file-notify--rm-descriptor' queues its stopped event through
+          ;; `insert-special-event'.  Deliver it synchronously so the callback
+          ;; runs inside this test's dynamically bound descriptor tables.
+          (cl-letf (((symbol-function 'insert-special-event)
+                     #'file-notify-handle-event))
+            (tramp-rpc-mock-test--reset-state))
           (should-not (process-live-p descriptor))
           (should-not (gethash descriptor file-notify-descriptors))
           (should (equal stopped `((,descriptor stopped "/rpc:mock:/tmp/")))))
@@ -1572,6 +2185,16 @@ This matches the behavior expected by `tramp-test28-process-file'."
                      "/rpc:mock:/tmp/file.gz"))
       (should (equal calls
                      '((dired-compress-file ("/rpc:mock:/tmp/file"))))))))
+
+(ert-deftest tramp-rpc-mock-test-prefetch-ancestor-cache-isolates-connections ()
+  "A global prefetch scan must not answer for another connection."
+  (let ((tramp-rpc-magit--ancestor-scan-caches
+         (make-hash-table :test 'equal))
+        (tramp-rpc-magit--ancestors-cache '((".git" . "/repo")))
+        (tramp-rpc-magit--prefetch-directory "/rpc:host-a:/repo/sub/"))
+    (should (tramp-rpc-magit--file-exists-p "/rpc:host-a:/repo/.git"))
+    (should (eq (tramp-rpc-magit--file-exists-p "/rpc:host-b:/repo/.git")
+                'not-cached))))
 
 (ert-deftest tramp-rpc-mock-test-ancestor-scan-parent-falls-through ()
   "Closest-only ancestor scan must not cache false negatives above the hit."
@@ -1687,17 +2310,26 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (equal (nreverse calls) '(("/tmp/file" nil)))))))
 
 (ert-deftest tramp-rpc-mock-test-connection-cache-clear-clears-ancestor-scans ()
-  "Connection cache clearing also drops ancestor marker scans."
+  "Connection cache clearing drops only that connection's ancestor scans."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-magit-loaded)
-  (let ((tramp-rpc-magit--ancestors-cache '((".git" . "/repo")))
-        (tramp-rpc-magit--ancestor-scan-caches (make-hash-table :test 'equal))
-        (vec (tramp-dissect-file-name "/ssh:mock:/repo/")))
-    (puthash '("ssh:mock" . "/repo/") '((".git" . "/repo"))
+  (let* ((vec (tramp-dissect-file-name "/ssh:mock:/repo/"))
+         (other-vec (tramp-dissect-file-name "/ssh:other:/repo/"))
+         (key (cons (tramp-rpc--connection-key-string vec) "/repo/"))
+         (other-key (cons (tramp-rpc--connection-key-string other-vec) "/repo/"))
+         (tramp-rpc-magit--ancestors-cache '((".git" . "/repo")))
+         (tramp-rpc-magit--ancestors-cache-timestamp (float-time))
+         (tramp-rpc-magit--prefetch-directory
+          (tramp-make-tramp-file-name vec "/repo/"))
+         (tramp-rpc-magit--ancestor-scan-caches (make-hash-table :test 'equal)))
+    (puthash key '((".git" . "/repo"))
+             tramp-rpc-magit--ancestor-scan-caches)
+    (puthash other-key '((".git" . "/repo"))
              tramp-rpc-magit--ancestor-scan-caches)
     (cl-letf (((symbol-function 'tramp-flush-directory-properties) #'ignore))
       (tramp-rpc--clear-file-caches-for-connection vec))
     (should-not tramp-rpc-magit--ancestors-cache)
-    (should (= 0 (hash-table-count tramp-rpc-magit--ancestor-scan-caches)))))
+    (should-not (gethash key tramp-rpc-magit--ancestor-scan-caches))
+    (should (gethash other-key tramp-rpc-magit--ancestor-scan-caches))))
 
 (ert-deftest tramp-rpc-mock-test-subtree-invalidation-flushes-tramp-properties ()
   "Subtree invalidation flushes descendant TRAMP file properties."
@@ -1726,12 +2358,12 @@ This matches the behavior expected by `tramp-test28-process-file'."
   (let ((default-directory "/ssh:other:/else/")
         (tramp-rpc-magit-disable-remote-diff-tab-width-detection nil)
         cleared)
-    (cl-letf (((symbol-function 'tramp-rpc--clear-file-metadata-caches)
-               (lambda () (push default-directory cleared)))
+    (cl-letf (((symbol-function 'tramp-rpc-magit--clear-caches-for-directory)
+               (lambda (directory) (push directory cleared)))
               ((symbol-function 'tramp-run-real-handler)
                (lambda (_operation _args) 'ok)))
       (tramp-rpc-handle-magit-status-setup-buffer "/ssh:mock:/repo"))
-    (should (equal cleared '("/ssh:mock:/repo/")))))
+    (should (equal cleared '("/ssh:mock:/repo")))))
 
 (ert-deftest tramp-rpc-mock-test-magit-cache-file-truename-accepts-bin-result ()
   "Magit metadata prefetch accepts bin file.truename results."
@@ -1873,8 +2505,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (unwind-protect
         (progn
           (process-put proc :tramp-rpc-vec vec)
-          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache)
-                     (lambda () (cl-incf status-clears)))
+          (puthash (tramp-rpc--connection-key vec) (list :process proc)
+                   tramp-rpc--connections)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection)
+                     (lambda (_vec) (cl-incf status-clears)))
                     ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
                      (lambda (path) (push path invalidations)))
                     ((symbol-function 'tramp-rpc--file-notify-dispatch)
@@ -1908,8 +2542,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (unwind-protect
         (progn
           (process-put proc :tramp-rpc-vec vec)
-          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache)
-                     (lambda () (cl-incf status-clears)))
+          (puthash (tramp-rpc--connection-key vec) (list :process proc)
+                   tramp-rpc--connections)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection)
+                     (lambda (_vec) (cl-incf status-clears)))
                     ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
                      (lambda (path) (push path invalidations)))
                     ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
@@ -1936,6 +2572,96 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (when (process-live-p proc)
         (delete-process proc)))))
 
+(ert-deftest tramp-rpc-mock-test-retired-process-fs-events-are-ignored ()
+  "Notifications from a replaced transport cannot invalidate current state."
+  (let* ((vec (tramp-dissect-file-name "/rpc:retired-events:/tmp/"))
+         (retired (make-pipe-process :name "tramp-rpc-retired-events" :noquery t))
+         (current (make-pipe-process :name "tramp-rpc-current-events" :noquery t))
+         (status-clears 0)
+         (invalidations nil)
+         (dispatches nil))
+    (unwind-protect
+        (progn
+          (process-put retired :tramp-rpc-vec vec)
+          (puthash (tramp-rpc--connection-key vec) (list :process current)
+                   tramp-rpc--connections)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection)
+                     (lambda (_vec) (cl-incf status-clears)))
+                    ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+                     (lambda (path) (push path invalidations)))
+                    ((symbol-function 'tramp-rpc--file-notify-dispatch)
+                     (lambda (&rest args) (push args dispatches))))
+            (tramp-rpc--handle-notification
+             retired "fs.events"
+             '((events . (((action . "changed")
+                            (path . "/tmp/stale"))))))
+            (should (= status-clears 0))
+            (should-not invalidations)
+            (should-not dispatches)))
+      (dolist (process (list retired current))
+        (when (process-live-p process) (delete-process process))))))
+
+(ert-deftest tramp-rpc-mock-test-fs-events-and-mutations-preserve-other-magit-connections ()
+  "A connection's fs event and mutation do not evict another connection's caches."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec-a (tramp-dissect-file-name "/rpc:cache-a:/repo-a/"))
+         (vec-b (tramp-dissect-file-name "/rpc:cache-b:/repo-b/"))
+         (connection-a (tramp-rpc--connection-key-string vec-a))
+         (connection-b (tramp-rpc--connection-key-string vec-b))
+         (process-key-a (cons connection-a "/repo-a/"))
+         (process-key-b (cons connection-b "/repo-b/"))
+         (ancestor-key-a (cons connection-a "/repo-a/"))
+         (ancestor-key-b (cons connection-b "/repo-b/"))
+         (proc (make-process :name "tramp-rpc-fs-events-isolation-test"
+                             :buffer nil
+                             :command '("cat")
+                             :connection-type 'pipe
+                             :noquery t))
+         (tramp-rpc-magit--process-caches (make-hash-table :test 'equal))
+         (tramp-rpc-magit--ancestor-scan-caches (make-hash-table :test 'equal))
+         (tramp-rpc-magit--ancestors-cache '((".git" . "/repo-b")))
+         (tramp-rpc-magit--ancestors-cache-timestamp (float-time))
+         (tramp-rpc-magit--prefetch-directory "/rpc:cache-b:/repo-b/")
+         (tramp-rpc--file-exists-cache (make-hash-table :test 'equal))
+         (tramp-rpc--file-truename-cache (make-hash-table :test 'equal))
+         (tramp-rpc--file-stat-cache (make-hash-table :test 'equal))
+         (tramp-rpc--watched-directories (make-hash-table :test 'equal))
+         (tramp-rpc--file-notify-descriptors (make-hash-table :test 'eq))
+         (tramp-rpc--file-notify-watch-counts (make-hash-table :test 'equal))
+         (tramp-rpc--suppress-fs-notifications nil))
+    (unwind-protect
+        (progn
+          (puthash process-key-a 'process-a tramp-rpc-magit--process-caches)
+          (puthash process-key-b 'process-b tramp-rpc-magit--process-caches)
+          (puthash ancestor-key-a 'ancestor-a tramp-rpc-magit--ancestor-scan-caches)
+          (puthash ancestor-key-b 'ancestor-b tramp-rpc-magit--ancestor-scan-caches)
+          (process-put proc :tramp-rpc-vec vec-a)
+          (puthash (tramp-rpc--connection-key vec-a) (list :process proc)
+                   tramp-rpc--connections)
+          (cl-letf (((symbol-function 'tramp-message) #'ignore)
+                    ((symbol-function 'tramp-rpc--file-notify-dispatch) #'ignore)
+                    ((symbol-function 'tramp-flush-file-properties) #'ignore)
+                    ((symbol-function 'tramp-flush-directory-properties) #'ignore))
+            (tramp-rpc--handle-notification
+             proc "fs.events"
+             '((events . (((action . "changed") (path . "/repo-a/file"))))))
+            (should-not (gethash process-key-a tramp-rpc-magit--process-caches))
+            (should-not (gethash ancestor-key-a tramp-rpc-magit--ancestor-scan-caches))
+            (should (eq (gethash process-key-b tramp-rpc-magit--process-caches)
+                        'process-b))
+            (should (eq (gethash ancestor-key-b tramp-rpc-magit--ancestor-scan-caches)
+                        'ancestor-b))
+            (should tramp-rpc-magit--ancestors-cache)
+
+            ;; Ordinary mutation invalidation uses the same connection scope.
+            (puthash ancestor-key-a 'ancestor-a tramp-rpc-magit--ancestor-scan-caches)
+            (tramp-rpc--invalidate-cache-for-path "/rpc:cache-a:/repo-a/file")
+            (should-not (gethash ancestor-key-a tramp-rpc-magit--ancestor-scan-caches))
+            (should (eq (gethash ancestor-key-b tramp-rpc-magit--ancestor-scan-caches)
+                        'ancestor-b))))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
 (ert-deftest tramp-rpc-mock-test-file-notify-canonical-event-invalidates-original-watch-spelling ()
   "Canonical fs.events paths also invalidate equivalent original watch paths."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
@@ -1954,6 +2680,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (unwind-protect
         (progn
           (process-put proc :tramp-rpc-vec vec)
+          (puthash (tramp-rpc--connection-key vec) (list :process proc)
+                   tramp-rpc--connections)
           (puthash descriptor
                    (list :watch-key watch-key
                          :directory "/rpc:mock:/tmp/link/"
@@ -1965,7 +2693,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                      :directory "/rpc:mock:/tmp/link/"
                      :canonical-directory "/rpc:mock:/tmp/real/")
                    tramp-rpc--file-notify-watch-counts)
-          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache) #'ignore)
+          (cl-letf (((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection)
+                     #'ignore)
                     ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
                      (lambda (path) (push path invalidations)))
                     ((symbol-function 'tramp-rpc--file-notify-dispatch) #'ignore))
@@ -1996,11 +2725,14 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (unwind-protect
         (progn
           (process-put proc :tramp-rpc-vec vec)
+          (puthash (tramp-rpc--connection-key vec) (list :process proc)
+                   tramp-rpc--connections)
           (cl-letf (((symbol-function 'tramp-rpc--call)
                      (lambda (_vec method _params)
                        (when (equal method "watch.add")
                          '((path . "/tmp/real/")))))
-                    ((symbol-function 'tramp-rpc-magit--clear-status-cache) #'ignore)
+                    ((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection)
+                     #'ignore)
                     ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
                      (lambda (path) (push path invalidations)))
                     ((symbol-function 'tramp-rpc--file-notify-dispatch) #'ignore))
@@ -2110,7 +2842,11 @@ This matches the behavior expected by `tramp-test28-process-file'."
                     "/rpc:other:/tmp/" nil
                     (lambda (event) (push event other-stopped-events)))
                    file-notify-descriptors)
-          (tramp-rpc--cleanup-file-notify-for-connection vec)
+          ;; Keep stopped-event delivery within the test's dynamic bindings;
+          ;; the real event loop dispatches queued special events later.
+          (cl-letf (((symbol-function 'insert-special-event)
+                     #'file-notify-handle-event))
+            (tramp-rpc--cleanup-file-notify-for-connection vec))
           (should-not (gethash descriptor tramp-rpc--file-notify-descriptors))
           (should-not (gethash watch-key tramp-rpc--file-notify-watch-counts))
           (should-not (gethash descriptor file-notify-descriptors))
@@ -4285,10 +5021,13 @@ It should attempt to connect (and fail), not silently bail."
                                     :localname "/tmp"))
          (non-essential nil))
     ;; With non-essential nil, it should try to connect and signal an error
-    ;; (not throw 'non-essential)
-    (should-error
-     (tramp-rpc--ensure-connection vec)
-     :type 'remote-file-error)))
+    ;; (not throw 'non-essential).  Keep this deterministic and local.
+    (cl-letf (((symbol-function 'tramp-rpc--connect)
+               (lambda (_vec)
+                 (signal 'remote-file-error '("mock connection failure")))))
+      (should-error
+       (tramp-rpc--ensure-connection vec)
+       :type 'remote-file-error))))
 
 (ert-deftest tramp-rpc-mock-test-handler-catches-non-essential ()
   "Test that `tramp-rpc-file-name-handler' falls back for non-essential ops.
@@ -4792,6 +5531,42 @@ itself has to carry the resolution."
           (should-not (get-buffer-process buffer)))
       (when (processp proc)
         (ignore-errors (delete-process proc)))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer)))))
+
+(ert-deftest tramp-rpc-mock-test-process-cleanup-does-not-count-stop-as-exit ()
+  "A relay stop event must not consume its user's exit notification."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-cleanup-stop-test*"))
+         (proc (let ((process-connection-type nil))
+                 (start-process "tramp-rpc-cleanup-stop-test" buffer "cat")))
+         (user-events nil))
+    (unwind-protect
+        (progn
+          (puthash proc '(:pid 4242) tramp-rpc--async-processes)
+          (set-process-sentinel
+           proc
+           (lambda (process event)
+             (tramp-rpc--pipe-process-sentinel
+              process event
+              (lambda (_process user-event)
+                (push user-event user-events)))))
+          (tramp-rpc--install-process-cleanup proc)
+          ;; Exercise the wrapper's non-terminal branch directly.  Emacs can
+          ;; report stop/continue events for subprocesses, but using job-control
+          ;; signals in batch tests is platform- and shell-dependent.
+          (funcall (process-sentinel proc) proc "stopped\n")
+          (should-not (process-get proc :tramp-rpc-user-sentinel-called))
+          (process-put proc :tramp-rpc-exit-code 0)
+          (process-put proc :tramp-rpc-exited t)
+          (process-send-eof proc)
+          (while (process-live-p proc)
+            (accept-process-output proc 0.01 nil t))
+          (accept-process-output nil 0.01)
+          (should (equal user-events '("finished\n"))))
+      (when (processp proc)
+        (ignore-errors (delete-process proc)))
+      (remhash proc tramp-rpc--async-processes)
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 


### PR DESCRIPTION
## Summary

Make sentinels generation-aware and reliably cancel timers, callbacks, relays, PTYs, and cached state on disconnect.

## Stack

Part **6 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/05-async-write-queues`
- Next PRs build on `remediation/06-transport-cleanup`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when remote connections disconnect or reconnect.
  - Prevented one remote connection from clearing another connection’s file, status, or metadata caches.
  - Fixed delayed or duplicated process output and completion notifications.
  - Improved cleanup of remote processes, file watches, and pending operations.
  - Preserved accurate Magit status and metadata during refreshes and connection failures.

- **Tests**
  - Added coverage for connection failures, process cleanup, file notifications, cache isolation, and network-free mock operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->