### PR TITLE
[9/11] Verify deployment artifacts and remove dead helpers

### DIFF
--- a/README.org
+++ b/README.org
@@ -212,18 +212,54 @@ Centralizes all advice functions:
 
 ** RPC Server Methods
 
-The server exposes RPC methods for:
+The dispatcher exposes these public methods:
 
-| Category  | Methods                                                            |
-|-----------+--------------------------------------------------------------------|
-| File      | ~file.stat~, ~file.stat_batch~, ~file.executable~, ~file.truename~ |
-| File I/O  | ~file.read~, ~file.write~, ~file.copy~, ~file.rename~, ~file.delete~, ~file.set_modes~, ~file.set_times~, ~file.make_symlink~, ~file.make_hardlink~, ~file.chown~ |
-| Directory | ~dir.list~, ~dir.create~, ~dir.remove~, ~dir.completions~         |
-| Process   | ~process.run~, ~process.start~, ~process.read~, ~process.write~, ~process.close_stdin~, ~process.kill~, ~process.list~ |
-| PTY       | ~process.start_pty~, ~process.read_pty~, ~process.write_pty~, ~process.resize_pty~, ~process.kill_pty~, ~process.close_pty~, ~process.list_pty~ |
-| System    | ~system.info~, ~system.getenv~, ~system.expand_path~, ~system.statvfs~, ~system.groups~ |
-| Batch     | ~batch~, ~commands.run_parallel~, ~ancestors.scan~                 |
-| Watch     | ~watch.add~, ~watch.remove~, ~watch.list~                         |
+| Category | Method | Description |
+|----------+--------+-------------|
+| Batch | ~batch~ | Execute multiple requests concurrently. |
+| File | ~file.stat~ | Return file metadata. |
+| File | ~file.truename~ | Resolve a file's canonical path. |
+| Directory | ~dir.list~ | List directory entries, optionally with attributes. |
+| Directory | ~dir.create~ | Create a directory. |
+| Directory | ~dir.remove~ | Remove a directory. |
+| File I/O | ~file.read~ | Read file bytes. |
+| File I/O | ~file.write~ | Write file bytes. |
+| File I/O | ~file.copy~ | Copy a file. |
+| File I/O | ~file.rename~ | Rename a file. |
+| File I/O | ~file.delete~ | Delete a file. |
+| File I/O | ~file.set_modes~ | Set file mode bits. |
+| File I/O | ~file.set_times~ | Set file timestamps. |
+| File I/O | ~file.make_symlink~ | Create a symbolic link. |
+| File I/O | ~file.make_hardlink~ | Create a hard link. |
+| File I/O | ~file.chown~ | Change file ownership. |
+| Process | ~process.run~ | Run a command synchronously. |
+| Process | ~process.start~ | Start a managed pipe process. |
+| Process | ~process.write~ | Write to managed process stdin. |
+| Process | ~process.read~ | Read managed process output. |
+| Process | ~process.status~ | Return managed process status. |
+| Process | ~process.close_stdin~ | Close managed process stdin. |
+| Process | ~process.kill~ | Signal a managed process. |
+| Process | ~process.list~ | List managed processes. |
+| PTY | ~process.start_pty~ | Start a pseudo-terminal process. |
+| PTY | ~process.read_pty~ | Read pseudo-terminal output. |
+| PTY | ~process.write_pty~ | Write pseudo-terminal input. |
+| PTY | ~process.resize_pty~ | Resize a pseudo-terminal. |
+| PTY | ~process.kill_pty~ | Signal a pseudo-terminal process. |
+| PTY | ~process.close_pty~ | Close a pseudo-terminal process. |
+| PTY | ~process.list_pty~ | List pseudo-terminal processes. |
+| System | ~system.info~ | Return server and host information. |
+| System | ~system.getenv~ | Read an environment variable. |
+| System | ~system.expand_path~ | Expand home-directory paths. |
+| System | ~system.statvfs~ | Return filesystem capacity information. |
+| System | ~system.groups~ | Return supplementary groups. |
+| Commands | ~commands.run_parallel~ | Run commands concurrently. |
+| Commands | ~ancestors.scan~ | Scan ancestor directories. |
+| High-level | ~highlevel.test_files_in_dir~ | Find named files in a directory. |
+| High-level | ~highlevel.locate_dominating_file_multi~ | Find an ancestor containing one of several names. |
+| High-level | ~highlevel.dir_locals_find_file_cache_update~ | Update directory-local file cache data. |
+| Watch | ~watch.add~ | Add a filesystem watch. |
+| Watch | ~watch.remove~ | Remove a filesystem watch. |
+| Watch | ~watch.list~ | List filesystem watches. |
 
 * Binary Deployment
 

--- a/doc/TECHNICAL_COMPARISON.org
+++ b/doc/TECHNICAL_COMPARISON.org
@@ -160,8 +160,6 @@ TRAMP-RPC exposes these method categories:
 | Method             | Parameters              | Returns                            |
 |--------------------+-------------------------+------------------------------------|
 | file.stat          | path, lstat             | FileAttributes (or null if absent) |
-| file.stat_batch    | paths, lstat            | [FileAttributes or null]           |
-| file.executable    | path                    | boolean                            |
 | file.truename      | path                    | string (canonical path)            |
 | file.read          | path, offset?, length?  | {content: binary, size: int}       |
 | file.write         | path, content, append?  | {written: int}                     |
@@ -180,7 +178,6 @@ TRAMP-RPC exposes these method categories:
 | dir.list         | path, include_attrs      | [{name, type, attrs?}]   |
 | dir.create       | path, parents?           | boolean                  |
 | dir.remove       | path, recursive?         | boolean                  |
