### PR TITLE
[7/11] Honor process coding systems exactly once

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -41,6 +41,7 @@
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process"
                   (vec pid data &optional owner-process))
+(declare-function tramp-rpc--encode-process-input "tramp-rpc-process")
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process"
                   (vec pid &optional owner-process))
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process"
@@ -72,6 +73,39 @@
 (defvar tramp-file-name-for-operation-external)
 
 ;; ============================================================================
+;; Process coding state
+;; ============================================================================
+
+(defun tramp-rpc--process-coding-advised-p (process)
+  "Return non-nil when PROCESS has a public relay coding state."
+  (and (processp process)
+       (process-get process :tramp-rpc-coding)))
+
+(defun tramp-rpc--set-process-coding-system-advice
+    (orig-fun process &optional decoding encoding)
+  "Keep relay output binary while exposing the requested coding pair.
+RPC relays receive raw bytes through their write side, so only their read side
+is configured with DECODING.  ENCODING is retained for RPC stdin writes and
+for `process-coding-system' callers."
+  (if (tramp-rpc--process-coding-advised-p process)
+      (let ((effective-encoding (or encoding 'raw-text-unix)))
+        ;; Validate both public sides before changing the relay.  Passing the
+        ;; binary write side to Emacs would otherwise hide an invalid requested
+        ;; encoding until the next process write.
+        (check-coding-system decoding)
+        (check-coding-system effective-encoding)
+        (funcall orig-fun process decoding 'binary)
+        (process-put process :tramp-rpc-coding
+                     (cons decoding effective-encoding)))
+    (funcall orig-fun process decoding encoding)))
+
+(defun tramp-rpc--process-coding-system-advice (orig-fun process)
+  "Return a relay's requested coding pair rather than its binary write side."
+  (or (and (tramp-rpc--process-coding-advised-p process)
+           (process-get process :tramp-rpc-coding))
+      (funcall orig-fun process)))
+
+;; ============================================================================
 ;; Process I/O handler
 ;; ============================================================================
 
@@ -96,10 +130,8 @@
         (let ((vec (process-get proc :tramp-rpc-vec))
               (pid (process-get proc :tramp-rpc-pid)))
           (tramp-rpc--debug "SEND-STRING PTY pid=%s len=%d" pid (length string))
-          ;; Send write request asynchronously - data must be binary for MessagePack
-          (let ((data-bytes (if (multibyte-string-p string)
-                                (encode-coding-string string 'utf-8-unix)
-                              string)))
+          ;; Encode user input exactly once with the public write side.
+          (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
             (tramp-rpc--call-async vec "process.write_pty"
                                    `((pid . ,pid)
                                      (data . ,(msgpack-bin-make data-bytes)))
@@ -115,7 +147,7 @@
         (tramp-rpc--write-remote-process
          (process-get proc :tramp-rpc-vec)
          (process-get proc :tramp-rpc-pid)
-         string
+         (tramp-rpc--encode-process-input proc string)
          proc))
        ;; Not an RPC process, use original function
        (t (tramp-run-real-handler #'process-send-string (list process string)))))))
@@ -141,9 +173,7 @@
               (pid (process-get proc :tramp-rpc-pid))
               (string (buffer-substring-no-properties start end)))
           (tramp-rpc--debug "SEND-REGION PTY pid=%s len=%d" pid (length string))
-          (let ((data-bytes (if (multibyte-string-p string)
-                                (encode-coding-string string 'utf-8-unix)
-                              string)))
+          (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
             (tramp-rpc--call-async vec "process.write_pty"
                                    `((pid . ,pid)
                                      (data . ,(msgpack-bin-make data-bytes)))
@@ -160,7 +190,7 @@
           (tramp-rpc--write-remote-process
            (process-get proc :tramp-rpc-vec)
            (process-get proc :tramp-rpc-pid)
-           string
+           (tramp-rpc--encode-process-input proc string)
            proc)))
        ;; Not an RPC process, use original function
        (t (tramp-run-real-handler #'process-send-region (list process start end)))))))
@@ -479,6 +509,14 @@ exited (remote side finished), delete it so the refresh can proceed."
 
 (defun tramp-rpc-handler-install ()
   "Install all process handler for tramp-rpc."
+  (unless (advice-member-p #'tramp-rpc--set-process-coding-system-advice
+                           'set-process-coding-system)
+    (advice-add 'set-process-coding-system :around
+                #'tramp-rpc--set-process-coding-system-advice))
+  (unless (advice-member-p #'tramp-rpc--process-coding-system-advice
+                           'process-coding-system)
+    (advice-add 'process-coding-system :around
+                #'tramp-rpc--process-coding-system-advice))
   (with-eval-after-load 'tramp-rpc
     (tramp-add-external-operation
      'process-send-string
@@ -555,6 +593,10 @@ exited (remote side finished), delete it so the refresh can proceed."
 
 (defun tramp-rpc-handler-remove ()
   "Remove all process handler installed by tramp-rpc."
+  (advice-remove 'set-process-coding-system
+                 #'tramp-rpc--set-process-coding-system-advice)
+  (advice-remove 'process-coding-system
+                 #'tramp-rpc--process-coding-system-advice)
   (tramp-remove-external-operation 'process-send-string 'tramp-rpc)
   (tramp-remove-external-operation 'process-send-region 'tramp-rpc)
   (tramp-remove-external-operation 'process-send-eof 'tramp-rpc)

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -49,7 +49,7 @@
 (declare-function tramp-rpc--call-async "tramp-rpc" (vec method params callback &optional connection))
 (declare-function tramp-rpc--get-direnv-environment "tramp-rpc")
 (declare-function tramp-rpc--get-remote-login-shell "tramp-rpc")
-(declare-function tramp-rpc--decode-output "tramp-rpc")
+(declare-function tramp-rpc--binary-bytes "tramp-rpc")
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
 (declare-function tramp-rpc--port-to-string "tramp-rpc")
@@ -154,10 +154,66 @@ CONNECTION is the captured RPC connection process."
          (or (not (processp owner)) (process-live-p owner)))))
 
 (defun tramp-rpc--process-write-data-bytes (data)
-  "Return DATA in the binary representation sent to the server."
+  "Return already-encoded DATA as a unibyte string for the server.
+The process I/O handlers perform the requested input encoding before DATA
+enters the queue.  Keep this helper byte-preserving so queued data cannot be
+encoded a second time."
   (if (multibyte-string-p data)
-      (encode-coding-string data 'utf-8-unix)
+      (encode-coding-string data 'binary)
     data))
+
+(defun tramp-rpc--process-coding (process)
+  "Return PROCESS's public (DECODING . ENCODING) coding pair."
+  (or (process-get process :tramp-rpc-coding)
+      (cons (car default-process-coding-system)
+            (cdr default-process-coding-system))))
+
+(defun tramp-rpc--encode-process-input (process data)
+  "Encode DATA once with PROCESS's public encoding coding system.
+Return raw unibyte bytes suitable for MessagePack bin payloads."
+  ;; Coding unibyte input preserves arbitrary bytes for binary and
+  ;; no-conversion, while Latin-1 and UTF-8 apply their normal semantics.
+  (encode-coding-string data (cdr (tramp-rpc--process-coding process))))
+
+(defun tramp-rpc--start-cat-relays (name buffer stderr-buffer cleanup)
+  "Start local cat relays for NAME, BUFFER, and STDERR-BUFFER.
+If relay construction fails, delete any relay already created and call CLEANUP
+before propagating the original error.
+Return (STDOUT-PROCESS . STDERR-PROCESS)."
+  (let (stdout-process stderr-process complete)
+    (unwind-protect
+        (prog1
+            (progn
+              (let ((process-connection-type nil))
+                (setq stdout-process
+                      (start-process name buffer "cat")))
+              (when stderr-buffer
+                (let ((process-connection-type nil))
+                  (setq stderr-process
+                        (start-process (format "%s-stderr" name)
+                                       stderr-buffer "cat")))
+                (set-process-query-on-exit-flag stderr-process nil))
+              (cons stdout-process stderr-process))
+          (setq complete t))
+      (unless complete
+        (dolist (process (list stderr-process stdout-process))
+          (when (process-live-p process)
+            (ignore-errors (delete-process process))))
+        (ignore-errors (funcall cleanup))))))
+
+(defun tramp-rpc--configure-relay-coding (process coding)
+  "Configure PROCESS's binary relay and remember public CODING.
+The relay's write side stays binary because output delivered to it is already
+raw remote bytes.  Its read side remains the requested decoder, allowing
+Emacs to retain decoder state across RPC chunks."
+  (let* ((requested (tramp-rpc--normalize-coding
+                     (or coding default-process-coding-system)))
+         (pair (if (consp requested)
+                   requested
+                 (cons requested requested))))
+    (set-process-coding-system process (car pair) 'binary)
+    (process-put process :tramp-rpc-coding pair)
+    pair))
 
 (defun tramp-rpc--process-write-queue-pending-bytes (queue)
   "Return the number of bytes still held by QUEUE, including its current write."
@@ -227,11 +283,9 @@ Returns the remote process PID."
 Returns plist with :stdout, :stderr, :exited, :exit-code."
   (let ((result (tramp-rpc--call vec "process.read" `((pid . ,pid)))))
     (list :stdout (when-let* ((s (alist-get 'stdout result)))
-                    (tramp-rpc--decode-output
-                     s (alist-get 'stdout_encoding result)))
+                    (tramp-rpc--binary-bytes s))
           :stderr (when-let* ((s (alist-get 'stderr result)))
-                    (tramp-rpc--decode-output
-                     s (alist-get 'stderr_encoding result)))
+                    (tramp-rpc--binary-bytes s))
           :exited (alist-get 'exited result)
           :exit-code (alist-get 'exit_code result))))
 
@@ -525,12 +579,12 @@ RESPONSE is the decoded RPC response plist."
           (let* ((info (gethash local-process tramp-rpc--async-processes))
                  (stderr-buffer (plist-get info :stderr-buffer))
                  (result (plist-get response :result))
+                 ;; RPC process streams are MessagePack bin values.  Keep
+                 ;; them raw until the local relay's incremental decoder.
                  (stdout (when-let* ((s (alist-get 'stdout result)))
-                           (tramp-rpc--decode-output
-                            s (alist-get 'stdout_encoding result))))
+                           (tramp-rpc--binary-bytes s)))
                  (stderr (when-let* ((s (alist-get 'stderr result)))
-                           (tramp-rpc--decode-output
-                            s (alist-get 'stderr_encoding result))))
+                           (tramp-rpc--binary-bytes s)))
                  (exited (alist-get 'exited result))
                  (exit-code (alist-get 'exit_code result)))
 
@@ -778,7 +832,10 @@ Resolves program path and loads direnv environment from working directory."
              (use-pty (eq connection-type 'pty))
              (pipe-sudo (and sudo-command (not use-pty)))
              (sudo-password nil)
-             (coding (tramp-rpc--normalize-coding coding)))
+             ;; Native process creation resolves omitted/nil coding from
+             ;; `default-process-coding-system'.
+             (coding (tramp-rpc--normalize-coding
+                      (or coding default-process-coding-system))))
         ;; For non-PTY literal sudo commands, validate sudo in the same RPC pipe
         ;; execution context that will run the command.  If a password is needed,
         ;; use sudo's stdin wrapper; a separate PTY preauth can miss tty-scoped
@@ -822,40 +879,38 @@ Resolves program path and loads direnv environment from working directory."
                    (program-args (cdr command))
                    (remote-pid (tramp-rpc--start-remote-process
                                 v program program-args localname process-env))
-                   ;; Use a local cat process as relay: we write output to its
-                   ;; stdin and it echoes to stdout, triggering proper I/O events.
-                   (local-process (let ((process-connection-type nil))
-                                    (start-process (or name "tramp-rpc-async")
-                                                   buffer
-                                                   "cat")))
+                   (connection (tramp-rpc--get-connection v))
                    (stderr-buffer (cond
                                    ((bufferp stderr) stderr)
                                    ((stringp stderr) (get-buffer-create stderr))
                                    (t nil)))
-                   ;; Create a stderr cat relay so that
-                   ;; (get-buffer-process stderr-buffer) returns a process,
-                   ;; matching the contract of native `make-process' with :stderr.
-                   (stderr-process
-                    (when stderr-buffer
-                      (let* ((process-connection-type nil)
-                             (proc (start-process
-                                    (format "%s-stderr" (or name "tramp-rpc-async"))
-                                    stderr-buffer
-                                    "cat")))
-                        (set-process-query-on-exit-flag proc nil)
-                        proc))))
+                   ;; Construct both local relays as one transaction.  If the
+                   ;; second `cat' fails, tear down the first and the remote
+                   ;; process rather than leaving either orphaned.
+                   (relays
+                    (tramp-rpc--start-cat-relays
+                     (or name "tramp-rpc-async") buffer stderr-buffer
+                     (lambda ()
+                       (ignore-errors
+                         (tramp-rpc--kill-remote-process
+                          v remote-pid 9 connection)))))
+                   (local-process (car relays))
+                   (stderr-process (cdr relays)))
+
+              ;; The public pair controls user input encoding.  The local
+              ;; relay itself reads with the requested decoder and writes
+              ;; binary remote bytes without another encoding pass.
+              (tramp-rpc--configure-relay-coding local-process coding)
+              (when stderr-process
+                (tramp-rpc--configure-relay-coding stderr-process coding))
+              (set-process-query-on-exit-flag local-process (not noquery))
 
               ;; Feed sudo's stdin password before exposing the relay to callers;
               ;; subsequent writes use the same queue and stay ordered after it.
               (when sudo-password
                 (tramp-rpc--write-remote-process
-                 v remote-pid (concat sudo-password "\n")))
-
-              ;; Configure the local relay process.
-              (when coding
-                (apply #'set-process-coding-system local-process
-                       (tramp-rpc--coding-args coding)))
-              (set-process-query-on-exit-flag local-process (not noquery))
+                 v remote-pid (tramp-rpc--encode-process-input
+                               local-process (concat sudo-password "\n"))))
 
               (process-put local-process :tramp-rpc-vec v)
               (process-put local-process :tramp-rpc-pid remote-pid)
@@ -1122,29 +1177,32 @@ DIRENV-ENV is an optional alist of environment variables for the process."
                                      (env . ,full-env))))
          (remote-pid (alist-get 'pid result))
          (tty-name (alist-get 'tty_name result))
+         (connection (tramp-rpc--get-connection vec))
          ;; Normalize buffer - it can be t, nil, a buffer, or a string
          (actual-buffer (cond
                          ((bufferp buffer) buffer)
                          ((stringp buffer) (get-buffer-create buffer))
                          ((eq buffer t) (current-buffer))
                          (t nil)))
-         ;; Create a local pipe process as a relay
-         ;; We use make-pipe-process for the local side - all actual I/O
-         ;; goes through our PTY RPC calls, not through this process.
-         (local-process (make-pipe-process
-                         :name (or name "tramp-rpc-pty")
-                         :buffer actual-buffer
-                         :coding (or (tramp-rpc--normalize-coding coding)
-                                     'utf-8-unix)
-                         :noquery t)))
+         ;; Use a local cat relay so Emacs owns incremental decoding of raw
+         ;; PTY bytes, exactly as it does for pipe process output.  If local
+         ;; construction fails, close the already-created remote PTY through
+         ;; the generation that created it.
+         (relays
+          (tramp-rpc--start-cat-relays
+           (or name "tramp-rpc-pty") actual-buffer nil
+           (lambda ()
+             (ignore-errors
+               (tramp-rpc--call vec "process.close_pty"
+                                `((pid . ,remote-pid)) connection)))))
+         (local-process (car relays)))
 
-    ;; Configure the local relay process
+    ;; Configure the local relay process.  Its write side is binary; the
+    ;; public coding pair is retained for process API and input encoding.
+    (tramp-rpc--configure-relay-coding local-process coding)
     (set-process-filter local-process (or filter #'tramp-rpc--pty-default-filter))
     (set-process-sentinel local-process #'tramp-rpc--pty-sentinel)
     (set-process-query-on-exit-flag local-process (not noquery))
-    (when coding
-      (apply #'set-process-coding-system local-process
-             (tramp-rpc--coding-args coding)))
 
     ;; Store process info
     (process-put local-process :tramp-rpc-pty t)
@@ -1162,18 +1220,17 @@ DIRENV-ENV is an optional alist of environment variables for the process."
                  #'tramp-rpc--adjust-pty-window-size)
 
     ;; Track the PTY process and its exact transport generation.
-    (let ((connection (tramp-rpc--get-connection vec)))
-      (puthash local-process
-               (list :vec vec :pid remote-pid
-                     :connection-process (plist-get connection :process)
-                     :rpc-pty t
-                     :poll-timer nil)
-               tramp-rpc--pty-processes)
-      ;; Preserve the connection plist itself: PTY exit uses it to send its
-      ;; close request through the exact transport generation that created it.
-      (process-put local-process :tramp-rpc-connection connection)
-      (process-put local-process :tramp-rpc-connection-process
-                   (plist-get connection :process)))
+    (puthash local-process
+             (list :vec vec :pid remote-pid
+                   :connection-process (plist-get connection :process)
+                   :rpc-pty t
+                   :poll-timer nil)
+             tramp-rpc--pty-processes)
+    ;; Preserve the connection plist itself: PTY exit uses it to send its
+    ;; close request through the exact transport generation that created it.
+    (process-put local-process :tramp-rpc-connection connection)
+    (process-put local-process :tramp-rpc-connection-process
+                 (plist-get connection :process))
 
     ;; Start async read loop
     (tramp-rpc--pty-start-async-read local-process)
@@ -1234,22 +1291,20 @@ RESPONSE is the decoded RPC response plist."
              (process-live-p local-process)
              (gethash local-process tramp-rpc--pty-processes))
     (condition-case nil
-        (let* ((result (plist-get response :result))
+               (let* ((result (plist-get response :result))
+               ;; Keep PTY bytes raw; the relay decoder owns character
+               ;; conversion and preserves split multibyte sequences.
                (output (when-let* ((o (alist-get 'output result)))
-                         (tramp-rpc--decode-output
-                          o (alist-get 'output_encoding result))))
+                         (tramp-rpc--binary-bytes o)))
                (exited (alist-get 'exited result))
                 (exit-code (alist-get 'exit_code result)))
 
-          ;; Deliver output via filter
+          ;; Feed raw bytes to the relay.  Its read-side decoder is
+          ;; incremental, so a character split across RPC responses is kept
+          ;; intact instead of being decoded once per chunk.
           (when (and output (> (length output) 0))
-            (if-let* ((filter (process-filter local-process)))
-                (funcall filter local-process output)
-              (when-let* ((buf (process-buffer local-process)))
-                (when (buffer-live-p buf)
-                  (with-current-buffer buf
-                    (goto-char (point-max))
-                    (insert output))))))
+            (let ((tramp-rpc--delivering-output t))
+              (process-send-string local-process output)))
 
           ;; Handle process exit or chain next read
           (if exited
@@ -1275,8 +1330,13 @@ RESPONSE is the decoded RPC response plist."
         (tramp-rpc--call vec "process.close_pty" `((pid . ,pid)) connection)))
     (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
     (process-put local-process :tramp-rpc-exited t)
+    ;; Close the relay's local stdin and let cat flush the final PTY bytes
+    ;; before exiting naturally.  A zero-timeout `accept-process-output' after
+    ;; `process-send-string' does not wait for the relay round trip, while
+    ;; deleting it here discards the final output returned with EXITED.
     (when (process-live-p local-process)
-      (delete-process local-process))))
+      (let ((tramp-rpc--closing-local-relay t))
+        (ignore-errors (process-send-eof local-process))))))
 
 (defun tramp-rpc--pty-sentinel (process event)
   "Sentinel for PTY relay PROCESS, preserving its user sentinel once."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2282,11 +2282,19 @@ text strings.  Returns nil if DATA is nil."
     (encode-coding-string data 'utf-8-unix))
    (t data)))
 
-(defun tramp-rpc--decode-output (data _encoding)
-  "Decode binary process DATA to a multibyte UTF-8 string.
-ENCODING is ignored (kept for API compatibility)."
+(defun tramp-rpc--decode-output (data encoding)
+  "Decode binary process DATA using ENCODING.
+This helper is for synchronous command/file paths.  Async relays keep their
+bytes raw and let the relay process decoder handle incremental output."
   (if data
-      (decode-coding-string (tramp-rpc--binary-bytes data) 'utf-8-unix)
+      (let ((coding (cond
+                     ((null encoding) 'utf-8-unix)
+                     ((coding-system-p encoding) encoding)
+                     ((stringp encoding)
+                      (or (coding-system-from-name encoding)
+                          'utf-8-unix))
+                     (t 'utf-8-unix))))
+        (decode-coding-string (tramp-rpc--binary-bytes data) coding))
     ""))
 
 (defun tramp-rpc--decode-filename (entry)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -1840,6 +1840,29 @@ This matches the upstream `tramp-test28-process-file' test."
     (should (equal (list 'utf-8-unix default-enc)
                    (tramp-rpc--coding-args '(utf-8-unix . nil))))))
 
+(ert-deftest tramp-rpc-test13b-cat-relay-construction-cleans-partial-state ()
+  "A failed stderr relay removes the stdout relay and remote child."
+  (let ((original-start-process (symbol-function 'start-process))
+        (stderr-buffer (generate-new-buffer " *tramp-rpc-stderr*"))
+        (calls 0)
+        stdout-process
+        cleaned)
+    (unwind-protect
+        (cl-letf (((symbol-function 'start-process)
+                   (lambda (&rest args)
+                     (cl-incf calls)
+                     (if (= calls 1)
+                         (setq stdout-process (apply original-start-process args))
+                       (error "simulated missing cat")))))
+          (should-error
+           (tramp-rpc--start-cat-relays
+            "tramp-rpc-partial-relay" nil stderr-buffer
+            (lambda () (setq cleaned t))))
+          (should cleaned)
+          (should (processp stdout-process))
+          (should-not (process-live-p stdout-process)))
+      (kill-buffer stderr-buffer))))
+
 (ert-deftest tramp-rpc-test13c-make-process-coding-pair ()
   "Test `make-process' handler accepts same-sided cons pair :coding values."
   (let ((default-directory "/rpc:mock:/tmp/")
@@ -1874,6 +1897,145 @@ This matches the upstream `tramp-test28-process-file' test."
                            '(utf-8-unix . utf-8-unix))))
         (when (processp proc)
           (ignore-errors (delete-process proc)))))))
+
+(ert-deftest tramp-rpc-test13d-coding-byte-boundary ()
+  "Process coding crosses RPC chunks exactly once."
+  (let* ((utf8 (encode-coding-string "é" 'binary))
+         (binary (string-make-unibyte "\xff\x00\xc3"))
+         (p (start-process "tramp-rpc-coding-boundary" nil "cat"))
+         (output ""))
+    (unwind-protect
+        (progn
+          (sleep-for .05)
+          (tramp-rpc--configure-relay-coding p '(utf-8-unix . utf-8-unix))
+          (set-process-filter p (lambda (_process string)
+                                  (setq output (concat output string))))
+          (let ((tramp-rpc--delivering-output t))
+            (process-send-string p (substring utf8 0 1))
+            (accept-process-output nil .05)
+            (process-send-string p (concat (substring utf8 1) "\n"))
+            (accept-process-output nil .2))
+          (should (equal output "é\n"))
+          (should (equal (tramp-rpc--decode-output
+                          (msgpack-bin-make (string-make-unibyte "\351"))
+                          'latin-1-unix)
+                         "é"))
+          (should (equal (tramp-rpc--decode-output binary 'binary) binary))
+          (should (equal (string-to-list
+                          (tramp-rpc--encode-process-input
+                           p "é"))
+                         '(195 169)))
+          (set-process-coding-system p 'latin-1-unix 'latin-1-unix)
+          (should (equal (process-coding-system p)
+                         '(latin-1-unix . latin-1-unix)))
+          (should (equal (string-to-list
+                          (tramp-rpc--encode-process-input p "é"))
+                         '(233)))
+          (set-process-coding-system p 'latin-1-unix)
+          (should (equal (process-coding-system p)
+                         '(latin-1-unix . raw-text-unix)))
+          (let ((before (process-coding-system p)))
+            (should-error
+             (set-process-coding-system p 'utf-8-unix 'no-such-coding-system)
+             :type 'coding-system-error)
+            (should (equal (process-coding-system p) before)))
+          (should (equal (tramp-rpc--encode-process-input
+                          p (string-make-unibyte "\xff\x00"))
+                         (string-make-unibyte "\xff\x00"))))
+      (when (processp p)
+        (delete-process p)))))
+
+(ert-deftest tramp-rpc-test13e-separate-stderr-coding-relay ()
+  "Separate stderr relays use the same requested decoder without mixing bytes."
+  (let* ((stdout (start-process "tramp-rpc-coding-stdout" nil "cat"))
+         (stderr (start-process "tramp-rpc-coding-stderr" nil "cat"))
+         (stdout-output "")
+         (stderr-output ""))
+    (unwind-protect
+        (progn
+          (sleep-for .05)
+          (tramp-rpc--configure-relay-coding stdout
+                                             '(utf-8-unix . latin-1-unix))
+          (tramp-rpc--configure-relay-coding stderr
+                                             '(utf-8-unix . latin-1-unix))
+          (set-process-filter stdout
+                              (lambda (_process string)
+                                (setq stdout-output (concat stdout-output string))))
+          (set-process-filter stderr
+                              (lambda (_process string)
+                                (setq stderr-output (concat stderr-output string))))
+          (puthash stdout (list :stderr-process stderr)
+                   tramp-rpc--async-processes)
+          (tramp-rpc--deliver-process-output
+           stdout (encode-coding-string "sortie\n" 'binary)
+           (encode-coding-string "erreur\n" 'binary) t)
+          (accept-process-output nil .2)
+          (should (equal stdout-output "sortie\n"))
+          (should (equal stderr-output "erreur\n"))
+          (should (equal (process-coding-system stdout)
+                         '(utf-8-unix . latin-1-unix))))
+      (remhash stdout tramp-rpc--async-processes)
+      (delete-process stdout)
+      (delete-process stderr))))
+
+(ert-deftest tramp-rpc-test13f-pty-coding-byte-boundary ()
+  "RPC PTY output remains raw until the local incremental decoder."
+  (let* ((process (start-process "tramp-rpc-coding-pty" nil "cat"))
+         (bytes (encode-coding-string "é" 'binary))
+         (output ""))
+    (unwind-protect
+        (progn
+          (sleep-for .05)
+          (tramp-rpc--configure-relay-coding process
+                                             '(utf-8-unix . latin-1-unix))
+          (set-process-filter process
+                              (lambda (_process string)
+                                (setq output (concat output string))))
+          (process-put process :tramp-rpc-pty t)
+          (puthash process '(:poll-timer nil) tramp-rpc--pty-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--pty-start-async-read)
+                     (lambda (&rest _args) nil)))
+            (tramp-rpc--pty-handle-async-response
+             process `(:result ((output . ,(substring bytes 0 1))
+                                (exited . nil))))
+            (tramp-rpc--pty-handle-async-response
+             process `(:result ((output . ,(concat (substring bytes 1) "\n"))
+                                (exited . nil))))
+            (accept-process-output nil .2))
+          (should (equal output "é\n")))
+      (remhash process tramp-rpc--pty-processes)
+      (delete-process process))))
+
+(ert-deftest tramp-rpc-test13g-pty-final-output-flushes-before-exit ()
+  "RPC PTY final output is delivered before its local relay exits."
+  (let* ((process (start-process "tramp-rpc-final-pty" nil "cat"))
+         (output "")
+         (sentinel-events nil))
+    (unwind-protect
+        (progn
+          (tramp-rpc--configure-relay-coding process 'binary)
+          (set-process-filter
+           process
+           (lambda (_process string)
+             (setq output (concat output string))))
+          (set-process-sentinel process #'tramp-rpc--pty-sentinel)
+          (process-put process :tramp-rpc-pty t)
+          (process-put process :tramp-rpc-user-sentinel
+                       (lambda (_process event)
+                         (push event sentinel-events)))
+          (puthash process '(:poll-timer nil) tramp-rpc--pty-processes)
+          (tramp-rpc--pty-handle-async-response
+           process '(:result ((output . "final output\n")
+                              (exited . t)
+                              (exit_code . 0))))
+          (while (process-live-p process)
+            (accept-process-output process 0.1 nil t))
+          (should (equal output "final output\n"))
+          (should (equal sentinel-events '("finished\n")))
+          (should-not (gethash process tramp-rpc--pty-processes)))
+      (remhash process tramp-rpc--pty-processes)
+      (when (processp process)
+        (ignore-errors (delete-process process))))))
 
 (ert-deftest tramp-rpc-test13d-async-read-rpc-error-exits-process ()
   "Test async read RPC errors terminate the local process state."


### PR DESCRIPTION
## Summary

Apply coding only at the local Emacs process boundary for UTF-8, Latin-1, binary, asymmetric pairs, stderr, and PTYs.

## Stack

Part **7 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/06-transport-cleanup`
- Next PRs build on `remediation/07-process-coding`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.
