### PR TITLE
[10/11] Finalize batch and request lifecycle handling

### DIFF
--- a/README.org
+++ b/README.org
@@ -216,7 +216,7 @@ The dispatcher exposes these public methods:
 
 | Category | Method | Description |
 |----------+--------+-------------|
-| Batch | ~batch~ | Execute multiple requests concurrently. |
+| Batch | ~batch~ | Execute up to 64 requests with bounded concurrency. |
 | File | ~file.stat~ | Return file metadata. |
 | File | ~file.truename~ | Resolve a file's canonical path. |
 | Directory | ~dir.list~ | List directory entries, optionally with attributes. |

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -189,9 +189,8 @@ and how shell commands are run during deployment.
 
 Recommended methods:
   \"scp\"   - Uses the scp protocol for file transfer (out-of-band).
-             Shell commands use a separate SSH session.  This is the
-             default and most reliable option for transferring large
-             binaries.
+             Shell commands use a separate SSH session.  This is a
+             reliable option for transferring large binaries.
   \"rsync\" - Uses rsync for file transfer (out-of-band).  Requires
              rsync to be installed on both local and remote hosts.
              Efficient for repeated deployments due to delta transfer.
@@ -202,7 +201,8 @@ Legacy methods (use inline encoding for file transfer):
              to PTY input buffer size limits.
   \"ssh\"   - Similar to sshx but with PTY allocation.  Same inline
              encoding limitations apply.
-  \"scpx\"  - Like scp but uses a PTY for the shell session."
+  \"scpx\"  - Like scp but uses a PTY for the shell session; this is the
+             default."
   :type '(choice (const :tag "SCP - out-of-band transfer (recommended)" "scp")
                  (const :tag "rsync - out-of-band transfer (requires rsync)" "rsync")
                  (const :tag "sshx - inline encoding (legacy)" "sshx")

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -635,6 +635,11 @@ using the current `tab-width' instead."
   :type 'boolean
   :group 'tramp-rpc)
 
+(defconst tramp-rpc-magit--metadata-batch-size 64
+  "Maximum metadata requests sent in one RPC batch.
+The server rejects batches larger than 64 entries, so status prefetches for
+large worktrees must be split without losing item/result ordering.")
+
 (defvar tramp-rpc-magit--ancestors-cache nil
   "Cached ancestor scan data from server-side RPC.
 This is populated by `tramp-rpc-magit--prefetch' for file existence checks.")
@@ -1087,16 +1092,26 @@ whitespace."
           (push (cons "file.truename" (tramp-rpc--encode-path local-file))
                 requests))))
     (when requests
-      (let ((results (tramp-rpc--call-batch vec (nreverse requests))))
-        (cl-mapc
-         (lambda (item result)
-           (unless (and (consp result) (plist-get result :error))
-             (pcase (car item)
-               ('stat (tramp-rpc-magit--cache-file-stat vec (cadr item) result))
-               ('truename (tramp-rpc-magit--cache-file-truename
-                           vec (cadr item) result)))))
-         (nreverse items)
-         results)))))
+      (setq items (nreverse items)
+            requests (nreverse requests))
+      (while requests
+        (let (batch-items batch-requests)
+          (dotimes (_ tramp-rpc-magit--metadata-batch-size)
+            (when requests
+              (push (pop items) batch-items)
+              (push (pop requests) batch-requests)))
+          (setq batch-items (nreverse batch-items)
+                batch-requests (nreverse batch-requests))
+          (cl-mapc
+           (lambda (item result)
+             (unless (and (consp result) (plist-get result :error))
+               (pcase (car item)
+                 ('stat (tramp-rpc-magit--cache-file-stat
+                         vec (cadr item) result))
+                 ('truename (tramp-rpc-magit--cache-file-truename
+                             vec (cadr item) result)))))
+           batch-items
+           (tramp-rpc--call-batch vec batch-requests)))))))
 
 (defun tramp-rpc-magit--prefetch-dynamic-status (vec directory root-local)
   "Prefetch status data that depends on initial git output.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1243,6 +1243,31 @@ Also clears the executable, exec-path, and login-shell caches."
     (process-put process :tramp-rpc-pending-ids
                  (delete id (process-get process :tramp-rpc-pending-ids)))))
 