-| dir.completions  | directory, prefix        | [string]                 |
 
 **** Process Operations
 | Method            | Parameters                   | Returns                    |

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -568,36 +568,132 @@ Returns t on success, nil on failure."
         (message "Downloading %s..." url)
         (with-timeout (tramp-rpc-deploy-download-timeout
                        (signal 'remote-file-error
-			       (list (format
-				      "Download timed out after %d seconds"
-				      tramp-rpc-deploy-download-timeout))))
-          (with-current-buffer (url-retrieve-synchronously url t t)
-            (goto-char (point-min))
-            ;; Check for HTTP errors
-            (unless (re-search-forward "^HTTP/[0-9.]+ 200" nil t)
-              (if (re-search-forward "^HTTP/[0-9.]+ \\([0-9]+\\)" nil t)
-                  (signal 'remote-file-error (list "HTTP error" (match-string 1)))
-                (signal 'remote-file-error (list "Invalid HTTP response"))))
-            ;; Find body (after blank line)
-            (re-search-forward "^\r?\n" nil t)
-            ;; Write body to file
-            (let ((coding-system-for-write 'binary))
-              (write-region (point) (point-max) dest nil 'silent))
-            (kill-buffer)
-            t)))
+                               (list (format "Download timed out after %d seconds"
+                                             tramp-rpc-deploy-download-timeout))))
+          (let ((buffer (url-retrieve-synchronously url t t)))
+            (unless buffer
+              (signal 'remote-file-error (list "No HTTP response" url)))
+            (unwind-protect
+                (with-current-buffer buffer
+                  (goto-char (point-min))
+                  (unless (re-search-forward "^HTTP/[0-9.]+ 200" nil t)
+                    (if (re-search-forward "^HTTP/[0-9.]+ \\([0-9]+\\)" nil t)
+                        (signal 'remote-file-error (list "HTTP error" (match-string 1)))
+                      (signal 'remote-file-error (list "Invalid HTTP response"))))
+                  (re-search-forward "^\\r?\\n" nil t)
+                  (let ((coding-system-for-write 'binary))
+                    (write-region (point) (point-max) dest nil 'silent))
+                  t)
+              (when (buffer-live-p buffer)
+                (kill-buffer buffer))))))
     (error
      (message "Download failed: %s" (error-message-string err))
      nil)))
 
+(defun tramp-rpc-deploy--release-checksum (metadata asset)
+  "Return the SHA256 in METADATA for exactly ASSET.
+Release metadata must be one standard sha256sum line.  Rejecting ambiguous
+or differently named entries prevents a valid checksum for another artifact
+from authorizing this download."
+  (let ((lines (split-string (string-trim metadata) "[\r\n]+" t)))
+    (unless (= (length lines) 1)
+      (signal 'remote-file-error (list "Malformed checksum metadata")))
+    (let ((line (car lines)))
+      (unless (string-match
+               "\\`\\([[:xdigit:]]\\{64\\}\\)[[:space:]]+\\*?\\([^[:space:]]+\\)\\'"
+               line)
+        (signal 'remote-file-error (list "Malformed checksum metadata")))
+      (let ((checksum (downcase (match-string 1 line)))
+            (named-asset (match-string 2 line)))
+        (unless (string= named-asset asset)
+          (signal 'remote-file-error
+                  (list "Checksum metadata names" named-asset "not" asset)))
+        checksum))))
+
 (defun tramp-rpc-deploy--verify-checksum (file expected-checksum)
-  "Verify that FILE has EXPECTED-CHECKSUM.
+  "Verify that FILE has the SHA256 EXPECTED-CHECKSUM.
 Returns t if checksum matches, nil otherwise."
-  (when (and file (file-exists-p file) expected-checksum)
-    (let ((actual (with-temp-buffer
-                    (set-buffer-multibyte nil)
-                    (insert-file-contents-literally file)
-                    (secure-hash 'sha256 (current-buffer)))))
-      (string= actual (car (split-string expected-checksum))))))
+  (when (and file (file-exists-p file)
+             (stringp expected-checksum)
+             (string-match-p "\\`[[:xdigit:]]\\{64\\}\\'" expected-checksum))
+    (string= (tramp-rpc-deploy--compute-checksum file)
+             (downcase expected-checksum))))
+
+(defun tramp-rpc-deploy--cache-provenance-path (cache-path)
+  "Return the provenance sidecar path for CACHE-PATH."
+  (concat cache-path ".provenance"))
+
+(defun tramp-rpc-deploy--write-file-atomically (path contents)
+  "Write CONTENTS to PATH without exposing a partial file."
+  (let ((temp-path (make-temp-file (concat path ".tmp."))))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-path
+            (insert contents))
+          (rename-file temp-path path t)
+          (setq temp-path nil))
+      (when temp-path
+        (ignore-errors (delete-file temp-path))))))
+
+(defun tramp-rpc-deploy--write-cache-provenance (cache-path kind digest)
+  "Atomically record KIND and SHA256 DIGEST for CACHE-PATH."
+  (unless (and (member kind '("release" "source-build"))
+               (stringp digest)
+               (string-match-p "\\`[[:xdigit:]]\\{64\\}\\'" digest))
+    (signal 'remote-file-error (list "Invalid cache provenance")))
+  (tramp-rpc-deploy--write-file-atomically
+   (tramp-rpc-deploy--cache-provenance-path cache-path)
+   (format "%s-sha256:%s\n" kind (downcase digest))))
+
+(defun tramp-rpc-deploy--invalidate-cache (cache-path)
+  "Remove CACHE-PATH and its provenance after failed source-cache validation."
+  (ignore-errors (delete-file cache-path))
+  (ignore-errors (delete-file (tramp-rpc-deploy--cache-provenance-path cache-path))))
+
+(defun tramp-rpc-deploy--promote-cached-binary (source cache-path kind)
+  "Atomically promote SOURCE to CACHE-PATH with KIND and a recorded digest.
+A crash after removing provenance can leave an untrusted cache entry, but
+never one authorized by stale provenance."
+  (make-directory (file-name-directory cache-path) t)
+  (let ((temp-path (make-temp-file (concat cache-path ".tmp.")))
+        (provenance-path (tramp-rpc-deploy--cache-provenance-path cache-path)))
+    (unwind-protect
+        (progn
+          (copy-file source temp-path t)
+          (set-file-modes temp-path #o755)
+          (let ((digest (tramp-rpc-deploy--compute-checksum temp-path)))
+            ;; Remove stale authority before changing the cache binary.
+            (ignore-errors (delete-file provenance-path))
+            (rename-file temp-path cache-path t)
+            (setq temp-path nil)
+            (tramp-rpc-deploy--write-cache-provenance cache-path kind digest)
+            cache-path))
+      (when temp-path
+        (ignore-errors (delete-file temp-path))))))
+
+(defun tramp-rpc-deploy--cached-binary-trusted-p (cache-path)
+  "Return non-nil when CACHE-PATH matches a recorded provenance digest."
+  (let* ((provenance-path (tramp-rpc-deploy--cache-provenance-path cache-path))
+         (provenance (and (file-exists-p provenance-path)
+                          (with-temp-buffer
+                            (insert-file-contents-literally provenance-path)
+                            (buffer-string)))))
+    (cond
+     ((and provenance
+           (string-match
+            "\\`\\(release\\|source-build\\)-sha256:\\([[:xdigit:]]\\{64\\}\\)\n?\\'"
+            provenance))
+      (let ((kind (match-string 1 provenance))
+            (digest (match-string 2 provenance)))
+        (if (tramp-rpc-deploy--verify-checksum cache-path digest)
+            t
+          (when (string= kind "source-build")
+            (tramp-rpc-deploy--invalidate-cache cache-path))
+          nil)))
+     ;; Legacy and malformed source-build records must never authorize reuse.
+     ((and provenance (string-prefix-p "source-build" provenance))
+      (tramp-rpc-deploy--invalidate-cache cache-path)
+      nil))))
 
 (defun tramp-rpc-deploy--extract-tarball (tarball dest-dir)
   "Extract TARBALL to DEST-DIR.
@@ -612,42 +708,47 @@ Returns the path to the extracted binary, or nil on failure."
       nil)))
 
 (defun tramp-rpc-deploy--download-binary (arch)
-  "Download pre-compiled binary for ARCH from GitHub releases.
-Returns the path to the binary on success, signals error on failure."
+  "Download a checksum-verified pre-compiled binary for ARCH.
+Returns the cached binary path on success, and never promotes an unverified
+release artifact into the cache."
   (let* ((cache-path (tramp-rpc-deploy--local-cache-path arch))
-         (cache-dir (file-name-directory cache-path))
+         (asset (tramp-rpc-deploy--release-asset-name arch))
          (tarball-url (tramp-rpc-deploy--download-url arch))
          (checksum-url (tramp-rpc-deploy--checksum-url arch))
          (temp-dir (make-temp-file "tramp-rpc-" t))
          (tarball-path (expand-file-name "server.tar.gz" temp-dir))
-         (checksum-path (expand-file-name "server.tar.gz.sha256" temp-dir)))
+         (checksum-path (expand-file-name "server.tar.gz.sha256" temp-dir))
+         (extract-dir (expand-file-name "extract" temp-dir)))
     (unwind-protect
         (progn
-          ;; Download checksum first
           (message "Fetching checksum for %s..." arch)
-          (let ((checksum-ok (tramp-rpc-deploy--download-file checksum-url checksum-path)))
-            ;; Download tarball
+          (unless (tramp-rpc-deploy--download-file checksum-url checksum-path)
+            (signal 'remote-file-error
+                    (list "Checksum metadata unavailable; refusing unverified release binary"
+                          checksum-url)))
+          (let ((expected (tramp-rpc-deploy--release-checksum
+                           (with-temp-buffer
+                             (insert-file-contents-literally checksum-path)
+                             (buffer-string))
+                           asset)))
             (message "Downloading tramp-rpc-server for %s..." arch)
             (unless (tramp-rpc-deploy--download-file tarball-url tarball-path)
-              (signal
-	       'remote-file-error
-	       (list "Download failed from" tarball-url "(release may not exist)")))
-            ;; Verify checksum if we got one
-            (when checksum-ok
-              (let ((expected (with-temp-buffer
-                                (insert-file-contents checksum-path)
-                                (buffer-string))))
-                (unless (tramp-rpc-deploy--verify-checksum tarball-path expected)
-                  (signal 'remote-file-error (list "Checksum verification failed")))))
-            ;; Extract
+              (signal 'remote-file-error
+                      (list "Download failed from" tarball-url "(release may not exist)")))
+            (unless (tramp-rpc-deploy--verify-checksum tarball-path expected)
+              (signal 'remote-file-error
+                      (list "Checksum verification failed for" asset)))
+            ;; Extract outside the cache: only a verified release can be promoted.
             (message "Extracting binary...")
-            (make-directory cache-dir t)
-            (unless (tramp-rpc-deploy--extract-tarball tarball-path cache-dir)
-              (signal 'remote-file-error (list "Failed to extract tarball")))
-            (message "Downloaded tramp-rpc-server for %s" arch)
+            (let ((binary (tramp-rpc-deploy--extract-tarball tarball-path extract-dir)))
+              (unless binary
+                (signal 'remote-file-error (list "Failed to extract tarball")))
+              (tramp-rpc-deploy--promote-cached-binary
+               binary cache-path "release"))
+            (message "Downloaded and verified tramp-rpc-server for %s" arch)
             cache-path))
-      ;; Cleanup temp dir
-      (delete-directory temp-dir t))))
+      ;; Never leave downloaded archives or unpromoted extraction behind.
+      (ignore-errors (delete-directory temp-dir t)))))
 
 ;;; ============================================================================
 ;;; Build from source
@@ -678,7 +779,6 @@ Returns the path to the binary on success, nil on failure."
   (let* ((default-directory tramp-rpc-deploy-source-directory)
          (target (tramp-rpc-deploy--arch-to-rust-target arch))
          (cache-path (tramp-rpc-deploy--local-cache-path arch))
-         (cache-dir (file-name-directory cache-path))
          (build-output (expand-file-name
                         (format "target/%s/release/%s"
                                 target tramp-rpc-deploy-binary-name)
@@ -698,10 +798,9 @@ Returns the path to the binary on success, nil on failure."
                          (expand-file-name "Cargo.toml" tramp-rpc-deploy-source-directory))))
       (if (zerop exit-code)
           (progn
-            ;; Copy to cache
-            (make-directory cache-dir t)
-            (copy-file build-output cache-path t)
-            (set-file-modes cache-path #o755)
+            ;; Promote only a complete binary with its recorded digest.
+            (tramp-rpc-deploy--promote-cached-binary
+             build-output cache-path "source-build")
             (message "Built tramp-rpc-server for %s" arch)
             cache-path)
         (with-current-buffer build-buffer
@@ -761,7 +860,8 @@ Returns the path to the local binary."
 
      ;; Check cache
      ((and (file-exists-p cache-path)
-           (file-executable-p cache-path))
+           (file-executable-p cache-path)
+           (tramp-rpc-deploy--cached-binary-trusted-p cache-path))
       (message "Using cached binary for %s" arch)
       cache-path)
 
@@ -874,6 +974,43 @@ Tries sha256sum first, then shasum -a 256 for macOS compatibility."
     (when (looking-at "\\([a-f0-9]\\{64\\}\\)")
       (match-string 1))))
 
+(defun tramp-rpc-deploy--make-remote-staging-directory (vec remote-local)
+  "Create and return a private staging directory beside REMOTE-LOCAL on VEC."
+  (let ((parent (file-name-directory remote-local)))
+    ;; Ask the remote shell to resolve `~' (and any symlinked parent) before
+    ;; invoking mktemp.  The default deployment directory is home-relative, so
+    ;; comparing mktemp's absolute output with the unexpanded `~/' spelling
+    ;; would reject every automatic deployment.
+    (tramp-send-command
+     vec
+     (format (concat "umask 077 && parent=$(cd %s && pwd -P) && "
+                     "directory=$(mktemp -d \"$parent/.tramp-rpc-transfer.XXXXXX\") && "
+                     "printf '%%s\\n%%s\\n' \"$parent\" \"$directory\"")
+             (tramp-shell-quote-argument parent)))
+    (with-current-buffer (tramp-get-connection-buffer vec)
+      (goto-char (point-min))
+      (let ((resolved-parent
+             (string-trim (buffer-substring-no-properties
+                           (line-beginning-position) (line-end-position))))
+            directory)
+        (forward-line 1)
+        (setq directory
+              (string-trim (buffer-substring-no-properties
+                            (line-beginning-position) (line-end-position))))
+        (unless (and (file-name-absolute-p resolved-parent)
+                     (file-name-absolute-p directory)
+                     (string= (file-name-as-directory resolved-parent)
+                              (file-name-directory directory)))
+          (signal 'remote-file-error
+                  (list "Could not create private remote staging directory")))
+        directory))))
+
+(defun tramp-rpc-deploy--remove-remote-staging-directory (vec directory)
+  "Remove remote staging DIRECTORY on VEC."
+  (when directory
+    (tramp-send-command-and-check
+     vec (format "rm -rf %s" (tramp-shell-quote-argument directory)))))
+
 (defun tramp-rpc-deploy--transfer-binary (vec local-path)
   "Transfer the binary at LOCAL-PATH to the remote host VEC.
 Uses TRAMP's `copy-file' with the bootstrap method for binary transfer.
@@ -883,15 +1020,6 @@ and reliable for large files.  With \"ssh\" or \"sshx\", TRAMP falls back
 to inline encoding (base64 through the shell), which can be fragile."
   (let* ((remote-path (tramp-rpc-deploy--remote-binary-path vec))
          (remote-local (tramp-file-local-name remote-path))
-         (remote-tmp-name (format "%s.tmp.%d"
-                                  (file-name-nondirectory remote-local)
-                                  (random 100000)))
-         (remote-tmp-path (tramp-make-tramp-file-name
-                           vec
-                           ;; Use concat to preserve ~ for remote expansion
-                           (concat (file-name-as-directory tramp-rpc-deploy-remote-directory)
-                                   remote-tmp-name)))
-         (remote-tmp-local (tramp-file-local-name remote-tmp-path))
          (local-checksum (tramp-rpc-deploy--compute-checksum local-path))
          (retries 0)
          (success nil)
@@ -910,56 +1038,82 @@ to inline encoding (base64 through the shell), which can be fragile."
 
     ;; Retry loop for reliability
     (while (and (not success) (< retries tramp-rpc-deploy-max-retries))
-      (let ((attempt (1+ retries)))
+      (let ((attempt (1+ retries))
+            staging-directory)
         (message "Transfer attempt %d/%d..." attempt tramp-rpc-deploy-max-retries)
-        (condition-case err
-            (progn
-              ;; Use TRAMP's copy-file for binary transfer via the bootstrap method.
-              ;; With "scp"/"rsync" methods this uses out-of-band transfer
-              ;; (actual scp/rsync binaries), avoiding inline base64 encoding.
-              (copy-file local-path remote-tmp-path t)
+        (unwind-protect
+            (condition-case err
+                (let* ((directory
+                        (setq staging-directory
+                              (tramp-rpc-deploy--make-remote-staging-directory
+                               vec remote-local)))
+                       (remote-tmp-local
+                        (expand-file-name
+                         (file-name-nondirectory remote-local) directory))
+                       (remote-tmp-path
+                        (tramp-make-tramp-file-name vec remote-tmp-local)))
+                  ;; The atomically-created private directory guarantees that
+                  ;; the destination does not exist.  Do not permit copy-file
+                  ;; to follow or replace a pre-planted pathname.
+                  (copy-file local-path remote-tmp-path nil)
 
-              ;; Verify the file was created and has content
-              (unless (tramp-send-command-and-check
-                       vec
-                       (format "test -s %s" (tramp-shell-quote-argument remote-tmp-local)))
-                (signal
-		 'remote-file-error
-		 (list "Temp file not created or is empty after copy")))
+                  (unless (tramp-send-command-and-check
+                           vec
+                           (format "test -s %s"
+                                   (tramp-shell-quote-argument remote-tmp-local)))
+                    (signal 'remote-file-error
+                            (list "Temp file not created or is empty after copy")))
 
-              ;; Verify checksum
-              (let ((remote-checksum (tramp-rpc-deploy--remote-checksum vec remote-tmp-local)))
-                (unless remote-checksum
-                  (signal
-		   'remote-file-error
-		   (list "Could not compute remote checksum (sha256sum/shasum not available?)")))
-                (if (string= local-checksum remote-checksum)
-                    (progn
-                      ;; Checksum matches - make executable and atomically move
-                      (tramp-send-command
+                  (let ((remote-checksum
+                         (tramp-rpc-deploy--remote-checksum vec remote-tmp-local)))
+                    (unless remote-checksum
+                      (signal
+                       'remote-file-error
+                       (list "Could not compute remote checksum (sha256sum/shasum not available?)")))
+                    (unless (string= local-checksum remote-checksum)
+                      (signal
+                       'remote-file-error
+                       (list (format "Checksum mismatch (local: %s, remote: %s)"
+                                     (substring local-checksum 0 12)
+                                     (substring remote-checksum 0 12))))))
+
+                  ;; Recheck the type and digest in the same remote shell
+                  ;; operation as activation.  This closes the interval between
+                  ;; the earlier diagnostic checksum and the atomic rename.
+                  ;; The staging directory is a child of the deployment
+                  ;; directory, so promotion remains a same-filesystem rename
+                  ;; while concurrent deployments stay isolated.
+                  (unless
+                      (tramp-send-command-and-check
                        vec
-                       (format "chmod +x %s && mv -f %s %s"
-                               (tramp-shell-quote-argument remote-tmp-local)
-                               (tramp-shell-quote-argument remote-tmp-local)
-                               (tramp-shell-quote-argument remote-local)))
-                      (setq success t)
-                      (message "Transfer completed successfully"))
-                  ;; Checksum mismatch - clean up and retry
-                  (let ((err-msg (format "Attempt %d: Checksum mismatch (local: %s, remote: %s)"
-                                         attempt
-                                         (substring local-checksum 0 12)
-                                         (substring remote-checksum 0 12))))
-                    (push err-msg errors)
-                    (message "%s" err-msg))
-                  (ignore-errors (delete-file remote-tmp-path))
-                  (setq retries (1+ retries)))))
-          (error
-           ;; Clean up on error and retry
-           (let ((err-msg (format "Attempt %d: %s" attempt (error-message-string err))))
-             (push err-msg errors)
-             (message "Transfer error: %s" err-msg))
-           (ignore-errors (delete-file remote-tmp-path))
-           (setq retries (1+ retries))))))
+                       (let ((tmp (tramp-shell-quote-argument remote-tmp-local))
+                             (dest (tramp-shell-quote-argument remote-local))
+                             (digest (tramp-shell-quote-argument local-checksum)))
+                         (format
+                          (concat "test -f %s && ! test -L %s && chmod +x %s && "
+                                  "test -f %s && ! test -L %s && "
+                                  "(test ! -e %s && ! test -L %s || "
+                                  "test -f %s && ! test -L %s) && "
+                                  "actual=$({ sha256sum %s 2>/dev/null || "
+                                  "shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1) && "
+                                  "test \"$actual\" = %s && mv -f %s %s && "
+                                  "test -f %s && ! test -L %s && test -x %s")
+                          tmp tmp tmp tmp tmp dest dest dest dest tmp tmp digest tmp dest
+                          dest dest dest)))
+                    (signal 'remote-file-error
+                            (list "Remote activation failed; existing binary was preserved")))
+                  (setq success t)
+                  (message "Transfer completed successfully"))
+              (error
+               (let ((err-msg
+                      (format "Attempt %d: %s" attempt (error-message-string err))))
+                 (push err-msg errors)
+                 (message "Transfer error: %s" err-msg))
+               (setq retries (1+ retries))))
+          (when staging-directory
+            (ignore-errors
+              (tramp-rpc-deploy--remove-remote-staging-directory
+               vec staging-directory))))))
 
     (unless success
       (signal

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -247,11 +247,6 @@ FORMAT-STRING and ARGS are passed to `format'."
               (write-region line nil log-file 'append 'silent))
           (error nil))))))
 
-(defvar tramp-rpc-deploy--source-tree-hash-cache nil
-  "Cache for the source tree hash.
-The value is a list (ROOT FINGERPRINT HASH), where FINGERPRINT is derived
-from source file names, mtimes, and sizes.")
-
 ;;; ============================================================================
 ;;; Architecture detection and path helpers
 ;;; ============================================================================
@@ -394,37 +389,22 @@ Linux targets use musl for fully static binaries."
                 (push file files)))))))
     (sort files #'string<)))
 
-(defun tramp-rpc-deploy--source-file-fingerprint (root files)
-  "Return a cache fingerprint for FILES under ROOT."
-  (mapcar (lambda (file)
-            (let ((attrs (file-attributes file)))
-              (list (file-relative-name file root)
-                    (file-attribute-modification-time attrs)
-                    (file-attribute-size attrs))))
-          files))
-
 (defun tramp-rpc-deploy--source-tree-hash ()
-  "Return a SHA256 hash for files that affect the server build, or nil."
+  "Return a SHA256 hash for files that affect the server build, or nil.
+Hash contents on every call: names, sizes, and mtimes cannot reliably detect
+same-size edits made within coarse timestamp resolution or by tools that
+preserve timestamps."
   (let ((root (tramp-rpc-deploy--source-root))
         (files (tramp-rpc-deploy--source-file-list)))
     (when (and root files)
-      (let ((fingerprint (tramp-rpc-deploy--source-file-fingerprint root files)))
-        (if (and tramp-rpc-deploy--source-tree-hash-cache
-                 (equal root (nth 0 tramp-rpc-deploy--source-tree-hash-cache))
-                 (equal fingerprint (nth 1 tramp-rpc-deploy--source-tree-hash-cache)))
-            (nth 2 tramp-rpc-deploy--source-tree-hash-cache)
-          (let ((hash
-                 (with-temp-buffer
-                   (set-buffer-multibyte nil)
-                   (dolist (file files)
-                     (insert (file-relative-name file root) "\0")
-                     (let ((coding-system-for-read 'binary))
-                       (insert-file-contents-literally file))
-                     (insert "\0"))
-                   (secure-hash 'sha256 (current-buffer)))))
-            (setq tramp-rpc-deploy--source-tree-hash-cache
-                  (list root fingerprint hash))
-            hash))))))
+      (with-temp-buffer
+        (set-buffer-multibyte nil)
+        (dolist (file files)
+          (insert (file-relative-name file root) "\0")
+          (let ((coding-system-for-read 'binary))
+            (insert-file-contents-literally file))
+          (insert "\0"))
+        (secure-hash 'sha256 (current-buffer))))))
 
 (defun tramp-rpc-deploy--git-revision ()
   "Return the short git revision for the source checkout, or nil."
@@ -576,11 +556,12 @@ Returns t on success, nil on failure."
             (unwind-protect
                 (with-current-buffer buffer
                   (goto-char (point-min))
-                  (unless (re-search-forward "^HTTP/[0-9.]+ 200" nil t)
-                    (if (re-search-forward "^HTTP/[0-9.]+ \\([0-9]+\\)" nil t)
+                  (unless (looking-at "HTTP/[0-9.]+ 200\\(?:[ \t]\\|$\\)")
+                    (if (looking-at "HTTP/[0-9.]+ \\([0-9]+\\)")
                         (signal 'remote-file-error (list "HTTP error" (match-string 1)))
                       (signal 'remote-file-error (list "Invalid HTTP response"))))
-                  (re-search-forward "^\\r?\\n" nil t)
+                  (unless (re-search-forward "^\\r?\\n" nil t)
+                    (signal 'remote-file-error (list "Malformed HTTP response")))
                   (let ((coding-system-for-write 'binary))
                     (write-region (point) (point-max) dest nil 'silent))
                   t)
@@ -700,9 +681,16 @@ never one authorized by stale provenance."
 Returns the path to the extracted binary, or nil on failure."
   (let ((default-directory dest-dir))
     (make-directory dest-dir t)
-    (if (zerop (call-process "tar" nil nil nil "-xzf" tarball "-C" dest-dir))
-        (let ((binary (expand-file-name tramp-rpc-deploy-binary-name dest-dir)))
-          (when (file-exists-p binary)
+    ;; Extract only the expected member, so unrelated archive paths cannot
+    ;; escape DEST-DIR or place content that influences promotion.
+    (if (zerop (call-process "tar" nil nil nil "-xzf" tarball "-C" dest-dir
+                             "--" tramp-rpc-deploy-binary-name))
+        (let* ((binary (expand-file-name tramp-rpc-deploy-binary-name dest-dir))
+               (attributes (and (not (file-symlink-p binary))
+                                (file-attributes binary 'integer))))
+          (when (and attributes
+                     (file-regular-p binary)
+                     (= (file-attribute-link-number attributes) 1))
             (set-file-modes binary #o755)
             binary))
       nil)))
@@ -938,14 +926,14 @@ Returns the path to the local binary."
 ;;; ============================================================================
 
 (defun tramp-rpc-deploy--remote-binary-exists-p (vec)
-  "Check if the correct version of the binary exists on remote VEC."
-  (let ((remote-path (tramp-rpc-deploy--remote-binary-path vec)))
-    ;; Use tramp-sh operations for checking since we're bootstrapping
+  "Check if a regular non-symlink executable binary exists on remote VEC."
+  (let* ((remote-path (tramp-rpc-deploy--remote-binary-path vec))
+         (path (tramp-shell-quote-argument
+                (tramp-file-local-name remote-path))))
+    ;; Use tramp-sh operations for checking since we're bootstrapping.
     (tramp-send-command-and-check
-     vec
-     (format "test -x %s"
-             (tramp-shell-quote-argument
-              (tramp-file-local-name remote-path))))))
+     vec (format "test -f %s && ! test -L %s && test -x %s"
+                 path path path))))
 
 (defun tramp-rpc-deploy--ensure-remote-directory (vec)
   "Ensure the remote deployment directory exists on VEC."
@@ -1053,7 +1041,7 @@ to inline encoding (base64 through the shell), which can be fragile."
                        (remote-tmp-path
                         (tramp-make-tramp-file-name vec remote-tmp-local)))
                   ;; The atomically-created private directory guarantees that
-                  ;; the destination does not exist.  Do not permit copy-file
+                  ;; the destination does not exist.  Do not permit `copy-file'
                   ;; to follow or replace a pre-planted pathname.
                   (copy-file local-path remote-tmp-path nil)
 

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -278,17 +278,6 @@ Returns the remote process PID."
                                    ,@(when env `((env . ,env)))))))
     (alist-get 'pid result)))
 
-(defun tramp-rpc--read-remote-process (vec pid)
-  "Read output from remote process PID on VEC.
-Returns plist with :stdout, :stderr, :exited, :exit-code."
-  (let ((result (tramp-rpc--call vec "process.read" `((pid . ,pid)))))
-    (list :stdout (when-let* ((s (alist-get 'stdout result)))
-                    (tramp-rpc--binary-bytes s))
-          :stderr (when-let* ((s (alist-get 'stderr result)))
-                    (tramp-rpc--binary-bytes s))
-          :exited (alist-get 'exited result)
-          :exit-code (alist-get 'exit_code result))))
-
 (defun tramp-rpc--write-remote-process (vec pid data &optional owner-process)
   "Write DATA to stdin of remote process PID on VEC.
 The queue remains bound to OWNER-PROCESS's original connection generation."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -966,15 +966,6 @@ Otherwise clear all entries."
   "Cache of executable paths keyed by (connection-key . program).
 Value is the full path or :not-found.")
 
-;; Forward-declare caches used by tramp-rpc--remove-connection (defined
-;; later in the exec-path section).  The byte-compiler needs to see
-;; these defvars before their first reference.
-(defvar tramp-rpc--exec-path-cache (make-hash-table :test 'equal)
-  "Cache of remote exec-path keyed by connection-key.")
-
-(defvar tramp-rpc--login-shell-cache (make-hash-table :test 'equal)
-  "Cache of remote login shell keyed by connection-key.")
-
 (defun tramp-rpc--clear-executable-cache (&optional vec)
   "Clear the executable cache.
 If VEC is provided, only clear entries for that connection.
@@ -991,6 +982,15 @@ Otherwise clear all entries."
         (dolist (key keys-to-remove)
           (remhash key tramp-rpc--executable-cache)))
     (clrhash tramp-rpc--executable-cache)))
+
+;; Forward-declare caches used by tramp-rpc--remove-connection (defined
+;; later in the exec-path section).  The byte-compiler needs to see
+;; these defvars before their first reference.
+(defvar tramp-rpc--exec-path-cache (make-hash-table :test 'equal)
+  "Cache of remote exec-path keyed by connection-key.")
+
+(defvar tramp-rpc--login-shell-cache (make-hash-table :test 'equal)
+  "Cache of remote login shell keyed by connection-key.")
 
 (defun tramp-rpc--environment-with (env key value)
   "Return ENV with KEY set to VALUE.
@@ -1211,7 +1211,7 @@ new generation is made visible."
 
 (defun tramp-rpc--remove-connection (vec &optional process)
   "Remove VEC's connection, optionally only when PROCESS is current.
-Also clears the executable, exec-path, and login shell caches."
+Also clears the executable, exec-path, and login-shell caches."
   (let* ((key (tramp-rpc--connection-key vec))
          (current (gethash key tramp-rpc--connections)))
     (when (and current

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 
 use super::HandlerResult;
-use super::file::{bytes_to_path, map_io_error};
+use super::file::{bytes_to_path, file_type_from_metadata_ft, map_io_error};
 
 use crate::protocol::path_or_bytes;
 
@@ -272,28 +272,6 @@ fn list_dir_sync(
     results.sort_by(|a, b| a.name.cmp(&b.name));
 
     Ok(results)
-}
-
-/// Convert std::fs::FileType to our FileType
-fn file_type_from_metadata_ft(ft: &std::fs::FileType) -> FileType {
-    use std::os::unix::fs::FileTypeExt;
-    if ft.is_file() {
-        FileType::File
-    } else if ft.is_dir() {
-        FileType::Directory
-    } else if ft.is_symlink() {
-        FileType::Symlink
-    } else if ft.is_char_device() {
-        FileType::CharDevice
-    } else if ft.is_block_device() {
-        FileType::BlockDevice
-    } else if ft.is_fifo() {
-        FileType::Fifo
-    } else if ft.is_socket() {
-        FileType::Socket
-    } else {
-        FileType::Unknown
-    }
 }
 
 /// Return the directory components that do not exist yet, from top to bottom.

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -72,7 +72,7 @@ pub async fn get_file_attributes(path: &Path, lstat: bool) -> Result<FileAttribu
     }
     .map_err(|e| map_io_error(e, &path.to_string_lossy()))?;
 
-    let file_type = get_file_type(&metadata);
+    let file_type = file_type_from_metadata_ft(&metadata.file_type());
 
     let link_target = if file_type == FileType::Symlink {
         fs::read_link(path)
@@ -111,9 +111,7 @@ pub async fn get_file_attributes(path: &Path, lstat: bool) -> Result<FileAttribu
     })
 }
 
-fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
-    let ft = metadata.file_type();
-
+pub(crate) fn file_type_from_metadata_ft(ft: &std::fs::FileType) -> FileType {
     if ft.is_file() {
         FileType::File
     } else if ft.is_dir() {

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -4320,20 +4320,26 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (make-directory (expand-file-name "server/src" dir) t)
           (with-temp-file (expand-file-name "Cargo.toml" dir)
             (insert "[package]\nname = \"tramp-rpc-server\"\n"))
-          (with-temp-file (expand-file-name "server/src/main.rs" dir)
-            (insert "fn main() {}\n"))
-          (let ((tramp-rpc-deploy-source-directory dir)
-                (tramp-rpc-deploy-git-build-policy 'auto))
-            (cl-letf (((symbol-function 'tramp-rpc-deploy--git-revision)
-                       (lambda () "abcdef123456")))
-              (let ((id1 (tramp-rpc-deploy--binary-id)))
-                (should (string-prefix-p "git-abcdef123456-" id1))
-                (should (string-match-p
-                         (concat "tramp-rpc-server-" (regexp-quote id1))
-                         (tramp-rpc-deploy-expected-binary-localname)))
-                (with-temp-file (expand-file-name "server/src/main.rs" dir)
-                  (insert "fn main() { println!(\"changed\"); }\n"))
-                (should-not (equal id1 (tramp-rpc-deploy--binary-id)))))))
+          (let ((source (expand-file-name "server/src/main.rs" dir)))
+            (with-temp-file source
+              (insert "fn main() { 1; }\n"))
+            (let ((tramp-rpc-deploy-source-directory dir)
+                  (tramp-rpc-deploy-git-build-policy 'auto))
+              (cl-letf (((symbol-function 'tramp-rpc-deploy--git-revision)
+                         (lambda () "abcdef123456")))
+                (let ((id1 (tramp-rpc-deploy--binary-id))
+                      (mtime (file-attribute-modification-time
+                              (file-attributes source))))
+                  (should (string-prefix-p "git-abcdef123456-" id1))
+                  (should (string-match-p
+                           (concat "tramp-rpc-server-" (regexp-quote id1))
+                           (tramp-rpc-deploy-expected-binary-localname)))
+                  ;; Equal-length content with the original timestamp must not
+                  ;; reuse a metadata-only source identity.
+                  (with-temp-file source
+                    (insert "fn main() { 2; }\n"))
+                  (set-file-times source mtime)
+                  (should-not (equal id1 (tramp-rpc-deploy--binary-id))))))))
       (delete-directory dir t))))
 
 (ert-deftest tramp-rpc-mock-test-deploy-binary-id-release-policy ()
@@ -4378,6 +4384,54 @@ This matches the behavior expected by `tramp-test28-process-file'."
                   (insert ";; lisp-only change\n"))
                 (should (equal id1 (tramp-rpc-deploy--binary-id)))))))
       (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-extraction-rejects-links ()
+  "Extracted symbolic and hard links cannot be promoted as the release binary."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-extract" t))
+         (dest (expand-file-name "dest" dir))
+         (outside (expand-file-name "outside" dir))
+         (binary (expand-file-name tramp-rpc-deploy-binary-name dest))
+         process-args)
+    (unwind-protect
+        (progn
+          (with-temp-file outside (insert "outside content"))
+          (cl-letf (((symbol-function 'call-process)
+                     (lambda (_program _infile _destination _display &rest args)
+                       (setq process-args args)
+                       (make-symbolic-link outside binary)
+                       0)))
+            (should-not (tramp-rpc-deploy--extract-tarball "archive.tar.gz" dest)))
+          (delete-file binary)
+          (cl-letf (((symbol-function 'call-process)
+                     (lambda (&rest _args)
+                       (add-name-to-file outside binary)
+                       0)))
+            (should-not (tramp-rpc-deploy--extract-tarball "archive.tar.gz" dest)))
+          (should (equal process-args
+                         (list "-xzf" "archive.tar.gz" "-C" dest "--"
+                               tramp-rpc-deploy-binary-name)))
+          (should (equal (with-temp-buffer
+                           (insert-file-contents-literally outside)
+                           (buffer-string))
+                         "outside content")))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-remote-present-requires-regular-file ()
+  "Remote presence rejects directories and symbolic links."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/scp:mock:/tmp/"))
+        command)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+               (lambda (remote-vec)
+                 (tramp-make-tramp-file-name remote-vec "/tmp/server")))
+              ((symbol-function 'tramp-send-command-and-check)
+               (lambda (_vec value) (setq command value) t)))
+      (should (tramp-rpc-deploy--remote-binary-exists-p vec))
+      (should (equal command
+                     "test -f /tmp/server && ! test -L /tmp/server && test -x /tmp/server")))))
 
 (ert-deftest tramp-rpc-mock-test-deploy-checksum-required ()
   "A missing checksum prevents a release binary from reaching the cache."
@@ -4738,9 +4792,9 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (with-temp-buffer
       (insert-file-contents
        (expand-file-name "server/src/handlers/mod.rs" tramp-rpc-mock-test--project-root))
-      (re-search-forward "async fn dispatch_inner" nil t)
+      (should (re-search-forward "async fn dispatch_inner" nil t))
       (let ((start (point))
-            (end (progn (re-search-forward "^    match result {" nil t)
+            (end (progn (should (re-search-forward "^ *match result {" nil t))
                         (match-beginning 0))))
         (goto-char start)
         (while (re-search-forward "\\\"\\([[:alnum:]_.]+\\)\\\" =>" end t)
@@ -4748,13 +4802,17 @@ This matches the behavior expected by `tramp-test28-process-file'."
     (push "batch" dispatcher)
     (with-temp-buffer
       (insert-file-contents (expand-file-name "README.org" tramp-rpc-mock-test--project-root))
-      (re-search-forward "^\\*\\* RPC Server Methods$" nil t)
+      (should (re-search-forward "^\\*\\* RPC Server Methods$" nil t))
       (let ((start (point))
             (end (or (and (re-search-forward "^\\* " nil t) (match-beginning 0))
                      (point-max))))
         (goto-char start)
         (while (re-search-forward "~\\([[:alnum:]_.]+\\)~" end t)
-          (push (match-string 1) documented))))
+          (when (or (string-match-p "\\." (match-string 1))
+                    (equal (match-string 1) "batch"))
+            (push (match-string 1) documented)))))
+    (should dispatcher)
+    (should documented)
     (should (equal (sort (delete-dups dispatcher) #'string<)
                    (sort (delete-dups documented) #'string<)))))
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -4379,6 +4379,385 @@ This matches the behavior expected by `tramp-test28-process-file'."
                 (should (equal id1 (tramp-rpc-deploy--binary-id)))))))
       (delete-directory dir t))))
 
+(ert-deftest tramp-rpc-mock-test-deploy-checksum-required ()
+  "A missing checksum prevents a release binary from reaching the cache."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-checksum" t))
+         (arch "x86_64-linux")
+         (tramp-rpc-deploy-local-cache-directory dir)
+         (tramp-rpc-deploy-source-directory nil)
+         (cache (tramp-rpc-deploy--local-cache-path arch)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc-deploy--download-file)
+                   (lambda (url dest)
+                     (if (string-suffix-p ".sha256" url)
+                         nil
+                       (with-temp-file dest (insert "unverified release"))))))
+          (should-error (tramp-rpc-deploy--download-binary arch)
+                        :type 'remote-file-error)
+          (should-not (file-exists-p cache)))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-malformed-or-mismatched-checksum ()
+  "Malformed, wrong-artifact, and mismatched checksums fail closed."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((jka-compr-inhibit t)
+         (dir (make-temp-file "tramp-rpc-checksum" t))
+         (arch "x86_64-linux")
+         (tramp-rpc-deploy-local-cache-directory dir)
+         (tramp-rpc-deploy-source-directory nil)
+         (asset (tramp-rpc-deploy--release-asset-name arch)))
+    (unwind-protect
+        (dolist (metadata (list "not a checksum"
+                                (format "%064x  different-artifact.tar.gz" 0)
+                                (format "%064x  %s" 0 asset)))
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--download-file)
+                     (lambda (url dest)
+                       (with-temp-file dest
+                         (insert (if (string-suffix-p ".sha256" url)
+                                     metadata
+                                   "release payload")))
+                       t))
+                    ((symbol-function 'tramp-rpc-deploy--extract-tarball)
+                     (lambda (&rest _args)
+                       (error "unverified archive was extracted"))))
+            (should-error (tramp-rpc-deploy--download-binary arch)
+                          :type 'remote-file-error)))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-verified-release-is-cached ()
+  "Only a verified release archive is extracted and marked for cache reuse."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((jka-compr-inhibit t)
+         (dir (make-temp-file "tramp-rpc-checksum" t))
+         (arch "x86_64-linux")
+         (payload "verified release payload")
+         (tramp-rpc-deploy-local-cache-directory dir)
+         (tramp-rpc-deploy-source-directory nil)
+         (asset (tramp-rpc-deploy--release-asset-name arch))
+         (cache (tramp-rpc-deploy--local-cache-path arch)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc-deploy--download-file)
+                   (lambda (url dest)
+                     (with-temp-file dest
+                       (insert (if (string-suffix-p ".sha256" url)
+                                   (format "%s  %s"
+                                           (secure-hash 'sha256 payload) asset)
+                                 payload)))
+                     t))
+                  ((symbol-function 'tramp-rpc-deploy--extract-tarball)
+                   (lambda (_tarball dest)
+                     (make-directory dest t)
+                     (let ((binary (expand-file-name tramp-rpc-deploy-binary-name dest)))
+                       (with-temp-file binary (insert "server binary"))
+                       binary))))
+          (should (equal (tramp-rpc-deploy--download-binary arch) cache))
+          (should (file-exists-p cache))
+          (should (tramp-rpc-deploy--cached-binary-trusted-p cache)))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-source-cache-records-digest-and-reuses ()
+  "A source build records a digest which authorizes an unchanged cache entry."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source-cache" t))
+         (arch "x86_64-linux")
+         (source (expand-file-name "source" dir))
+         (cache-dir (expand-file-name "cache" dir))
+         cache
+         (output (expand-file-name
+                  (format "target/%s/release/%s"
+                          (tramp-rpc-deploy--arch-to-rust-target arch)
+                          tramp-rpc-deploy-binary-name)
+                  source)))
+    (unwind-protect
+        (progn
+          (make-directory (file-name-directory output) t)
+          (with-temp-file output (insert "source build"))
+          (let ((tramp-rpc-deploy-source-directory source)
+                (tramp-rpc-deploy-local-cache-directory cache-dir))
+            (setq cache (tramp-rpc-deploy--local-cache-path arch))
+            (cl-letf (((symbol-function 'tramp-rpc-deploy--cargo-available-p) (lambda () t))
+                      ((symbol-function 'tramp-rpc-deploy--can-build-for-arch-p) (lambda (_arch) t))
+                      ((symbol-function 'call-process) (lambda (&rest _args) 0)))
+              (should (equal (tramp-rpc-deploy--build-binary arch) cache)))
+          (should (string-match-p
+                   "\\`source-build-sha256:[[:xdigit:]]\\{64\\}\n\\'"
+                   (with-temp-buffer
+                     (insert-file-contents-literally
+                      (tramp-rpc-deploy--cache-provenance-path cache))
+                     (buffer-string))))
+          (let ((tramp-rpc-deploy-source-directory nil)
+                (tramp-rpc-deploy-bundled-binary-directory nil)
+                (tramp-rpc-deploy-local-cache-directory cache-dir))
+            (cl-letf (((symbol-function 'tramp-rpc-deploy--download-binary)
+                       (lambda (&rest _args) (error "valid source cache was not reused")))
+                      ((symbol-function 'tramp-rpc-deploy--build-binary)
+                       (lambda (&rest _args) (error "valid source cache was not reused"))))
+              (should (equal (tramp-rpc-deploy--ensure-local-binary arch) cache)))))
+      (delete-directory dir t)))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-modified-source-cache-is-invalidated ()
+  "A modified source-built cache binary is removed rather than reused."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source-cache" t))
+         (cache (expand-file-name "server" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file cache (insert "source build"))
+          (set-file-modes cache #o755)
+          (tramp-rpc-deploy--write-cache-provenance
+           cache "source-build" (tramp-rpc-deploy--compute-checksum cache))
+          (with-temp-file cache (insert "modified source build"))
+          (should-not (tramp-rpc-deploy--cached-binary-trusted-p cache))
+          (should-not (file-exists-p cache))
+          (should-not (file-exists-p (tramp-rpc-deploy--cache-provenance-path cache))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-corrupt-source-cache-is-invalidated ()
+  "A corrupt source-built cache binary is removed rather than reused."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source-cache" t))
+         (cache (expand-file-name "server" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file cache (insert "source build"))
+          (set-file-modes cache #o755)
+          (tramp-rpc-deploy--write-cache-provenance
+           cache "source-build" (tramp-rpc-deploy--compute-checksum cache))
+          (let ((coding-system-for-write 'binary))
+            (with-temp-file cache (insert "\0corrupt source build")))
+          (should-not (tramp-rpc-deploy--cached-binary-trusted-p cache))
+          (should-not (file-exists-p cache))
+          (should-not (file-exists-p (tramp-rpc-deploy--cache-provenance-path cache))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-source-cache-missing-or-malformed-digest-is-invalidated ()
+  "Missing or malformed source-build digests cannot authorize cache reuse."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source-cache" t))
+         (cache (expand-file-name "server" dir)))
+    (unwind-protect
+        (dolist (provenance '("source-build\n" "source-build-sha256:not-a-digest\n"))
+          (with-temp-file cache (insert "source build"))
+          (set-file-modes cache #o755)
+          (with-temp-file (tramp-rpc-deploy--cache-provenance-path cache)
+            (insert provenance))
+          (should-not (tramp-rpc-deploy--cached-binary-trusted-p cache))
+          (should-not (file-exists-p cache))
+          (should-not (file-exists-p (tramp-rpc-deploy--cache-provenance-path cache))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-invalid-source-cache-rebuilds ()
+  "An invalid source cache falls through to the source-build fallback."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source-cache" t))
+         (arch "x86_64-linux")
+         (cache-dir (expand-file-name "cache" dir))
+         cache
+         (built (expand-file-name "rebuilt-server" dir))
+         calls)
+    (unwind-protect
+        (progn
+          (with-temp-file built (insert "rebuilt source build"))
+          (let ((tramp-rpc-deploy-source-directory nil)
+                (tramp-rpc-deploy-bundled-binary-directory nil)
+                (tramp-rpc-deploy-local-cache-directory cache-dir)
+                (tramp-rpc-deploy-git-build-policy 'release))
+            (setq cache (tramp-rpc-deploy--local-cache-path arch))
+            (make-directory (file-name-directory cache) t)
+            (with-temp-file cache (insert "source build"))
+            (set-file-modes cache #o755)
+            (tramp-rpc-deploy--write-cache-provenance
+             cache "source-build" (tramp-rpc-deploy--compute-checksum cache))
+            (with-temp-file cache (insert "corrupt source build"))
+            (cl-letf (((symbol-function 'tramp-rpc-deploy--download-binary)
+                       (lambda (_arch)
+                         (push 'download calls)
+                         (signal 'remote-file-error '("release unavailable"))))
+                      ((symbol-function 'tramp-rpc-deploy--build-binary)
+                       (lambda (_arch)
+                         (push 'build calls)
+                         built)))
+              (should (equal (tramp-rpc-deploy--ensure-local-binary arch) built))
+              (should (equal (nreverse calls) '(download build)))))
+          (should-not (file-exists-p cache)))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-checksum-failure-falls-back-to-source-build ()
+  "A rejected release download tries the existing source-build fallback."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-checksum" t))
+         (built (expand-file-name "built-server" dir))
+         (tramp-rpc-deploy-local-cache-directory (expand-file-name "cache" dir))
+         (tramp-rpc-deploy-source-directory nil)
+         (tramp-rpc-deploy-bundled-binary-directory nil)
+         (tramp-rpc-deploy-git-build-policy 'release)
+         calls)
+    (unwind-protect
+        (progn
+          (with-temp-file built (insert "source build"))
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--download-binary)
+                     (lambda (_arch)
+                       (push 'download calls)
+                       (signal 'remote-file-error '("bad checksum"))))
+                    ((symbol-function 'tramp-rpc-deploy--build-binary)
+                     (lambda (_arch)
+                       (push 'build calls)
+                       built)))
+            (should (equal (tramp-rpc-deploy--ensure-local-binary "x86_64-linux") built))
+            (should (equal (nreverse calls) '(download build)))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-staging-expands-remote-home ()
+  "Home-relative deployment directories accept mktemp's absolute result."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((home (make-temp-file "tramp-rpc-remote-home" t))
+         (parent (expand-file-name ".cache/emacs/tramp-rpc/" home))
+         (remote-local (concat "~/.cache/emacs/tramp-rpc/"
+                               tramp-rpc-deploy-binary-name))
+         (vec (tramp-dissect-file-name "/scp:mock:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-staging*"))
+         directory)
+    (unwind-protect
+        (progn
+          (make-directory parent t)
+          (cl-letf (((symbol-function 'tramp-send-command)
+                     (lambda (_vec command)
+                       (with-current-buffer buffer
+                         (erase-buffer)
+                         (let ((process-environment
+                                (cons (concat "HOME=" home) process-environment))
+                               (default-directory "/"))
+                           (should (zerop (call-process "sh" nil buffer nil
+                                                       "-c" command)))))))
+                    ((symbol-function 'tramp-get-connection-buffer)
+                     (lambda (_vec) buffer)))
+            (setq directory
+                  (tramp-rpc-deploy--make-remote-staging-directory
+                   vec remote-local)))
+          (should (file-name-absolute-p directory))
+          (should (equal (file-name-directory directory) parent)))
+      (when directory
+        (delete-directory directory t))
+      (when (buffer-live-p buffer)
+        (kill-buffer buffer))
+      (delete-directory home t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-final-verification-preserves-old-binary ()
+  "A staging-file swap before activation fails without replacing the old binary."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-transfer" t))
+         (remote-dir (expand-file-name "remote-cache" dir))
+         (local (expand-file-name "server" dir))
+         (vec (tramp-dissect-file-name "/scp:mock:/tmp/"))
+         (tramp-rpc-deploy-remote-directory remote-dir)
+         (tramp-rpc-deploy-max-retries 1)
+         (remote-local (tramp-file-local-name
+                        (tramp-rpc-deploy--remote-binary-path vec)))
+         (copy-file-function (symbol-function 'copy-file))
+         staging-directory remote-tmp activation-command error-message)
+    (unwind-protect
+        (progn
+          (make-directory remote-dir t)
+          (with-temp-file local (insert "new binary"))
+          (with-temp-file remote-local (insert "old binary"))
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--ensure-remote-directory) #'ignore)
+                    ((symbol-function 'tramp-rpc-deploy--make-remote-staging-directory)
+                     (lambda (_vec _remote-local)
+                       (setq staging-directory
+                             (make-temp-file
+                              (expand-file-name ".tramp-rpc-transfer."
+                                                remote-dir)
+                              t))))
+                    ((symbol-function 'tramp-rpc-deploy--remove-remote-staging-directory)
+                     (lambda (_vec directory)
+                       (delete-directory directory t)))
+                    ((symbol-function 'copy-file)
+                     (lambda (from to &optional ok-if-already-exists &rest _args)
+                       (should-not ok-if-already-exists)
+                       (setq remote-tmp (tramp-file-local-name to))
+                       (funcall copy-file-function from remote-tmp nil)))
+                    ((symbol-function 'tramp-rpc-deploy--remote-checksum)
+                     (lambda (_vec path) (tramp-rpc-deploy--compute-checksum path)))
+                    ((symbol-function 'tramp-send-command-and-check)
+                     (lambda (_vec command)
+                       (when (string-prefix-p "test -f " command)
+                         (setq activation-command command)
+                         ;; Simulate a replacement after the diagnostic checksum
+                         ;; but immediately before the compound activation shell.
+                         (with-temp-file remote-tmp (insert "substituted binary")))
+                       (zerop (call-process "sh" nil nil nil "-c" command)))))
+            (condition-case err
+                (tramp-rpc-deploy--transfer-binary vec local)
+              (remote-file-error (setq error-message (error-message-string err))))
+            (should (string-match-p "Remote activation failed" error-message))
+            (should (string-prefix-p
+                     (file-name-as-directory remote-dir)
+                     (file-name-directory remote-tmp)))
+            (should (equal (file-name-directory remote-tmp)
+                           (file-name-as-directory staging-directory)))
+            (let ((tmp (tramp-shell-quote-argument remote-tmp))
+                  (dest (tramp-shell-quote-argument remote-local))
+                  (digest (tramp-shell-quote-argument
+                           (tramp-rpc-deploy--compute-checksum local))))
+              (should
+               (equal activation-command
+                      (format
+                       (concat "test -f %s && ! test -L %s && chmod +x %s && "
+                               "test -f %s && ! test -L %s && "
+                               "(test ! -e %s && ! test -L %s || "
+                               "test -f %s && ! test -L %s) && "
+                               "actual=$({ sha256sum %s 2>/dev/null || "
+                               "shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1) && "
+                               "test \"$actual\" = %s && mv -f %s %s && "
+                               "test -f %s && ! test -L %s && test -x %s")
+                       tmp tmp tmp tmp tmp dest dest dest dest tmp tmp digest tmp dest
+                       dest dest dest)))
+            (should (equal (with-temp-buffer
+                             (insert-file-contents-literally remote-local)
+                             (buffer-string))
+                           "old binary"))
+            (should-not (file-exists-p remote-tmp)))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-method-table-matches-dispatcher ()
+  "README's RPC table documents exactly the dispatcher's public methods."
+  :tags '(:deploy)
+  (let (dispatcher documented)
+    (with-temp-buffer
+      (insert-file-contents
+       (expand-file-name "server/src/handlers/mod.rs" tramp-rpc-mock-test--project-root))
+      (re-search-forward "async fn dispatch_inner" nil t)
+      (let ((start (point))
+            (end (progn (re-search-forward "^    match result {" nil t)
+                        (match-beginning 0))))
+        (goto-char start)
+        (while (re-search-forward "\\\"\\([[:alnum:]_.]+\\)\\\" =>" end t)
+          (push (match-string 1) dispatcher))))
+    (push "batch" dispatcher)
+    (with-temp-buffer
+      (insert-file-contents (expand-file-name "README.org" tramp-rpc-mock-test--project-root))
+      (re-search-forward "^\\*\\* RPC Server Methods$" nil t)
+      (let ((start (point))
+            (end (or (and (re-search-forward "^\\* " nil t) (match-beginning 0))
+                     (point-max))))
+        (goto-char start)
+        (while (re-search-forward "~\\([[:alnum:]_.]+\\)~" end t)
+          (push (match-string 1) documented))))
+    (should (equal (sort (delete-dups dispatcher) #'string<)
+                   (sort (delete-dups documented) #'string<)))))
+
 ;; With latest tramp, tramp-file-name-with-sudo natively produces
 ;; /rpc:user@host|sudo:root@host:/path for rpc paths since the rpc
 ;; method is now multi-hop capable (inherits ssh connection params).


### PR DESCRIPTION
## Summary

Require verified checksums and source-cache digests, activate binaries atomically, and remove proven dead or duplicate helpers.

## Stack

Part **9 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/08-pty-io`
- Next PRs build on `remediation/09-deployment-cleanup`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded RPC method documentation with categorized descriptions for available operations.
  * Improved deployment security through checksum validation, verified archives, trusted cache provenance, and safe atomic activation.
  * Source changes are detected more reliably, including when file size and timestamps are unchanged.

* **Bug Fixes**
  * Improved remote binary transfer validation and protection against unsafe files and extraction results.
  * Removed outdated RPC methods from the technical comparison documentation.

* **Tests**
  * Added comprehensive coverage for secure extraction, cache validation, source builds, activation races, and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->