+(defun tramp-rpc--maybe-clear-pending-response-state (process buffer)
+  "Discard BUFFER's pending-response table when PROCESS has no requests."
+  (when (and (processp process)
+             (null (process-get process :tramp-rpc-pending-ids)))
+    (remhash buffer tramp-rpc--pending-responses)))
+
+(defun tramp-rpc--release-pending-requests (process buffer ids)
+  "Untrack IDS on PROCESS and remove their buffered responses from BUFFER.
+This is idempotent so it can run from every synchronous wait exit path."
+  (dolist (id ids)
+    (tramp-rpc--untrack-pending-request process id)
+    (when-let* ((pending (gethash buffer tramp-rpc--pending-responses)))
+      (remhash id pending)))
+  (tramp-rpc--maybe-clear-pending-response-state process buffer))
+
+(defmacro tramp-rpc--with-pending-requests (spec &rest body)
+  "Run BODY, releasing unresolved request IDS on every exit."
+  (declare (indent 1) (debug t))
+  (let ((process (nth 0 spec))
+        (buffer (nth 1 spec))
+        (ids (nth 2 spec)))
+    `(unwind-protect
+         (progn ,@body)
+       (tramp-rpc--release-pending-requests ,process ,buffer ,ids))))
+
 (defun tramp-rpc--cleanup-connection-generation
     (process vec event reason &optional remote-cleanup)
   "Clean up one PROCESS generation for VEC.
@@ -1307,7 +1332,9 @@ local relay deletion when PROCESS is still live."
           (error
            (tramp-rpc--debug "transport cleanup callback failed: %S"
                              callback-error))))
-      (process-put process :tramp-rpc-pending-ids nil)
+      ;; Keep injected errors and the request IDs until active waiters consume
+      ;; them.  Their unwind-protect cleanup removes the generation state.
+      (tramp-rpc--maybe-clear-pending-response-state process generation-buffer)
       ;; Explicit disconnect owns transport deletion; unexpected death is
       ;; already dispatched by Emacs and this is harmlessly idempotent.
       (when (and remote-cleanup (process-live-p process))
@@ -1317,17 +1344,6 @@ local relay deletion when PROCESS is still live."
   "Clean up unexpected death of PROCESS generation for VEC."
   (tramp-rpc--cleanup-connection-generation
    process vec event :transport-death nil))
-
-(defun tramp-rpc--remove-connection-requests (process)
-  "Remove asynchronous request callbacks belonging to PROCESS."
-  (let (ids)
-    (maphash (lambda (id callback-process)
-               (when (eq callback-process process)
-                 (push id ids)))
-             tramp-rpc--async-callback-processes)
-    (dolist (id ids)
-      (remhash id tramp-rpc--async-callbacks)
-      (remhash id tramp-rpc--async-callback-processes))))
 
 (defun tramp-rpc--install-connection-sentinel (process vec)
   "Install the transport sentinel on PROCESS for VEC's generation."
@@ -1870,18 +1886,33 @@ Uses length-prefixed binary framing: <4-byte BE length><msgpack payload>."
                  process
                  (plist-get response :method)
                  (plist-get response :params))
-              ;; Handle normal response
-              (let* ((id (plist-get response :id))
-                     (callback (gethash id tramp-rpc--async-callbacks)))
-                (if callback
-                    (progn
-                      (tramp-rpc--debug "FILTER dispatching async id=%s" id)
-                      (remhash id tramp-rpc--async-callbacks)
-                      (remhash id tramp-rpc--async-callback-processes)
-                      (funcall callback response))
-                  ;; Not an async response - store for sync code
-                  (tramp-rpc--debug "FILTER storing sync response id=%s" id)
-                  (puthash id response (tramp-rpc--get-pending-responses buffer)))))))))))
+              ;; A cleaned generation may still receive buffered output.  Its
+              ;; injected transport-death errors belong to live waiters and
+              ;; must not be overwritten by those late normal responses.
+              (unless (or (process-get process :tramp-rpc-transport-cleaned)
+                          (process-get process :tramp-rpc-transport-dead))
+                (let* ((id (plist-get response :id))
+                       (callback (gethash id tramp-rpc--async-callbacks)))
+                  (if callback
+                      (progn
+                        (tramp-rpc--debug "FILTER dispatching async id=%s" id)
+                        (remhash id tramp-rpc--async-callbacks)
+                        (remhash id tramp-rpc--async-callback-processes)
+                        (condition-case callback-error
+                            (funcall callback response)
+                          (error
+                           ;; One client callback must not strand complete
+                           ;; responses already buffered behind its frame.
+                           (tramp-rpc--debug
+                            "async response callback failed for id=%s: %S"
+                            id callback-error))))
+                    ;; Store only responses for this transport's live waiters.
+                    ;; Late responses from an abandoned generation are discarded.
+                    (when (member id (process-get process :tramp-rpc-pending-ids))
+                      (tramp-rpc--debug "FILTER storing sync response id=%s" id)
+                      (puthash id response
+                               (tramp-rpc--get-pending-responses
+                                (process-buffer process))))))))))))))
 
 (defun tramp-rpc--call-async (vec method params callback &optional connection)
   "Call METHOD with PARAMS asynchronously on the RPC server for VEC.
@@ -1915,15 +1946,17 @@ Returns the result or signals an error.
 Uses 5s total timeout with 10ms polling."
   (tramp-rpc--call-with-timeout vec method params 5 0.01))
 
-(defun tramp-rpc--find-response-by-id (expected-id)
+(defun tramp-rpc--find-response-by-id (expected-id &optional process)
   "Check pending responses for EXPECTED-ID.
-Returns the response plist if found and removes it from pending, nil otherwise."
-  (let* ((pending (tramp-rpc--get-pending-responses (current-buffer)))
-         (response (gethash expected-id pending)))
+Returns the response plist if found and removes it from pending, nil otherwise.
+PROCESS identifies the transport generation owning the request."
+  (let* ((buffer (current-buffer))
+         (owner-process (or process (get-buffer-process buffer)))
+         (pending (gethash buffer tramp-rpc--pending-responses))
+         (response (and pending (gethash expected-id pending))))
     (when response
-      (remhash expected-id pending)
-      (tramp-rpc--untrack-pending-request
-       (get-buffer-process (current-buffer)) expected-id)
+      (tramp-rpc--release-pending-requests
+       owner-process buffer (list expected-id))
       response)))
 
 (defun tramp-rpc--process-accessible-p (process)
@@ -1974,10 +2007,11 @@ Returns the result or signals an error."
     (tramp-rpc--debug "SEND id=%s method=%s" expected-id method)
     (tramp-rpc--track-pending-request process expected-id)
 
-    ;; Send request (binary data with length prefix, no newline)
-    (process-send-string process request)
+    (tramp-rpc--with-pending-requests (process buffer (list expected-id))
+      ;; Send request (binary data with length prefix, no newline)
+      (process-send-string process request)
 
-    ;; Wait for response with matching ID using wall-clock deadline.
+      ;; Wait for response with matching ID using wall-clock deadline.
     ;; NOTE: We use (float-time) instead of decrementing a counter because
     ;; accept-process-output can return early (e.g. async process output
     ;; arrives), and decrementing by poll-interval each iteration would
@@ -1986,6 +2020,8 @@ Returns the result or signals an error."
       (let ((start-time (float-time))
             (deadline (+ (float-time) total-timeout))
             response)
+        ;; A transport sentinel may have injected an error before the loop.
+        (setq response (tramp-rpc--find-response-by-id expected-id process))
         ;; Wait for a response with the correct ID
         (while (and (not response)
                     (< (float-time) deadline)
@@ -2002,7 +2038,7 @@ Returns the result or signals an error."
                   ;; Sleep briefly - other thread may receive our response
                   (sleep-for poll-interval)
                   ;; Check if other thread already got our response
-                  (setq response (tramp-rpc--find-response-by-id expected-id))))
+                  (setq response (tramp-rpc--find-response-by-id expected-id process))))
             ;; Process is accessible - proceed with accept-process-output
             ;; Use same pattern as tramp-accept-process-output:
             ;; - poll-interval timeout to avoid spinning
@@ -2021,7 +2057,7 @@ Returns the result or signals an error."
                     (tramp-rpc--drain-connection-stderr conn)
                     t))
                 ;; Check if our response arrived in pending responses
-                (setq response (tramp-rpc--find-response-by-id expected-id))
+                (setq response (tramp-rpc--find-response-by-id expected-id process))
               ;; User quit - propagate it
               (tramp-rpc--debug "QUIT id=%s (user interrupted)" expected-id)
               (keyboard-quit))))
@@ -2056,7 +2092,7 @@ Returns the result or signals an error."
               (tramp-rpc--debug "ERROR id=%s code=%s msg=%s errno=%s"
                                expected-id code msg os-errno)
               (tramp-rpc--signal-rpc-error "RPC" msg code os-errno nil data))
-          (plist-get response :result))))))
+          (plist-get response :result)))))))
 
 (defun tramp-rpc--call-batch (vec requests)
   "Execute multiple RPC REQUESTS in a single round-trip for VEC.
@@ -2085,14 +2121,17 @@ Returns:
     (tramp-rpc--debug "SEND-BATCH id=%s count=%d" expected-id (length requests))
     (tramp-rpc--track-pending-request process expected-id)
 
-    ;; Send batch request (binary data with length prefix, no newline)
-    (process-send-string process request)
+    (tramp-rpc--with-pending-requests (process buffer (list expected-id))
+      ;; Send batch request (binary data with length prefix, no newline)
+      (process-send-string process request)
 
-    ;; Wait for response with matching ID using wall-clock deadline
+      ;; Wait for response with matching ID using wall-clock deadline
     (with-current-buffer buffer
       (let ((start-time (float-time))
             (deadline (+ (float-time) 30))
             response)
+        ;; A transport sentinel may have injected an error before the loop.
+        (setq response (tramp-rpc--find-response-by-id expected-id process))
         (while (and (not response)
                     (< (float-time) deadline)
                     (process-live-p process))
@@ -2106,7 +2145,7 @@ Returns:
                 ;; Sleep briefly - other thread may receive our response
                 (sleep-for 0.1)
                 ;; Check if other thread already got our response
-                (setq response (tramp-rpc--find-response-by-id expected-id)))
+                (setq response (tramp-rpc--find-response-by-id expected-id process)))
             ;; Process is accessible
             (if (with-tramp-suspended-timers
                   (with-local-quit
@@ -2115,7 +2154,7 @@ Returns:
                     (tramp-rpc--drain-connection-stderr conn)
                     t))
                 ;; Check if our response arrived in pending responses
-                (setq response (tramp-rpc--find-response-by-id expected-id))
+                (setq response (tramp-rpc--find-response-by-id expected-id process))
               (tramp-rpc--debug "QUIT-BATCH id=%s (user interrupted)" expected-id)
               (keyboard-quit))))
 
@@ -2149,45 +2188,61 @@ Returns:
 	       'remote-file-error
 	       (list "Batch RPC error"
                      (tramp-rpc-protocol-error-message response))))
-          (tramp-rpc-protocol-decode-batch-response response))))))
+          (tramp-rpc-protocol-decode-batch-response response)))))))
 
 ;; ============================================================================
 ;; Request pipelining support
 ;; ============================================================================
 
-(defun tramp-rpc--send-requests (vec requests)
+(defun tramp-rpc--send-requests (vec requests &optional connection)
   "Send multiple REQUESTS to the RPC server for VEC without waiting.
 REQUESTS is a list of (METHOD . PARAMS) cons cells.
+CONNECTION, when non-nil, is the captured connection generation to use.
 Returns a list of request IDs in the same order."
-  (let* ((conn (tramp-rpc--ensure-connection vec))
+  (let* ((conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (plist-get conn :process))
-         ids)
-    (dolist (req requests)
-      (let* ((id-and-bytes (let ((tramp-rpc-protocol--message-target process))
-                             (tramp-rpc-protocol-encode-request-with-id
-                              (car req) (cdr req))))
-             (id (car id-and-bytes))
-             (bytes (cdr id-and-bytes)))
-        (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
-        (push id ids)
-        (tramp-rpc--track-pending-request process id)
-        ;; Send binary data with length prefix, no newline
-        (process-send-string process bytes)))
-    (nreverse ids)))
+         (buffer (plist-get conn :buffer))
+         ids completed)
+    (unwind-protect
+        (progn
+          (dolist (req requests)
+            (let* ((id-and-bytes (let ((tramp-rpc-protocol--message-target process))
+                                   (tramp-rpc-protocol-encode-request-with-id
+                                    (car req) (cdr req))))
+                   (id (car id-and-bytes))
+                   (bytes (cdr id-and-bytes)))
+              (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
+              (push id ids)
+              (tramp-rpc--track-pending-request process id)
+              ;; Send binary data with length prefix, no newline
+              (process-send-string process bytes)))
+          (setq completed t)
+          (nreverse ids))
+      (unless completed
+        (tramp-rpc--release-pending-requests process buffer ids)))))
 
-(defun tramp-rpc--receive-responses (vec ids &optional timeout)
+(defun tramp-rpc--receive-responses (vec ids &optional timeout connection)
   "Receive responses for request IDS from the RPC server for VEC.
 Returns an alist mapping each ID to its response plist.
-TIMEOUT is the maximum time to wait in seconds (default 30)."
-  (let* ((conn (tramp-rpc--ensure-connection vec))
+TIMEOUT is the maximum time to wait in seconds (default 30).
+CONNECTION, when non-nil, is the captured connection generation to use."
+  (let* ((conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
          (deadline (+ (float-time) (or timeout 30)))
          (remaining-ids (copy-sequence ids))
          (responses (make-hash-table :test 'eql)))
     (tramp-rpc--debug "RECV-PIPE waiting for %d responses: %S" (length ids) ids)
-    (with-current-buffer buffer
-      (while (and remaining-ids
+    (unwind-protect
+        (progn
+          (with-current-buffer buffer
+            ;; Consume transport-death errors before checking process status.
+            (dolist (id remaining-ids)
+              (let ((response (tramp-rpc--find-response-by-id id process)))
+                (when response
+                  (puthash id response responses)
+                  (setq remaining-ids (delete id remaining-ids)))))
+            (while (and remaining-ids
                   (< (float-time) deadline)
                   (process-live-p process))
         ;; Check if process is locked to another thread before trying to accept
@@ -2201,7 +2256,7 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
               (sleep-for 0.1)
               ;; Check if other thread already got any of our responses
               (dolist (id remaining-ids)
-                (let ((response (tramp-rpc--find-response-by-id id)))
+                (let ((response (tramp-rpc--find-response-by-id id process)))
                   (when response
                     (tramp-rpc--debug "RECV-PIPE found id=%s (after sleep)" id)
                     (puthash id response responses)
@@ -2215,7 +2270,7 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
                   t))
               ;; Check for each remaining ID in pending responses
               (dolist (id remaining-ids)
-                (let ((response (tramp-rpc--find-response-by-id id)))
+                (let ((response (tramp-rpc--find-response-by-id id process)))
                   (when response
                     (tramp-rpc--debug "RECV-PIPE found id=%s" id)
                     ;; Store response by ID
@@ -2223,20 +2278,21 @@ TIMEOUT is the maximum time to wait in seconds (default 30)."
                     ;; Remove from remaining
                     (setq remaining-ids (delete id remaining-ids)))))
             (tramp-rpc--debug "RECV-PIPE quit (user interrupted)")
-            (keyboard-quit)))))
-    (when remaining-ids
-      (tramp-rpc--debug "RECV-PIPE missing ids: %S" remaining-ids)
-      (signal
-       'remote-file-error
-       (list (if (process-live-p process)
-                 (format "Timeout waiting for pipelined RPC responses from %s (missing ids: %S)"
-                         (tramp-file-name-host vec) remaining-ids)
-               (format "RPC process died waiting for pipelined responses from %s (missing ids: %S)"
-                       (tramp-file-name-host vec) remaining-ids)))))
-    ;; Convert hash table to alist in original order
-    (mapcar (lambda (id)
-              (cons id (gethash id responses)))
-            ids)))
+              (keyboard-quit)))))
+          (when remaining-ids
+            (tramp-rpc--debug "RECV-PIPE missing ids: %S" remaining-ids)
+            (signal
+             'remote-file-error
+             (list (if (process-live-p process)
+                       (format "Timeout waiting for pipelined RPC responses from %s (missing ids: %S)"
+                               (tramp-file-name-host vec) remaining-ids)
+                     (format "RPC process died waiting for pipelined responses from %s (missing ids: %S)"
+                             (tramp-file-name-host vec) remaining-ids)))))
+          ;; Convert hash table to alist in original order
+          (mapcar (lambda (id)
+                    (cons id (gethash id responses)))
+                  ids))
+      (tramp-rpc--release-pending-requests process buffer ids))))
 
 (defun tramp-rpc--call-pipelined (vec requests)
   "Execute multiple REQUESTS in a pipelined fashion for VEC.
@@ -2247,8 +2303,9 @@ Each result is either the actual result or an error plist.
 Unlike `tramp-rpc--call-batch', this sends each request as a separate
 RPC call, allowing the server to process them concurrently.
 This is more efficient when the server has async support."
-  (let* ((ids (tramp-rpc--send-requests vec requests))
-         (responses (tramp-rpc--receive-responses vec ids)))
+  (let* ((connection (tramp-rpc--ensure-connection vec))
+         (ids (tramp-rpc--send-requests vec requests connection))
+         (responses (tramp-rpc--receive-responses vec ids nil connection)))
     ;; Process responses in order and extract results
     (mapcar (lambda (id-response)
               (let ((response (cdr id-response)))

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -8,16 +8,22 @@ pub mod process;
 
 use crate::msgpack_map;
 use crate::protocol::{Request, RequestId, Response, RpcError, from_value};
+use futures::{StreamExt, TryStreamExt};
 use rmpv::Value;
 
 /// Dispatch a request to the appropriate handler
 pub async fn dispatch(request: Request) -> Response {
     // Handle batch separately (it needs special handling and can't recurse)
     if request.method == "batch" {
-        let result = batch_execute(request.params.clone()).await;
-        return match result {
-            Ok(value) => Response::success(request.id.clone(), value),
-            Err(error) => Response::error(Some(request.id.clone()), error),
+        let id = request.id.clone();
+        let result = batch_execute(request.params).await;
+        let response = match result {
+            Ok(value) => Response::success(id.clone(), value),
+            Err(error) => Response::error(Some(id.clone()), error),
+        };
+        return match validate_batch_response_size(&response, crate::MAX_FRAME_SIZE) {
+            Ok(()) => response,
+            Err(error) => Response::error(Some(id), error),
         };
     }
 
@@ -93,6 +99,21 @@ fn login_shell() -> Option<String> {
 }
 
 use crate::protocol::IntoValue;
+
+/// Maximum entries accepted by one batch request.  This remains well above
+/// the existing 10-stat benchmark while bounding per-request work.
+const MAX_BATCH_ENTRIES: usize = 64;
+/// Keep nested batch work below the global general-request admission limit.
+pub(crate) const BATCH_CONCURRENCY: usize = 4;
+
+fn bounded_batch_futures<F>(
+    futures: impl IntoIterator<Item = F>,
+) -> impl futures::Stream<Item = F::Output>
+where
+    F: std::future::Future,
+{
+    futures::stream::iter(futures).buffered(BATCH_CONCURRENCY)
+}
 
 fn hostname() -> String {
     let mut buf = [0u8; 256];
@@ -260,6 +281,23 @@ pub(crate) fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+fn validate_batch_response_size(
+    response: &Response,
+    max_frame_size: usize,
+) -> Result<(), RpcError> {
+    let encoded_size = rmp_serde::to_vec_named(response)
+        .map_err(|error| {
+            RpcError::internal_error(format!("Failed to encode batch response: {error}"))
+        })?
+        .len();
+    if encoded_size > max_frame_size {
+        return Err(RpcError::internal_error(
+            "Batch response exceeds maximum frame size",
+        ));
+    }
+    Ok(())
+}
+
 /// Execute multiple RPC requests in a single batch
 async fn batch_execute(params: Value) -> HandlerResult {
     #[derive(serde::Deserialize)]
@@ -280,51 +318,71 @@ async fn batch_execute(params: Value) -> HandlerResult {
 
     let batch_params: BatchParams =
         from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    if batch_params.requests.len() > MAX_BATCH_ENTRIES {
+        return Err(RpcError::invalid_params(format!(
+            "batch requests cannot exceed {MAX_BATCH_ENTRIES} entries"
+        )));
+    }
 
-    // Execute all requests concurrently using tokio::join_all
-    let futures: Vec<_> = batch_params
-        .requests
-        .into_iter()
-        .map(|req| async move {
-            // Create a fake Request to reuse dispatch logic
-            let fake_request = Request {
-                version: "2.0".to_string(),
-                id: RequestId::Number(0), // Dummy ID, not used in batch
-                method: req.method,
-                params: req.params,
-            };
+    let results = bounded_batch_futures(batch_params.requests.into_iter().map(|req| async move {
+        // Create a fake Request to reuse dispatch logic.
+        let fake_request = Request {
+            version: "2.0".to_string(),
+            id: RequestId::Number(0), // Dummy ID, not used in batch
+            method: req.method,
+            params: req.params,
+        };
 
-            // Get the result by calling the handler directly (not full dispatch)
-            let response = dispatch_inner(fake_request).await;
+        // Get the result by calling the handler directly (not full dispatch).
+        let response = dispatch_inner(fake_request).await;
 
-            // Convert Response to a result object
-            match (response.result, response.error) {
-                (Some(result), None) => msgpack_map! { "result" => result },
-                (None, Some(error)) => {
-                    let mut error_fields = vec![
-                        (
-                            Value::String("code".into()),
-                            Value::Integer(error.code.into()),
-                        ),
-                        (
-                            Value::String("message".into()),
-                            Value::String(error.message.into()),
-                        ),
-                    ];
-                    if let Some(data) = error.data {
-                        error_fields.push((Value::String("data".into()), data));
-                    }
-                    msgpack_map! {
-                        "error" => Value::Map(error_fields)
-                    }
+        // Convert Response to a result object.
+        let result = match (response.result, response.error) {
+            (Some(result), None) => msgpack_map! { "result" => result },
+            (None, Some(error)) => {
+                let mut error_fields = vec![
+                    (
+                        Value::String("code".into()),
+                        Value::Integer(error.code.into()),
+                    ),
+                    (
+                        Value::String("message".into()),
+                        Value::String(error.message.into()),
+                    ),
+                ];
+                if let Some(data) = error.data {
+                    error_fields.push((Value::String("data".into()), data));
                 }
-                _ => msgpack_map! { "result" => Value::Nil },
+                msgpack_map! {
+                    "error" => Value::Map(error_fields)
+                }
             }
-        })
-        .collect();
-
-    // Run all batch requests concurrently
-    let results = futures::future::join_all(futures).await;
+            _ => msgpack_map! { "result" => Value::Nil },
+        };
+        Ok::<Value, RpcError>(result)
+    }))
+    .try_fold(
+        (Vec::new(), 0usize),
+        |(mut results, size), result| async move {
+            let result_size = rmp_serde::to_vec_named(&result)
+                .map_err(|error| {
+                    RpcError::internal_error(format!("Failed to encode batch entry: {error}"))
+                })?
+                .len();
+            let size = size
+                .checked_add(result_size)
+                .ok_or_else(|| RpcError::internal_error("Batch response size overflow"))?;
+            if size > crate::MAX_FRAME_SIZE {
+                return Err(RpcError::internal_error(
+                    "Batch response exceeds maximum frame size",
+                ));
+            }
+            results.push(result);
+            Ok((results, size))
+        },
+    )
+    .await
+    .map(|(results, _)| results)?;
 
     Ok(msgpack_map! { "results" => Value::Array(results) })
 }
@@ -450,7 +508,144 @@ mod tests {
     }
 
     use crate::msgpack_map;
+    use futures::StreamExt;
     use std::os::unix::ffi::OsStrExt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::{Barrier, Semaphore};
+
+    #[tokio::test]
+    async fn batch_accepts_max_entries_in_order() {
+        let result = batch_execute(msgpack_map! {
+            "requests" => Value::Array(
+                (0..MAX_BATCH_ENTRIES)
+                    .map(|index| msgpack_map! {
+                        "method" => "system.expand_path",
+                        "params" => msgpack_map! {
+                            "path" => format!("/batch-order-{index}"),
+                        },
+                    })
+                    .collect(),
+            ),
+        })
+        .await
+        .expect("maximum-sized batch should be accepted");
+
+        let results = result
+            .as_map()
+            .and_then(|map| map.iter().find(|(key, _)| key.as_str() == Some("results")))
+            .and_then(|(_, value)| value.as_array())
+            .expect("results array");
+        assert_eq!(results.len(), MAX_BATCH_ENTRIES);
+        for (index, entry) in results.iter().enumerate() {
+            let value = entry
+                .as_map()
+                .and_then(|map| map.iter().find(|(key, _)| key.as_str() == Some("result")))
+                .and_then(|(_, value)| value.as_str())
+                .expect("ordered batch result");
+            assert_eq!(value, format!("/batch-order-{index}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_executor_limits_in_flight_subrequests() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let ready = Arc::new(Barrier::new(BATCH_CONCURRENCY + 1));
+        let release = Arc::new(Semaphore::new(0));
+        let total = BATCH_CONCURRENCY * 2;
+        let worker_active = Arc::clone(&active);
+        let worker_peak = Arc::clone(&peak);
+        let worker_ready = Arc::clone(&ready);
+        let worker_release = Arc::clone(&release);
+        let futures = (0..total).map(move |index| {
+            let active = Arc::clone(&worker_active);
+            let peak = Arc::clone(&worker_peak);
+            let ready = Arc::clone(&worker_ready);
+            let release = Arc::clone(&worker_release);
+            async move {
+                let in_flight = active.fetch_add(1, Ordering::AcqRel) + 1;
+                peak.fetch_max(in_flight, Ordering::AcqRel);
+                if index < BATCH_CONCURRENCY {
+                    ready.wait().await;
+                }
+                let _permit = release.acquire().await.expect("release semaphore is open");
+                active.fetch_sub(1, Ordering::AcqRel);
+                index
+            }
+        });
+        let executor =
+            tokio::spawn(async move { bounded_batch_futures(futures).collect::<Vec<_>>().await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), ready.wait())
+            .await
+            .expect("executor should reach the configured concurrency");
+        assert_eq!(active.load(Ordering::Acquire), BATCH_CONCURRENCY);
+        assert!(peak.load(Ordering::Acquire) <= BATCH_CONCURRENCY);
+        assert_eq!(peak.load(Ordering::Acquire), BATCH_CONCURRENCY);
+
+        release.add_permits(total);
+        assert_eq!(
+            executor
+                .await
+                .expect("bounded executor task should complete"),
+            (0..total).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_rejects_too_many_entries_and_keeps_nested_non_recursive() {
+        let too_many = batch_execute(msgpack_map! {
+            "requests" => Value::Array(
+                (0..=MAX_BATCH_ENTRIES)
+                    .map(|_| msgpack_map! { "method" => "system.info" })
+                    .collect(),
+            ),
+        })
+        .await
+        .expect_err("oversized batch should be rejected");
+        assert_eq!(too_many.code, RpcError::INVALID_PARAMS);
+
+        let nested = batch_execute(msgpack_map! {
+            "requests" => Value::Array(vec![msgpack_map! {
+                "method" => "batch",
+                "params" => msgpack_map! {
+                    "requests" => Value::Array(vec![msgpack_map! {
+                        "method" => "system.info",
+                    }]),
+                },
+            }]),
+        })
+        .await
+        .expect("nested batch should remain a bounded per-entry error");
+        let nested_error_code = nested
+            .as_map()
+            .and_then(|map| map.iter().find(|(key, _)| key.as_str() == Some("results")))
+            .and_then(|(_, value)| value.as_array())
+            .and_then(|results| results.first())
+            .and_then(Value::as_map)
+            .and_then(|entry| entry.iter().find(|(key, _)| key.as_str() == Some("error")))
+            .and_then(|(_, value)| value.as_map())
+            .and_then(|error| error.iter().find(|(key, _)| key.as_str() == Some("code")))
+            .and_then(|(_, value)| value.as_i64());
+        assert_eq!(
+            nested_error_code,
+            Some(i64::from(RpcError::METHOD_NOT_FOUND))
+        );
+
+        let result = msgpack_map! {
+            "results" => Value::Array(vec![Value::Binary(vec![0; 64])]),
+        };
+        let response = Response::success(RequestId::Number(99), result.clone());
+        let inner_size = rmp_serde::to_vec_named(&result).unwrap().len();
+        let frame_size = rmp_serde::to_vec_named(&response).unwrap().len();
+        assert!(frame_size > inner_size);
+        let frame_error = validate_batch_response_size(&response, inner_size)
+            .expect_err("response envelope must count toward the frame limit");
+        assert_eq!(frame_error.code, RpcError::INTERNAL_ERROR);
+        validate_batch_response_size(&response, frame_size)
+            .expect("a response exactly at the frame limit is legal");
+    }
 
     #[tokio::test]
     async fn batch_errors_preserve_data() {

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -1010,6 +1010,10 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
         if let Some(managed) = get_process_map().lock().await.get_mut(&pid) {
             managed.exit_status = Some(exit_status);
         }
+        if signal == libc::SIGKILL {
+            get_process_map().lock().await.remove(&pid);
+        }
+        return Ok(true);
     }
     if signal == libc::SIGKILL {
         // Explicit SIGKILL is the caller's opt-out from drain-preserving
@@ -1017,6 +1021,12 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
         // this call did; already in-flight reads retain the shared state.
         get_process_map().lock().await.remove(&pid);
     }
+
+    // Signal delivery is the success criterion, matching local
+    // `signal-process': a signal is a request, not a guarantee that the
+    // process exits within the bounded wait.  The entry stays reachable so
+    // the caller can escalate (e.g. retry with SIGKILL) and later reads
+    // still drain buffered output; the reap above is purely opportunistic.
     Ok(true)
 }
 
@@ -1951,12 +1961,19 @@ async fn terminate_pty_process(
         } else if let Some(managed) = processes.get_mut(&pid) {
             managed.exit_status = Some(exit_code);
         }
-    } else if remove {
-        // A missing wait status is still safe to discard: cancellation was
-        // published before removal and the child will not be reused by this
-        // server process while its descriptor remains owned by this request.
-        get_pty_process_map().lock().await.remove(&pid);
+        return Ok(true);
     }
+
+    if remove {
+        // Explicit close discards the PTY even if its status was already
+        // consumed by another status poll.
+        get_pty_process_map().lock().await.remove(&pid);
+        return Ok(true);
+    }
+
+    // As for pipe children: delivery is success; termination is not
+    // guaranteed within the bounded wait and the entry stays for escalation
+    // and draining.
     Ok(true)
 }
 
@@ -2777,12 +2794,14 @@ mod tests {
             .unwrap() as u32;
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
+        // Delivery is success even when the child ignores the signal,
+        // matching local `signal-process'; the entry stays for escalation.
         kill(Value::Map(vec![(
             Value::String("pid".into()),
             Value::Integer(pid.into()),
         )]))
         .await
-        .expect("SIGTERM");
+        .expect("ignored SIGTERM is still delivered successfully");
         assert!(get_process_map().lock().await.contains_key(&pid));
 
         let os_pid = pipe_os_pid(pid).await;
@@ -3056,6 +3075,45 @@ mod tests {
         }
         assert!(exited);
         assert_eq!(exit_code, Some(128 + libc::SIGTERM as i64));
+        assert!(!get_pty_process_map().lock().await.contains_key(&pid));
+    }
+
+    #[tokio::test]
+    async fn pty_kill_ignored_sigterm_then_sigkill_reaps_child() {
+        let _test_lock = test_process_map_lock().await;
+        let temp = tempfile::tempdir().expect("temporary PTY directory");
+        let marker = temp.path().join("ready");
+        let pid = start_signal_ignoring_pty(&marker).await;
+        let os_pid = pty_os_pid(pid).await;
+
+        // Delivery is success even when the child ignores the signal.
+        kill_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::Integer((libc::SIGTERM as i64).into()),
+            ),
+        ]))
+        .await
+        .expect("ignored SIGTERM is still delivered successfully");
+        assert!(get_pty_process_map().lock().await.contains_key(&pid));
+
+        kill_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::Integer((libc::SIGKILL as i64).into()),
+            ),
+        ]))
+        .await
+        .expect("SIGKILL should terminate and reap the PTY child");
+        assert_reaped(os_pid);
+        close_pty(Value::Map(vec![(
+            Value::String("pid".into()),
+            Value::Integer(pid.into()),
+        )]))
+        .await
+        .expect("close PTY after SIGKILL");
         assert!(!get_pty_process_map().lock().await.contains_key(&pid));
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -38,6 +38,12 @@ const DEFERRED_REQUEST_LIMIT: usize = 64;
 const ERROR_RESPONSE_CHANNEL_SIZE: usize = 16;
 const EOF_TASK_JOIN_WAIT: std::time::Duration = std::time::Duration::from_millis(500);
 
+#[cfg(test)]
+struct CleanupBarrier {
+    first_pass_complete: tokio::sync::Notify,
+    continue_cleanup: tokio::sync::Notify,
+}
+
 /// Shared handle to the stdout writer, used by both response writing
 /// and the watcher's notification sending.
 pub type WriterHandle = Arc<Mutex<BufWriter<tokio::io::Stdout>>>;
@@ -94,7 +100,7 @@ async fn read_frames<R>(
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TaskClass {
     General,
     Control,
@@ -108,13 +114,27 @@ struct Admissions {
 }
 
 impl Admissions {
+    #[cfg(test)]
     fn try_acquire(&self, class: TaskClass) -> Option<OwnedSemaphorePermit> {
-        let semaphore = match class {
+        self.try_acquire_many(class, 1)
+    }
+
+    fn semaphore(&self, class: TaskClass) -> &Arc<Semaphore> {
+        match class {
             TaskClass::General => &self.general,
             TaskClass::Control => &self.control,
             TaskClass::PtyWrite => &self.pty_write,
-        };
-        Arc::clone(semaphore).try_acquire_owned().ok()
+        }
+    }
+
+    fn available_permits(&self, class: TaskClass) -> usize {
+        self.semaphore(class).available_permits()
+    }
+
+    fn try_acquire_many(&self, class: TaskClass, permits: usize) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(self.semaphore(class))
+            .try_acquire_many_owned(u32::try_from(permits).ok()?)
+            .ok()
     }
 }
 
@@ -140,6 +160,14 @@ fn task_class(method: &str) -> TaskClass {
         // lifecycle operations retain their separately reserved control slots.
         "process.write_pty" => TaskClass::PtyWrite,
         _ => TaskClass::General,
+    }
+}
+
+fn request_permit_count(method: &str) -> usize {
+    if method == "batch" {
+        handlers::BATCH_CONCURRENCY
+    } else {
+        1
     }
 }
 
@@ -189,8 +217,11 @@ fn spawn_request<W>(
     });
 }
 
-async fn run_connection<R, W>(reader: R, writer: Arc<Mutex<W>>)
-where
+async fn run_connection<R, W>(
+    reader: R,
+    writer: Arc<Mutex<W>>,
+    #[cfg(test)] cleanup_barrier: Option<Arc<CleanupBarrier>>,
+) where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
@@ -213,9 +244,16 @@ where
     let mut tasks: JoinSet<()> = JoinSet::new();
     let admissions = Admissions::default();
     let mut deferred: VecDeque<Request> = VecDeque::new();
+    let mut general_bypass_budget = None;
 
     loop {
-        start_admissible(&mut deferred, &mut tasks, &writer, &admissions);
+        start_admissible(
+            &mut deferred,
+            &mut tasks,
+            &writer,
+            &admissions,
+            &mut general_bypass_budget,
+        );
         // Stop pulling frames while the backlog is full.  The bounded frame
         // channel then stops draining the pipe, which is the throttle the
         // client can actually observe.
@@ -259,34 +297,109 @@ where
     // children before joining request tasks: a task blocked on their pipes or
     // a descendant-held descriptor must not prevent SIGKILL escalation.
     handlers::cleanup_managed_processes().await;
-    let _ = tokio::time::timeout(EOF_TASK_JOIN_WAIT, async {
-        while tasks.join_next().await.is_some() {}
-    })
-    .await;
+    drain_tasks_for(&mut tasks, EOF_TASK_JOIN_WAIT).await;
     tasks.abort_all();
+    // `spawn_blocking` work cannot be cancelled once it has started.  Do not
+    // let such a task hold EOF teardown forever; the second managed-child
+    // cleanup below still catches registrations completed before this deadline.
+    drain_tasks_for(&mut tasks, EOF_TASK_JOIN_WAIT).await;
     frame_reader.abort();
+    // A request can register a child after the first map snapshot while its
+    // task is being joined or aborted.  The second pass closes that race.
+    #[cfg(test)]
+    if let Some(barrier) = cleanup_barrier {
+        barrier.first_pass_complete.notify_one();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            barrier.continue_cleanup.notified(),
+        )
+        .await
+        .expect("test should release the connection cleanup barrier");
+    }
+    handlers::cleanup_managed_processes().await;
     drop(errors);
     let _ = tokio::time::timeout(EOF_TASK_JOIN_WAIT, error_writer).await;
 }
 
+async fn drain_tasks_for(tasks: &mut JoinSet<()>, wait: std::time::Duration) {
+    let _ = tokio::time::timeout(wait, async { while tasks.join_next().await.is_some() {} }).await;
+}
+
 /// Start every queued request that currently fits in its class.
 ///
-/// Requests are kept in arrival order, but a class with free slots is never
-/// blocked by a queued request of a saturated class -- that is what keeps
-/// `process.kill' responsive behind a backlog of long-polling reads.
+/// Requests of different classes do not block one another.  Within the general
+/// class, a large request gets a bounded bypass budget equal to the permits
+/// that were idle when it first became blocked.  Those permits may serve
+/// already-arriving one-permit work once, but are then reserved as they return,
+/// preventing both head-of-line idling and indefinite batch starvation.
 fn start_admissible<W>(
     deferred: &mut VecDeque<Request>,
     tasks: &mut JoinSet<()>,
     writer: &Arc<Mutex<W>>,
     admissions: &Admissions,
+    general_bypass_budget: &mut Option<usize>,
 ) where
     W: AsyncWrite + Unpin + Send + 'static,
 {
     let mut still_deferred = VecDeque::with_capacity(deferred.len());
+    let mut general_waiting = false;
+    let mut control_blocked = false;
+    let mut pty_write_blocked = false;
     while let Some(request) = deferred.pop_front() {
-        match admissions.try_acquire(task_class(&request.method)) {
-            Some(permit) => spawn_request(tasks, request, permit, writer),
-            None => still_deferred.push_back(request),
+        let class = task_class(&request.method);
+        let permit_count = request_permit_count(&request.method);
+
+        if class == TaskClass::General && general_waiting {
+            let Some(budget) = general_bypass_budget.as_mut() else {
+                still_deferred.push_back(request);
+                continue;
+            };
+            if permit_count > *budget {
+                still_deferred.push_back(request);
+                continue;
+            }
+            if let Some(permit) = admissions.try_acquire_many(class, permit_count) {
+                *budget -= permit_count;
+                spawn_request(tasks, request, permit, writer);
+            } else {
+                still_deferred.push_back(request);
+            }
+            continue;
+        }
+
+        let blocked = match class {
+            TaskClass::General => false,
+            TaskClass::Control => control_blocked,
+            TaskClass::PtyWrite => pty_write_blocked,
+        };
+        if blocked {
+            still_deferred.push_back(request);
+            continue;
+        }
+
+        match admissions.try_acquire_many(class, permit_count) {
+            Some(permit) => {
+                if class == TaskClass::General && permit_count > 1 {
+                    *general_bypass_budget = None;
+                }
+                spawn_request(tasks, request, permit, writer);
+            }
+            None => {
+                if class == TaskClass::General && permit_count > 1 {
+                    if general_bypass_budget.is_none() {
+                        *general_bypass_budget =
+                            Some(admissions.available_permits(TaskClass::General));
+                    }
+                    general_waiting = true;
+                } else {
+                    match class {
+                        TaskClass::General => general_waiting = true,
+                        TaskClass::Control => control_blocked = true,
+                        TaskClass::PtyWrite => pty_write_blocked = true,
+                    }
+                }
+                still_deferred.push_back(request);
+            }
         }
     }
     *deferred = still_deferred;
@@ -311,7 +424,21 @@ async fn accept_frame<W>(
             return;
         }
     };
-    match admissions.try_acquire(task_class(&request.method)) {
+    // Never let a newly arrived request bypass an older deferred request in
+    // the same class.  Otherwise a stream of one-permit requests can consume
+    // each newly freed slot before an older batch can reserve all its permits.
+    let class = task_class(&request.method);
+    if deferred
+        .iter()
+        .any(|queued| task_class(&queued.method) == class)
+    {
+        deferred.push_back(request);
+        return;
+    }
+
+    // A batch reserves its full subrequest concurrency from the shared general
+    // admission bound, so concurrent batches cannot multiply that limit.
+    match admissions.try_acquire_many(class, request_permit_count(&request.method)) {
         Some(permit) => spawn_request(tasks, request, permit, writer),
         // Queue rather than reject.  The caller stops reading frames once the
         // queue is full, so the client is throttled instead of being handed a
@@ -333,7 +460,13 @@ async fn main() {
         watcher::init(manager);
     }
 
-    run_connection(tokio::io::stdin(), stdout).await;
+    run_connection(
+        tokio::io::stdin(),
+        stdout,
+        #[cfg(test)]
+        None,
+    )
+    .await;
 }
 
 fn decode_request(payload: &[u8]) -> Result<Request, Box<Response>> {
@@ -411,6 +544,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_abort_joinset_drain_is_bounded_for_blocking_task() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let mut tasks = JoinSet::new();
+        tasks.spawn_blocking(move || {
+            started_tx.send(()).expect("test should observe task start");
+            release_rx
+                .recv()
+                .expect("test should release blocking task");
+        });
+        started_rx.await.expect("blocking task should start");
+
+        tasks.abort_all();
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            drain_tasks_for(&mut tasks, std::time::Duration::from_millis(10)),
+        )
+        .await
+        .expect("aborted JoinSet drain must not wait for blocking work");
+        assert_eq!(tasks.len(), 1);
+
+        release_tx.send(()).expect("release blocking task");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while tasks.join_next().await.is_some() {}
+        })
+        .await
+        .expect("released blocking task should join");
+    }
+
+    #[tokio::test]
     async fn test_parse_request() {
         let params = Value::Map(vec![(
             Value::String("path".into()),
@@ -475,6 +638,149 @@ mod tests {
         assert_eq!(frames_rx.recv().await, Some(vec![0xc0]));
     }
 
+    #[test]
+    fn test_batches_reserve_shared_general_admission() {
+        let admissions = Admissions::default();
+        let mut permits = Vec::new();
+        for _ in 0..GENERAL_TASK_LIMIT / handlers::BATCH_CONCURRENCY {
+            permits.push(
+                admissions
+                    .try_acquire_many(TaskClass::General, request_permit_count("batch"))
+                    .expect("batch reservation should fit"),
+            );
+        }
+        assert_eq!(admissions.general.available_permits(), 0);
+        assert!(
+            admissions
+                .try_acquire_many(TaskClass::General, request_permit_count("batch"))
+                .is_none()
+        );
+        assert!(admissions.try_acquire(TaskClass::General).is_none());
+
+        permits.pop();
+        assert_eq!(
+            admissions.general.available_permits(),
+            handlers::BATCH_CONCURRENCY
+        );
+    }
+
+    #[tokio::test]
+    async fn test_older_batch_blocks_later_general_requests_until_it_fits() {
+        let admissions = Admissions::default();
+        let _held = admissions
+            .try_acquire_many(
+                TaskClass::General,
+                GENERAL_TASK_LIMIT - handlers::BATCH_CONCURRENCY + 1,
+            )
+            .expect("hold all but three general permits");
+        let mut deferred = VecDeque::from([
+            Request {
+                version: "2.0".into(),
+                id: RequestId::Number(1),
+                method: "batch".into(),
+                params: Value::Nil,
+            },
+            Request {
+                version: "2.0".into(),
+                id: RequestId::Number(2),
+                method: "process.status".into(),
+                params: Value::Nil,
+            },
+            Request {
+                version: "2.0".into(),
+                id: RequestId::Number(3),
+                method: "process.status".into(),
+                params: Value::Nil,
+            },
+            Request {
+                version: "2.0".into(),
+                id: RequestId::Number(4),
+                method: "process.status".into(),
+                params: Value::Nil,
+            },
+            Request {
+                version: "2.0".into(),
+                id: RequestId::Number(5),
+                method: "process.status".into(),
+                params: Value::Nil,
+            },
+        ]);
+        let writer = Arc::new(Mutex::new(tokio::io::sink()));
+        let mut tasks = JoinSet::new();
+        let mut bypass_budget = None;
+
+        start_admissible(
+            &mut deferred,
+            &mut tasks,
+            &writer,
+            &admissions,
+            &mut bypass_budget,
+        );
+
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(bypass_budget, Some(0));
+        assert_eq!(deferred.len(), 2);
+        assert_eq!(deferred[0].method, "batch");
+        assert!(matches!(&deferred[1].id, RequestId::Number(5)));
+        tasks.abort_all();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_new_general_requests_share_bounded_batch_bypass_budget() {
+        let admissions = Admissions::default();
+        let _held = admissions
+            .try_acquire_many(
+                TaskClass::General,
+                GENERAL_TASK_LIMIT - handlers::BATCH_CONCURRENCY + 1,
+            )
+            .expect("hold all but three general permits");
+        let mut deferred = VecDeque::from([Request {
+            version: "2.0".into(),
+            id: RequestId::Number(1),
+            method: "batch".into(),
+            params: Value::Nil,
+        }]);
+        let writer = Arc::new(Mutex::new(tokio::io::sink()));
+        let mut tasks = JoinSet::new();
+        let mut bypass_budget = None;
+        let (errors, _error_responses) = mpsc::channel(1);
+
+        start_admissible(
+            &mut deferred,
+            &mut tasks,
+            &writer,
+            &admissions,
+            &mut bypass_budget,
+        );
+        assert_eq!(bypass_budget, Some(3));
+
+        for id in 2..=5 {
+            accept_frame(
+                make_request_with_id(id, "process.status", Value::Nil),
+                &mut deferred,
+                &admissions,
+                &mut tasks,
+                &writer,
+                &errors,
+            )
+            .await;
+        }
+        start_admissible(
+            &mut deferred,
+            &mut tasks,
+            &writer,
+            &admissions,
+            &mut bypass_budget,
+        );
+
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(bypass_budget, Some(0));
+        assert_eq!(deferred.len(), 2);
+        assert_eq!(deferred[0].method, "batch");
+        assert!(matches!(&deferred[1].id, RequestId::Number(5)));
+        tasks.abort_all();
+    }
+
     /// Malformed frames must always be answered.  A dropped response leaves
     /// the client blocked on its own timeout with no diagnosis.
     #[tokio::test]
@@ -488,6 +794,7 @@ mod tests {
         let connection = tokio::spawn(run_connection(
             server_reader,
             Arc::new(Mutex::new(server_writer)),
+            None,
         ));
 
         let malformed = ERROR_RESPONSE_CHANNEL_SIZE * 3;
@@ -511,7 +818,7 @@ mod tests {
         }
 
         drop(writes.await.unwrap());
-        connection.await.unwrap();
+        connection.await.expect("connection task should not panic");
     }
 
     fn frame(payload: &[u8]) -> Vec<u8> {
@@ -546,7 +853,7 @@ mod tests {
         let (mut client, server_reader) = tokio::io::duplex(1024);
         let (server_writer, mut client_reader) = tokio::io::duplex(1024);
         let writer = Arc::new(Mutex::new(server_writer));
-        let connection = tokio::spawn(run_connection(server_reader, writer));
+        let connection = tokio::spawn(run_connection(server_reader, writer, None));
         let first = make_request("missing.first", Value::Map(vec![]));
         let second = make_request("missing.second", Value::Map(vec![]));
 
@@ -581,6 +888,7 @@ mod tests {
         let connection = tokio::spawn(run_connection(
             server_reader,
             Arc::new(Mutex::new(server_writer)),
+            None,
         ));
 
         for id in 1..=GENERAL_TASK_LIMIT as i64 {
@@ -848,6 +1156,56 @@ mod tests {
     /// still be SIGKILLed and reaped when the transport reaches EOF, so the
     /// connection task terminates within its bounded cleanup window.
     #[tokio::test]
+    async fn test_connection_eof_second_cleanup_catches_late_registration() {
+        let _test_lock = handlers::process::test_process_map_lock().await;
+        let barrier = Arc::new(CleanupBarrier {
+            first_pass_complete: tokio::sync::Notify::new(),
+            continue_cleanup: tokio::sync::Notify::new(),
+        });
+        let (client, server_reader) = tokio::io::duplex(4096);
+        let (server_writer, _client_reader) = tokio::io::duplex(4096);
+        let connection = tokio::spawn(run_connection(
+            server_reader,
+            Arc::new(Mutex::new(server_writer)),
+            Some(Arc::clone(&barrier)),
+        ));
+
+        drop(client);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            barrier.first_pass_complete.notified(),
+        )
+        .await
+        .expect("connection should reach the second cleanup pass");
+        let start = handlers::process::start(Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("sleep".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![Value::String("30".into())]),
+            ),
+        ]))
+        .await
+        .expect("register child between cleanup passes");
+        assert!(map_get(&start, "pid").and_then(Value::as_u64).is_some());
+        let managed_pids = handlers::process::test_managed_os_pids().await;
+        assert_eq!(managed_pids.len(), 1);
+        let os_pid = managed_pids[0];
+        barrier.continue_cleanup.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(3), connection)
+            .await
+            .expect("second cleanup should be bounded")
+            .expect("connection task should not panic");
+        assert!(handlers::process::test_managed_maps_empty().await);
+        assert!(matches!(
+            nix::sys::wait::waitpid(
+                nix::unistd::Pid::from_raw(os_pid),
+                Some(nix::sys::wait::WaitPidFlag::WNOHANG)
+            ),
+            Err(nix::errno::Errno::ECHILD)
+        ));
+    }
+
+    #[tokio::test]
     async fn test_connection_eof_sigkills_blocked_pipe_and_pty_requests() {
         let _test_lock = handlers::process::test_process_map_lock().await;
         let (mut client, server_reader) = tokio::io::duplex(4096);
@@ -855,6 +1213,7 @@ mod tests {
         let connection = tokio::spawn(run_connection(
             server_reader,
             Arc::new(Mutex::new(server_writer)),
+            None,
         ));
         let temp = tempfile::tempdir().expect("temporary marker directory");
         let markers = [
@@ -975,6 +1334,7 @@ mod tests {
         let connection = tokio::spawn(run_connection(
             server_reader,
             Arc::new(Mutex::new(server_writer)),
+            None,
         ));
 
         let start = make_request(

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -115,30 +115,18 @@
              (file-directory-p (expand-file-name "lisp" source)))
     (add-to-list 'load-path (expand-file-name "lisp" source))))
 
-;; Install msgpack from MELPA if not available
+;; Mock tests use the installed msgpack dependency; they never install or
+;; refresh packages, which could turn a local test run into network I/O.
 (defvar tramp-rpc-mock-test--msgpack-available
   (or (require 'msgpack nil t)
-      ;; Try to install from MELPA
-      (condition-case err
-          (progn
-            (require 'package)
-            (unless (assoc 'msgpack package-alist)
-              ;; Add MELPA if not present
-              (add-to-list 'package-archives
-                           '("melpa" . "https://melpa.org/packages/") t)
-              (package-initialize)
-              (unless package-archive-contents
-                (package-refresh-contents))
-              (package-install 'msgpack))
-            (require 'msgpack)
-            t)
-        (error
-         (message "Could not install msgpack: %s" err)
-         nil)))
+      (progn
+        (require 'package)
+        (package-initialize)
+        (require 'msgpack nil t)))
   "Non-nil if msgpack.el is available.")
 
 (unless tramp-rpc-mock-test--msgpack-available
-  (error "tramp-rpc mock tests require msgpack.el"))
+  (error "tramp-rpc mock tests require an installed msgpack.el"))
 
 (require 'tramp-rpc-protocol)
 
@@ -1072,6 +1060,9 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (defconst tramp-rpc-mock-test--tramp-rpc-loaded t
   "The full TRAMP-RPC backend was loaded successfully.")
 
+(load (expand-file-name "tramp-rpc-request-tests.el"
+                        (file-name-directory (or load-file-name buffer-file-name))))
+
 (ert-deftest tramp-rpc-mock-test-file-executable-root ()
   "Root requires an execute bit, rather than bypassing all mode checks."
   (let ((attrs '(nil 1 1 1 0 0 0 0 "----------")))
@@ -1091,22 +1082,27 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (ert-deftest tramp-rpc-mock-test-pipelined-timeout-signals-error ()
   "A live connection with no response reaches the pipeline timeout branch."
   (let* ((buffer (generate-new-buffer " *tramp-rpc-pipeline-test*"))
-         (process (start-process "tramp-rpc-pipeline-test" buffer "sh" "-c" "sleep 2"))
+         (process (make-pipe-process :name "tramp-rpc-pipeline-test"
+                                     :buffer buffer :noquery t))
          (vec (tramp-dissect-file-name "/rpc:mock:/tmp/"))
-         (timeout 0.15)
-         (started (float-time)))
+         (calls 0))
     (unwind-protect
         (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
-                   (lambda (_vec) (list :process process :buffer buffer))))
+                   (lambda (_vec) (list :process process :buffer buffer)))
+                  ((symbol-function 'float-time)
+                   (lambda (&rest _)
+                     (setq calls (1+ calls))
+                     (if (<= calls 2) 0 1))))
           (should (process-live-p process))
           (condition-case err
               (progn
-                (tramp-rpc--receive-responses vec '(1) timeout)
+                (tramp-rpc--receive-responses vec '(1) 0.15)
                 (error "Expected pipelined response timeout"))
             (remote-file-error
              (should (string-match-p "Timeout" (error-message-string err)))))
-          (should (>= (- (float-time) started) (* timeout 0.8)))
-          (should (process-live-p process)))
+          (should (process-live-p process))
+          (should-not (process-get process :tramp-rpc-pending-ids))
+          (should-not (gethash buffer tramp-rpc--pending-responses)))
       (when (process-live-p process) (delete-process process))
       (kill-buffer buffer))))
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -2426,6 +2426,22 @@ This matches the behavior expected by `tramp-test28-process-file'."
                     tramp-rpc--file-truename-cache "/rpc:mock:/repo")
                    "/rpc:mock:/home/arthur/src/doom"))))
 
+(ert-deftest tramp-rpc-mock-test-magit-metadata-prefetch-bounds-batches ()
+  "Large Magit metadata prefetches stay within the server batch limit."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-magit-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:mock:/repo/"))
+        (files (cl-loop for i below 40
+                        collect (format "/repo/file-%02d" i)))
+        batch-sizes)
+    (cl-letf (((symbol-function 'tramp-rpc--call-batch)
+               (lambda (_vec requests)
+                 (push (length requests) batch-sizes)
+                 (make-list (length requests) '(:error -1)))))
+      (tramp-rpc-magit--prefetch-file-metadata vec files))
+    ;; Forty same-directory files produce two per-file requests plus one
+    ;; shared directory stat: 81 requests, split at the server's 64-entry cap.
+    (should (equal (nreverse batch-sizes) '(64 17)))))
+
 (defun tramp-rpc-mock-test--sudo-helper-available-p ()
   "Return non-nil when the sudo path helpers needed by this test are available."
   (and (require 'tramp-cmds nil t)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -141,6 +141,15 @@
       (msgpack-bin-string data)
     data))
 
+(defun tramp-rpc-mock-test--wait-for (predicate description &optional process)
+  "Run the event loop until PREDICATE succeeds or report DESCRIPTION."
+  (let ((deadline (+ (float-time) 1.0)))
+    (while (and (< (float-time) deadline) (not (funcall predicate)))
+      (accept-process-output process 0.01))
+    (unless (funcall predicate)
+      (error "Timed out waiting for %s (process status: %S)"
+             description (and (processp process) (process-status process))))))
+
 ;;; ============================================================================
 ;;; Protocol Tests (No server required)
 ;;; ============================================================================
@@ -1818,7 +1827,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
             (should (timerp (plist-get info :delivery-timer)))
             (should (timerp (plist-get info :poll-timer))))
           (tramp-rpc--cleanup-async-processes vec nil)
-          (sleep-for 0.05)
+          (let ((barrier nil))
+            (run-at-time 0 nil (lambda () (setq barrier t)))
+            (tramp-rpc-mock-test--wait-for
+             (lambda () barrier) "cancelled timer barrier"))
           (should-not fired)
           (should-not (gethash process tramp-rpc--async-processes)))
       (when (process-live-p process) (delete-process process)))))
@@ -1874,7 +1886,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (puthash process '(:direct-ssh t) tramp-rpc--pty-processes)
           (set-process-sentinel process #'tramp-rpc--direct-ssh-pty-sentinel)
           (delete-process process)
-          (sleep-for 0.02)
+          (tramp-rpc-mock-test--wait-for
+           (lambda () (and (not (gethash process tramp-rpc--pty-processes))
+                           (= calls 1)))
+           "direct PTY sentinel")
           (should-not (gethash process tramp-rpc--pty-processes))
           (should (= calls 1)))
       (when (process-live-p process) (delete-process process)))))
@@ -1894,7 +1909,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (set-process-sentinel process (lambda (_process _event) (cl-incf calls)))
           (tramp-rpc--install-direct-ssh-pty-sentinel process)
           (delete-process process)
-          (sleep-for 0.02)
+          (tramp-rpc-mock-test--wait-for
+           (lambda () (and (not (gethash process tramp-rpc--pty-processes))
+                           (= calls 1)))
+           "replacement direct PTY sentinel")
           (should-not (gethash process tramp-rpc--pty-processes))
           (should (= calls 1)))
       (when (process-live-p process) (delete-process process)))))

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -1,0 +1,228 @@
+;;; tramp-rpc-request-tests.el --- Request lifecycle tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'tramp-rpc)
+
+(defun tramp-rpc-mock-test-request--connection ()
+  "Return a live process and its buffer for request lifecycle tests."
+  (let* ((buffer (generate-new-buffer " *tramp-rpc-mock-test-request*"))
+         (process (make-pipe-process :name "tramp-rpc-mock-test-request"
+                                     :buffer buffer :noquery t)))
+    (process-put process :tramp-rpc-buffer buffer)
+    (list process buffer)))
+
+(defmacro tramp-rpc-mock-test-request--with-connection (spec &rest body)
+  "Run BODY with a disposable test PROCESS and BUFFER."
+  (declare (indent 1) (debug t))
+  (let ((process (nth 0 spec))
+        (buffer (nth 1 spec)))
+    `(let* ((pair (tramp-rpc-mock-test-request--connection))
+            (,process (car pair))
+            (,buffer (cadr pair)))
+       (unwind-protect
+           (progn ,@body)
+         (when (process-live-p ,process)
+           (delete-process ,process))
+         (when (buffer-live-p ,buffer)
+           (kill-buffer ,buffer))))))
+
+(defun tramp-rpc-mock-test-request--vec ()
+  "Return a harmless vector for lifecycle diagnostics."
+  (tramp-dissect-file-name "/rpc:request-test:/tmp/"))
+
+(defun tramp-rpc-mock-test-request--timeout-clock ()
+  "Return a clock which makes the first wait check expire."
+  (let ((calls 0))
+    (lambda (&rest _)
+      (setq calls (1+ calls))
+      (if (<= calls 2) 0 100))))
+
+(ert-deftest tramp-rpc-mock-test-request-sync-timeout-discards-late-response ()
+  "A timed out synchronous ID is not buffered when its response arrives late."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((clock (tramp-rpc-mock-test-request--timeout-clock))
+          (vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(101 . "request")))
+                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
+                ((symbol-function 'float-time) clock))
+        (should-error (tramp-rpc--call-with-timeout vec "test" nil 0 0)
+                      :type 'remote-file-error)
+        (should-not (process-get process :tramp-rpc-pending-ids))
+        (let ((messages (list '(:id 101 :result late))))
+          (cl-letf (((symbol-function 'tramp-rpc-protocol-try-read-message)
+                     (lambda (_buffer)
+                       (set-marker (mark-marker) (point-max))
+                       (pop messages))))
+            (tramp-rpc--connection-filter process "late")))
+        (should-not (gethash buffer tramp-rpc--pending-responses))))))
+
+(ert-deftest tramp-rpc-mock-test-request-callback-error-does-not-strand-next-frame ()
+  "A failing async callback does not stop delivery of buffered responses."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((tramp-rpc--async-callbacks (make-hash-table :test 'eql))
+          (tramp-rpc--async-callback-processes (make-hash-table :test 'eql))
+          (tramp-rpc--pending-responses (make-hash-table :test 'eq))
+          (messages (list '(:id 201 :result first)
+                          '(:id 202 :result second))))
+      (puthash 201 (lambda (_response) (error "callback failed"))
+               tramp-rpc--async-callbacks)
+      (puthash 201 process tramp-rpc--async-callback-processes)
+      (tramp-rpc--track-pending-request process 202)
+      (cl-letf (((symbol-function 'tramp-rpc-protocol-try-read-message)
+                 (lambda (_buffer)
+                   (set-marker (mark-marker) (point-max))
+                   (pop messages))))
+        (tramp-rpc--connection-filter process "two responses"))
+      (should-not (gethash 201 tramp-rpc--async-callbacks))
+      (should (equal '(:id 202 :result second)
+                     (gethash 202 (tramp-rpc--get-pending-responses buffer)))))))
+
+(ert-deftest tramp-rpc-mock-test-request-batch-timeout-cleans-id ()
+  "A batch timeout releases its request ID and response table."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-batch-request-with-id)
+                 (lambda (&rest _) '(102 . "batch")))
+                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
+                ((symbol-function 'float-time) (tramp-rpc-mock-test-request--timeout-clock)))
+        (should-error (tramp-rpc--call-batch vec '(("test" . nil)))
+                      :type 'remote-file-error)
+        (should-not (process-get process :tramp-rpc-pending-ids))
+        (should-not (gethash buffer tramp-rpc--pending-responses))))))
+
+(ert-deftest tramp-rpc-mock-test-request-pipeline-death-keeps-receive-on-old-generation ()
+  "A pipeline receives its injected error from the generation that sent it."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let* ((replacement-buffer (generate-new-buffer " *tramp-rpc-replacement*"))
+           (replacement (make-pipe-process :name "tramp-rpc-replacement"
+                                           :buffer replacement-buffer :noquery t))
+           (vec (tramp-rpc-mock-test-request--vec))
+           (old-connection (list :process process :buffer buffer))
+           (replacement-connection (list :process replacement
+                                         :buffer replacement-buffer))
+           (tramp-rpc--connections (make-hash-table :test 'equal))
+           (ensure-calls 0))
+      (unwind-protect
+          (progn
+            (puthash (tramp-rpc--connection-key vec) old-connection
+                     tramp-rpc--connections)
+            (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                       (lambda (_vec)
+                         (setq ensure-calls (1+ ensure-calls))
+                         (tramp-rpc--get-connection vec)))
+                      ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                       (lambda (&rest _) '(103 . "request")))
+                      ((symbol-function 'process-send-string)
+                       (lambda (&rest _)
+                         (puthash (tramp-rpc--connection-key vec)
+                                  replacement-connection tramp-rpc--connections)
+                         (tramp-rpc--cleanup-connection-generation
+                          process vec "closed\n" :transport-death))))
+              (should (equal '((:error -32098 :message "RPC transport closed for request-test (closed)"))
+                             (tramp-rpc--call-pipelined vec '(("test" . nil)))))
+              (should (= ensure-calls 1))
+              (should-not (process-get process :tramp-rpc-pending-ids))
+              (should-not (gethash buffer tramp-rpc--pending-responses))
+              (should (eq replacement
+                          (plist-get (tramp-rpc--get-connection vec) :process))))
+        (when (process-live-p replacement)
+          (delete-process replacement))
+        (when (buffer-live-p replacement-buffer)
+          (kill-buffer replacement-buffer)))))))
+
+(ert-deftest tramp-rpc-mock-test-request-user-quit-cleans-id ()
+  "User quit while synchronously waiting releases the request ID."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(105 . "quit")))
+                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
+                ((symbol-function 'accept-process-output)
+                 (lambda (&rest _) (signal 'quit nil))))
+        (condition-case nil
+            (tramp-rpc--call-with-timeout vec "test" nil 30 0)
+          (quit nil))
+        (should-not (process-get process :tramp-rpc-pending-ids))
+        (should-not (gethash buffer tramp-rpc--pending-responses))))))
+
+(ert-deftest tramp-rpc-mock-test-request-send-error-cleans-id ()
+  "A send failure before waiting releases the request ID."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(106 . "send-error")))
+                ((symbol-function 'process-send-string)
+                 (lambda (&rest _) (error "send failed"))))
+        (should-error (tramp-rpc--call-with-timeout vec "test" nil 30 0))
+        (should-not (process-get process :tramp-rpc-pending-ids))
+        (should-not (gethash buffer tramp-rpc--pending-responses))))))
+
+(ert-deftest tramp-rpc-mock-test-request-non-essential-bailout-cleans-id ()
+  "A non-essential locked wait releases the request ID."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (non-essential t)
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(107 . "bail")))
+                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
+                ((symbol-function 'tramp-rpc--process-accessible-p)
+                 (lambda (_process) nil)))
+        (should (eq 'non-essential
+                    (catch 'non-essential
+                      (tramp-rpc--call-with-timeout vec "test" nil 30 0)
+                      nil)))
+        (should-not (process-get process :tramp-rpc-pending-ids))
+        (should-not (gethash buffer tramp-rpc--pending-responses))))))
+
+(ert-deftest tramp-rpc-mock-test-request-transport-death-response-is-not-overwritten ()
+  "Late normal output cannot overwrite a transport error awaiting its waiter."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (tramp-rpc--track-pending-request process 108)
+      (tramp-rpc--cleanup-connection-generation process vec "closed\n"
+                                                 :transport-death)
+      (let ((messages (list '(:id 108 :result late))))
+        (cl-letf (((symbol-function 'tramp-rpc-protocol-try-read-message)
+                   (lambda (_buffer)
+                     (set-marker (mark-marker) (point-max))
+                     (pop messages))))
+          (tramp-rpc--connection-filter process "late")))
+      (with-current-buffer buffer
+        (let ((response (tramp-rpc--find-response-by-id 108 process)))
+          (should (tramp-rpc-protocol-error-p response))
+          (should (= -32098 (tramp-rpc-protocol-error-code response)))))
+      (should-not (process-get process :tramp-rpc-pending-ids))
+      (should-not (gethash buffer tramp-rpc--pending-responses)))))
+
+(ert-deftest tramp-rpc-mock-test-request-abandon-one-preserves-live-request ()
+  "Releasing one request does not discard another live request's response."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((pending (make-hash-table :test 'eql)))
+      (puthash buffer pending tramp-rpc--pending-responses)
+      (tramp-rpc--track-pending-request process 109)
+      (tramp-rpc--track-pending-request process 110)
+      (puthash 110 '(:id 110 :result live) pending)
+      (tramp-rpc--release-pending-requests process buffer '(109))
+      (should (equal '(110) (process-get process :tramp-rpc-pending-ids)))
+      (should (equal '(:id 110 :result live) (gethash 110 pending)))
+      (should (= 1 (hash-table-count pending))))))
+
+;;; tramp-rpc-request-tests.el ends here

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -162,9 +162,9 @@ Value is a cons cell (CHECKED . RESULT).")
                  (cl-incf count)
                  (funcall orig-call-async vec method params callback connection)))
               ((symbol-function 'tramp-rpc--send-requests)
-               (lambda (vec requests)
+               (lambda (vec requests &optional connection)
                  (cl-incf count (length requests))
-                 (funcall orig-send-requests vec requests))))
+                 (funcall orig-send-requests vec requests connection))))
       (setq result (funcall thunk))
       (cons result count))))
 
@@ -194,9 +194,9 @@ when THUNK signals so tests can assert error-path roundtrips."
                  (cl-incf count)
                  (funcall orig-call-async vec method params callback connection)))
               ((symbol-function 'tramp-rpc--send-requests)
-               (lambda (vec requests)
+               (lambda (vec requests &optional connection)
                  (cl-incf count (length requests))
-                 (funcall orig-send-requests vec requests))))
+                 (funcall orig-send-requests vec requests connection))))
       (condition-case err
           (setq result (funcall thunk))
         (error (setq error err)))
@@ -401,6 +401,7 @@ The directory is deleted after BODY completes."
   (skip-unless (tramp-rpc-test-enabled))
   (let ((vec (tramp-dissect-file-name (tramp-rpc-test--remote-directory))))
     (should (listp (tramp-get-remote-groups vec 'integer)))))
+
 
 ;;; ============================================================================
 ;;; Test 01: File Name Syntax

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -127,6 +127,15 @@ When set, cross-remote tests (copy/rename between different hosts) are run.")
   "Cached result of `tramp-rpc-test-enabled'.
 Value is a cons cell (CHECKED . RESULT).")
 
+(defun tramp-rpc-test--wait-for (predicate description &optional process)
+  "Run the event loop until PREDICATE succeeds or report DESCRIPTION."
+  (let ((deadline (+ (float-time) 1.0)))
+    (while (and (< (float-time) deadline) (not (funcall predicate)))
+      (accept-process-output process 0.01))
+    (unless (funcall predicate)
+      (error "Timed out waiting for %s (process status: %S)"
+             description (and (processp process) (process-status process))))))
+
 (defun tramp-rpc-test--clear-call-count-caches ()
   "Clear TRAMP/TRAMP-RPC caches before call-count measurement."
   (maphash
@@ -1902,22 +1911,25 @@ This matches the upstream `tramp-test28-process-file' test."
           (ignore-errors (delete-process proc)))))))
 
 (ert-deftest tramp-rpc-test13d-coding-byte-boundary ()
-  "Process coding crosses RPC chunks exactly once."
+  "Process coding applies exactly once across the local relay."
   (let* ((utf8 (encode-coding-string "é" 'binary))
          (binary (string-make-unibyte "\xff\x00\xc3"))
          (p (start-process "tramp-rpc-coding-boundary" nil "cat"))
          (output ""))
     (unwind-protect
         (progn
-          (sleep-for .05)
+          (tramp-rpc-test--wait-for (lambda () (process-live-p p))
+                                    "coding relay process" p)
           (tramp-rpc--configure-relay-coding p '(utf-8-unix . utf-8-unix))
           (set-process-filter p (lambda (_process string)
                                   (setq output (concat output string))))
-          (let ((tramp-rpc--delivering-output t))
-            (process-send-string p (substring utf8 0 1))
-            (accept-process-output nil .05)
-            (process-send-string p (concat (substring utf8 1) "\n"))
-            (accept-process-output nil .2))
+          ;; Preserve the decoder boundary across separate pipe RPC chunks.
+          (tramp-rpc--deliver-process-output
+           p (substring utf8 0 1) nil nil)
+          (tramp-rpc--deliver-process-output
+           p (concat (substring utf8 1) "\n") nil nil)
+          (tramp-rpc-test--wait-for
+           (lambda () (equal output "é\n")) "complete UTF-8 output" p)
           (should (equal output "é\n"))
           (should (equal (tramp-rpc--decode-output
                           (msgpack-bin-make (string-make-unibyte "\351"))
@@ -1956,7 +1968,10 @@ This matches the upstream `tramp-test28-process-file' test."
          (stderr-output ""))
     (unwind-protect
         (progn
-          (sleep-for .05)
+          (tramp-rpc-test--wait-for (lambda () (process-live-p stdout))
+                                    "stdout coding relay process" stdout)
+          (tramp-rpc-test--wait-for (lambda () (process-live-p stderr))
+                                    "stderr coding relay process" stderr)
           (tramp-rpc--configure-relay-coding stdout
                                              '(utf-8-unix . latin-1-unix))
           (tramp-rpc--configure-relay-coding stderr
@@ -1972,7 +1987,12 @@ This matches the upstream `tramp-test28-process-file' test."
           (tramp-rpc--deliver-process-output
            stdout (encode-coding-string "sortie\n" 'binary)
            (encode-coding-string "erreur\n" 'binary) t)
-          (accept-process-output nil .2)
+          (tramp-rpc-test--wait-for
+           (lambda () (equal stdout-output "sortie\n"))
+           "complete stdout coding output" stdout)
+          (tramp-rpc-test--wait-for
+           (lambda () (equal stderr-output "erreur\n"))
+           "complete stderr coding output" stderr)
           (should (equal stdout-output "sortie\n"))
           (should (equal stderr-output "erreur\n"))
           (should (equal (process-coding-system stdout)
@@ -1988,7 +2008,8 @@ This matches the upstream `tramp-test28-process-file' test."
          (output ""))
     (unwind-protect
         (progn
-          (sleep-for .05)
+          (tramp-rpc-test--wait-for (lambda () (process-live-p process))
+                                    "PTY coding relay process" process)
           (tramp-rpc--configure-relay-coding process
                                              '(utf-8-unix . latin-1-unix))
           (set-process-filter process
@@ -2004,7 +2025,9 @@ This matches the upstream `tramp-test28-process-file' test."
             (tramp-rpc--pty-handle-async-response
              process `(:result ((output . ,(concat (substring bytes 1) "\n"))
                                 (exited . nil))))
-            (accept-process-output nil .2))
+            (tramp-rpc-test--wait-for
+             (lambda () (equal output "é\n")) "complete PTY coding output"
+             process))
           (should (equal output "é\n")))
       (remhash process tramp-rpc--pty-processes)
       (delete-process process))))


### PR DESCRIPTION
## Summary

Bound batches, close cleanup races, discard abandoned responses, pin pipeline generations, and replace timing sleeps with event waits.

## Stack

Part **10 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/09-deployment-cleanup`
- Next PRs build on `remediation/10-request-finalization`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.
