### PR TITLE
[11/11] Close remaining lifecycle and cache gaps

### DIFF
--- a/README.org
+++ b/README.org
@@ -373,6 +373,28 @@ cargo build --release --target aarch64-unknown-linux-gnu
 (setq tramp-rpc-deploy-download-timeout 60)
 #+end_src
 
+** Deployment fallback policy
+
+When the expected remote binary already exists and is executable, TRAMP-RPC
+reuses it if no trusted local artifact can be obtained (for example because
+download, build, or local-cache access is unavailable).  This fallback never
+covers a missing remote binary.  Whenever a trusted local artifact is
+available, TRAMP-RPC compares SHA256 digests and either reuses the match or,
+with automatic deployment enabled, replaces a mismatch through the verified
+staging-and-activation operation.  With automatic deployment disabled, a
+verified mismatch remains an explicit error.
+
+** Process compatibility notes
+
+- RPC PTYs disable kernel ~ECHO~, ~ECHONL~, and ~ONLCR~.  Emacs terminal
+  consumers such as comint and eat perform local echo and line handling; code
+  that relies directly on kernel echo or CRLF conversion will observe different
+  PTY semantics.
+- RPC PTY writes wait for the remote write acknowledgement and can therefore
+  block for up to the RPC timeout when the remote program stops reading.
+  Pipe writes remain queued by default; set
+  ~tramp-rpc-synchronous-pipe-writes~ non-nil to make them synchronous too.
+
 * Troubleshooting
 
 ** Check deployment status

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -41,6 +41,7 @@
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process"
                   (vec pid data &optional owner-process))
+(declare-function tramp-rpc--drain-write-queue "tramp-rpc-process")
 (declare-function tramp-rpc--encode-process-input "tramp-rpc-process")
 (declare-function tramp-rpc--close-remote-stdin "tramp-rpc-process"
                   (vec pid &optional owner-process))
@@ -51,7 +52,6 @@
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")
-(declare-function tramp-rpc--call-async "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
@@ -59,6 +59,7 @@
 (defvar tramp-rpc--closing-local-relay)
 (defvar tramp-rpc--pty-processes)
 (defvar tramp-rpc--async-processes)
+(defvar tramp-rpc-synchronous-pipe-writes)
 
 ;; Functions from vc-dispatcher.el (used by vc-exec-after handler)
 (declare-function vc-exec-after "vc-dispatcher")
@@ -130,12 +131,13 @@ for `process-coding-system' callers."
         (let ((vec (process-get proc :tramp-rpc-vec))
               (pid (process-get proc :tramp-rpc-pid)))
           (tramp-rpc--debug "SEND-STRING PTY pid=%s len=%d" pid (length string))
-          ;; Encode user input exactly once with the public write side.
+          ;; Match local `process-send-string' semantics: return only after the
+          ;; bytes reached the remote PTY's kernel buffer.
           (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
-            (tramp-rpc--call-async vec "process.write_pty"
-                                   `((pid . ,pid)
-                                     (data . ,(msgpack-bin-make data-bytes)))
-                                   #'ignore))  ; Ignore the response
+            (tramp-rpc--call vec "process.write_pty"
+                             `((pid . ,pid)
+                               (data . ,(msgpack-bin-make data-bytes)))
+                             (process-get proc :tramp-rpc-connection)))
           nil))
        ;; Regular async RPC process (pipe-based)
        ((and proc
@@ -144,11 +146,12 @@ for `process-coding-system' callers."
              (not (process-get proc :tramp-rpc-pty)))
         (tramp-rpc--debug "SEND-STRING pipe pid=%s len=%d"
                          (process-get proc :tramp-rpc-pid) (length string))
-        (tramp-rpc--write-remote-process
-         (process-get proc :tramp-rpc-vec)
-         (process-get proc :tramp-rpc-pid)
-         (tramp-rpc--encode-process-input proc string)
-         proc))
+        (let ((vec (process-get proc :tramp-rpc-vec))
+              (pid (process-get proc :tramp-rpc-pid)))
+          (tramp-rpc--write-remote-process
+           vec pid (tramp-rpc--encode-process-input proc string) proc)
+          (when tramp-rpc-synchronous-pipe-writes
+            (tramp-rpc--drain-write-queue vec pid proc))))
        ;; Not an RPC process, use original function
        (t (tramp-run-real-handler #'process-send-string (list process string)))))))
 
@@ -174,10 +177,10 @@ for `process-coding-system' callers."
               (string (buffer-substring-no-properties start end)))
           (tramp-rpc--debug "SEND-REGION PTY pid=%s len=%d" pid (length string))
           (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
-            (tramp-rpc--call-async vec "process.write_pty"
-                                   `((pid . ,pid)
-                                     (data . ,(msgpack-bin-make data-bytes)))
-                                   #'ignore))
+            (tramp-rpc--call vec "process.write_pty"
+                             `((pid . ,pid)
+                               (data . ,(msgpack-bin-make data-bytes)))
+                             (process-get proc :tramp-rpc-connection)))
           nil))
        ;; Regular async RPC process (pipe-based)
        ((and proc
@@ -187,11 +190,12 @@ for `process-coding-system' callers."
         (let ((string (buffer-substring-no-properties start end)))
           (tramp-rpc--debug "SEND-REGION pipe pid=%s len=%d"
                            (process-get proc :tramp-rpc-pid) (length string))
-          (tramp-rpc--write-remote-process
-           (process-get proc :tramp-rpc-vec)
-           (process-get proc :tramp-rpc-pid)
-           (tramp-rpc--encode-process-input proc string)
-           proc)))
+          (let ((vec (process-get proc :tramp-rpc-vec))
+                (pid (process-get proc :tramp-rpc-pid)))
+            (tramp-rpc--write-remote-process
+             vec pid (tramp-rpc--encode-process-input proc string) proc)
+            (when tramp-rpc-synchronous-pipe-writes
+              (tramp-rpc--drain-write-queue vec pid proc)))))
        ;; Not an RPC process, use original function
        (t (tramp-run-real-handler #'process-send-region (list process start end)))))))
 
@@ -220,10 +224,10 @@ for `process-coding-system' callers."
             (if (process-get proc :tramp-rpc-pty)
                 ;; PTY processes: send Ctrl-D (EOF character) via the PTY.
                 (let ((eof-char (string ?\C-d))) ; ASCII 4 = Ctrl-D
-                  (tramp-rpc--call-async vec "process.write_pty"
-                                         `((pid . ,pid)
-                                           (data . ,(msgpack-bin-make eof-char)))
-                                         #'ignore))
+                  (tramp-rpc--call vec "process.write_pty"
+                                   `((pid . ,pid)
+                                     (data . ,(msgpack-bin-make eof-char)))
+                                   (process-get proc :tramp-rpc-connection)))
               ;; Pipe processes: a queue failure must reach the caller.
               (tramp-rpc--close-remote-stdin vec pid proc)))))
        ;; Not a tramp-rpc process

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -999,6 +999,15 @@ Tries sha256sum first, then shasum -a 256 for macOS compatibility."
     (tramp-send-command-and-check
      vec (format "rm -rf %s" (tramp-shell-quote-argument directory)))))
 
+(defun tramp-rpc-deploy--remote-binary-matches-p (vec local-path)
+  "Return non-nil when VEC's deployed binary matches LOCAL-PATH."
+  (let* ((remote-local
+          (tramp-file-local-name (tramp-rpc-deploy--remote-binary-path vec)))
+         (local-checksum (tramp-rpc-deploy--compute-checksum local-path))
+         (remote-checksum (tramp-rpc-deploy--remote-checksum vec remote-local)))
+    (and remote-checksum (string= local-checksum remote-checksum))))
+
+
 (defun tramp-rpc-deploy--transfer-binary (vec local-path)
   "Transfer the binary at LOCAL-PATH to the remote host VEC.
 Uses TRAMP's `copy-file' with the bootstrap method for binary transfer.
@@ -1139,7 +1148,13 @@ attempted.  Returns `tramp-rpc-deploy-remote-binary-path' if set,
 otherwise the bare binary name \"tramp-rpc-server\".
 
 Otherwise, if `tramp-rpc-deploy-auto-deploy' is nil and the binary
-is missing, signals an error."
+is missing, signals an error.
+
+An existing executable is reused when no trusted local artifact can be
+obtained (for example, download, build, or cache access is unavailable).
+When a trusted local artifact is available, its checksum is always compared:
+a mismatch is replaced only with auto-deploy enabled, and otherwise signals
+an explicit error.  A missing remote binary never uses this fallback."
   (if tramp-rpc-deploy-never-deploy
       ;; Never deploy mode: use explicit path or bare binary name
       (let ((path (or tramp-rpc-deploy-remote-binary-path
@@ -1151,22 +1166,59 @@ is missing, signals an error."
 	   ;; For simplified Tramp syntax.
 	   (tramp-default-method (tramp-file-name-method bootstrap-vec))
 	   tramp-default-method-alist)
-      (if (tramp-rpc-deploy--remote-binary-exists-p bootstrap-vec)
-          ;; Binary already exists
-          (tramp-file-local-name (tramp-rpc-deploy--remote-binary-path bootstrap-vec))
-        ;; Need to deploy
-        (if tramp-rpc-deploy-auto-deploy
-            (let* ((arch (tramp-rpc-deploy--detect-remote-arch bootstrap-vec))
-                   (local-binary (tramp-rpc-deploy--ensure-local-binary arch)))
-              (message "Deploying tramp-rpc-server (%s) to %s..."
-                       arch (tramp-file-name-host vec))
+      (let* ((remote-present
+              (tramp-rpc-deploy--remote-binary-exists-p bootstrap-vec))
+             (remote-local
               (tramp-file-local-name
-               (tramp-rpc-deploy--transfer-binary bootstrap-vec local-binary)))
+               (tramp-rpc-deploy--remote-binary-path bootstrap-vec))))
+        (cond
+         ((and (not remote-present) (not tramp-rpc-deploy-auto-deploy))
           (signal
-	   'remote-file-error
-	   (list "tramp-rpc-server not found on"
-		 (tramp-file-name-host vec)
-		 "and auto-deploy is disabled")))))))
+           'remote-file-error
+           (list "tramp-rpc-server not found on"
+                 (tramp-file-name-host vec)
+                 "and auto-deploy is disabled")))
+         (t
+          ;; The pre-existing remote executable is a usable fallback only when
+          ;; local artifact acquisition itself failed.  Once we have a trusted
+          ;; artifact, retain strict checksum comparison and replacement.
+          (let* ((artifact
+                  (condition-case err
+                      (let* ((arch
+                              (tramp-rpc-deploy--detect-remote-arch bootstrap-vec))
+                             (local-binary
+                              (tramp-rpc-deploy--ensure-local-binary arch)))
+                        (list :arch arch :local-binary local-binary))
+                    (remote-file-error
+                     (if remote-present
+                         (list :unavailable err)
+                       (signal (car err) (cdr err))))))
+                 (arch (plist-get artifact :arch))
+                 (local-binary (plist-get artifact :local-binary)))
+            (if (eq (car artifact) :unavailable)
+                (progn
+                  (message
+                   "Using existing remote tramp-rpc-server; no trusted local artifact is available: %s"
+                   (error-message-string (cadr artifact)))
+                  remote-local)
+              (cond
+               ((and remote-present
+                     (tramp-rpc-deploy--remote-binary-matches-p
+                      bootstrap-vec local-binary))
+                remote-local)
+               (tramp-rpc-deploy-auto-deploy
+                (when remote-present
+                  (message "Existing remote tramp-rpc-server failed checksum verification; replacing it"))
+                (message "Deploying tramp-rpc-server (%s) to %s..."
+                         arch (tramp-file-name-host vec))
+                (tramp-file-local-name
+                 (tramp-rpc-deploy--transfer-binary bootstrap-vec local-binary)))
+               (remote-present
+                (signal
+                 'remote-file-error
+                 (list "Existing tramp-rpc-server on"
+                       (tramp-file-name-host vec)
+                       "failed checksum verification and auto-deploy is disabled"))))))))))))
 
 (defun tramp-rpc-deploy-remove-binary (vec)
   "Remove the tramp-rpc-server binary from remote VEC."

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -90,13 +90,38 @@ Keys are expanded filenames, values are (TIMESTAMP . TRUENAME).")
 Keys are (EXPANDED-FILENAME . LSTAT), values are (TIMESTAMP . STAT).
 STAT may be nil, which records a missing file.")
 
+(defun tramp-rpc--effective-cache-ttl ()
+  "Return the current TTL for TRAMP-RPC metadata caches.
+`remote-file-name-inhibit-cache' t disables caching, while a numeric value
+caps the project-specific TTL.  Nil retains the explicit TRAMP-RPC TTL."
+  (cond
+   ((eq remote-file-name-inhibit-cache t) 0)
+   ((numberp remote-file-name-inhibit-cache)
+    (min tramp-rpc--cache-ttl (max 0 remote-file-name-inhibit-cache)))
+   (t tramp-rpc--cache-ttl)))
+
+(defun tramp-rpc--cache-entry-valid-p (timestamp)
+  "Return non-nil when a cache entry created at TIMESTAMP is reusable."
+  (let ((age (- (float-time) timestamp)))
+    (cond
+     ((eq remote-file-name-inhibit-cache t) nil)
+     ((numberp remote-file-name-inhibit-cache)
+      (< age (tramp-rpc--effective-cache-ttl)))
+     ;; TRAMP also binds this to `current-time' to invalidate entries older
+     ;; than the start of a compound operation.
+     ((consp remote-file-name-inhibit-cache)
+      (and (not (time-less-p (seconds-to-time timestamp)
+                             remote-file-name-inhibit-cache))
+           (< age tramp-rpc--cache-ttl)))
+     (t (< age tramp-rpc--cache-ttl)))))
+
 (defun tramp-rpc--cache-get (cache key)
   "Get value for KEY from CACHE if not expired.
 Returns the cached value, or nil if not found or expired."
   (when-let* ((entry (gethash key cache)))
     (let ((timestamp (car entry))
           (value (cdr entry)))
-      (if (< (- (float-time) timestamp) tramp-rpc--cache-ttl)
+      (if (tramp-rpc--cache-entry-valid-p timestamp)
           value
         ;; Expired, remove it
         (remhash key cache)
@@ -118,7 +143,7 @@ Unlike `tramp-rpc--cache-get', this preserves cached nil values."
         'not-cached
       (let ((timestamp (car entry))
             (value (cdr entry)))
-        (if (< (- (float-time) timestamp) tramp-rpc--cache-ttl)
+        (if (tramp-rpc--cache-entry-valid-p timestamp)
             value
           (remhash key cache)
           'not-cached)))))
@@ -158,14 +183,15 @@ must still report symlink type for lstat."
 
 (defvar tramp-rpc-magit--ancestors-cache)
 (defvar tramp-rpc-magit--prefetch-directory)
+(defvar tramp-rpc-magit--ancestors-cache-timestamp)
 (defvar tramp-rpc-magit--ancestor-scan-caches)
-(defvar tramp-rpc-magit--prefetch-directory)
 
 (defun tramp-rpc-magit--clear-ancestor-caches ()
   "Clear cached ancestor marker scans."
   (when (boundp 'tramp-rpc-magit--ancestor-scan-caches)
     (clrhash tramp-rpc-magit--ancestor-scan-caches))
-  (setq tramp-rpc-magit--ancestors-cache nil))
+  (setq tramp-rpc-magit--ancestors-cache nil
+        tramp-rpc-magit--ancestors-cache-timestamp nil))
 
 (defun tramp-rpc-magit--clear-ancestor-caches-for-connection (vec)
   "Clear ancestor caches belonging to the connection identified by VEC."
@@ -182,6 +208,7 @@ must still report symlink type for lstat."
       (with-parsed-tramp-file-name tramp-rpc-magit--prefetch-directory nil
         (when (equal (format "%S" (tramp-rpc--connection-key v)) connection-key)
           (setq tramp-rpc-magit--ancestors-cache nil
+                tramp-rpc-magit--ancestors-cache-timestamp nil
                 tramp-rpc-magit--prefetch-directory nil))))))
 
 (defun tramp-rpc--invalidate-cache-for-path (filename)
@@ -643,6 +670,9 @@ large worktrees must be split without losing item/result ordering.")
 (defvar tramp-rpc-magit--ancestors-cache nil
   "Cached ancestor scan data from server-side RPC.
 This is populated by `tramp-rpc-magit--prefetch' for file existence checks.")
+
+(defvar tramp-rpc-magit--ancestors-cache-timestamp nil
+  "Creation time of `tramp-rpc-magit--ancestors-cache'.")
 
 (defconst tramp-rpc-magit--ancestor-marker-names
   '(".git" ".svn" ".hg" ".bzr" "_darcs"
@@ -1389,7 +1419,8 @@ as the process-file cache.  Also fetches ancestor markers."
         ;; Fetch ancestor markers for project/VC detection
         (setq tramp-rpc-magit--ancestors-cache
               (tramp-rpc-ancestors-scan
-               directory tramp-rpc-magit--ancestor-marker-names))
+               directory tramp-rpc-magit--ancestor-marker-names)
+              tramp-rpc-magit--ancestors-cache-timestamp (float-time))
         (when tramp-rpc-magit--debug
           (let ((cache (tramp-rpc-magit--get-process-cache)))
             (tramp-rpc--debug "tramp-rpc-magit: prefetched %d commands + ancestors for %s"
@@ -1452,12 +1483,17 @@ the server scans the entire tree in one operation."
 (defun tramp-rpc-magit--ancestor-scan-for-directory (directory)
   "Return cached ancestor marker scan for DIRECTORY, fetching it if needed."
   (let* ((directory (file-name-as-directory (expand-file-name directory)))
-         (key (tramp-rpc-magit--ancestor-scan-cache-key directory)))
-    (or (gethash key tramp-rpc-magit--ancestor-scan-caches)
-        (puthash key
-                 (tramp-rpc-ancestors-scan
-                  directory tramp-rpc-magit--ancestor-marker-names)
-                 tramp-rpc-magit--ancestor-scan-caches))))
+         (key (tramp-rpc-magit--ancestor-scan-cache-key directory))
+         (entry (gethash key tramp-rpc-magit--ancestor-scan-caches)))
+    (if (and entry (tramp-rpc--cache-entry-valid-p (car entry)))
+        (cdr entry)
+      (when entry
+        (remhash key tramp-rpc-magit--ancestor-scan-caches))
+      (let ((scan (tramp-rpc-ancestors-scan
+                   directory tramp-rpc-magit--ancestor-marker-names)))
+        (puthash key (cons (float-time) scan)
+                 tramp-rpc-magit--ancestor-scan-caches)
+        scan))))
 
 (defun tramp-rpc-magit--ancestor-cache-covers-p (scan-directory candidate-dir)
   "Return non-nil if SCAN-DIRECTORY's ancestor scan covers CANDIDATE-DIR."
@@ -1504,18 +1540,22 @@ Returns t, nil, or \\='not-cached if not in cache."
       ;; Reuse any dynamic scan whose root is below this candidate directory;
       ;; ancestor scans cover all parents of their search root.
       (maphash
-       (lambda (key scan)
+       (lambda (key entry)
          (when (and (eq answer 'not-cached)
+                    (tramp-rpc--cache-entry-valid-p (car entry))
                     (equal (car key)
                            (tramp-rpc-magit--file-connection-key expanded))
                     (tramp-rpc-magit--ancestor-cache-covers-p
                      (cdr key) file-dir))
            (setq answer
                  (tramp-rpc-magit--file-exists-in-ancestor-scan
-                  expanded scan))))
+                  expanded (cdr entry)))))
        tramp-rpc-magit--ancestor-scan-caches)
       (when (and (eq answer 'not-cached)
                  tramp-rpc-magit--ancestors-cache
+                 tramp-rpc-magit--ancestors-cache-timestamp
+                 (tramp-rpc--cache-entry-valid-p
+                  tramp-rpc-magit--ancestors-cache-timestamp)
                  tramp-rpc-magit--prefetch-directory
                  (equal (tramp-rpc-magit--file-connection-key expanded)
                         (tramp-rpc-magit--file-connection-key

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -1215,8 +1215,7 @@ DIRENV-ENV is an optional alist of environment variables for the process."
                    :rpc-pty t
                    :poll-timer nil)
              tramp-rpc--pty-processes)
-    ;; Preserve the connection plist itself: PTY exit uses it to send its
-    ;; close request through the exact transport generation that created it.
+    ;; PTY exit uses the exact transport generation that created it.
     (process-put local-process :tramp-rpc-connection connection)
     (process-put local-process :tramp-rpc-connection-process
                  (plist-get connection :process))
@@ -1327,7 +1326,10 @@ RESPONSE is the decoded RPC response plist."
                (connection (process-get local-process :tramp-rpc-connection)))
       (ignore-errors
         (tramp-rpc--call vec "process.close_pty" `((pid . ,pid)) connection)))
-    (process-put local-process :tramp-rpc-exit-code (or exit-code 0))
+    ;; A terminal server response without a status is abnormal.  In
+    ;; particular, do not translate a killed remote PTY into local success.
+    (process-put local-process :tramp-rpc-exit-code
+                 (if (integerp exit-code) exit-code -1))
     (process-put local-process :tramp-rpc-exited t)
     ;; Close the relay's local stdin and let cat flush the final PTY bytes
     ;; before exiting naturally.  A zero-timeout `accept-process-output' after

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -495,6 +495,7 @@ proxy hops remain."
 (declare-function tramp-rpc--cache-get "tramp-rpc-magit")
 (declare-function tramp-rpc--cache-put "tramp-rpc-magit")
 (declare-function tramp-rpc--cache-lookup "tramp-rpc-magit")
+(declare-function tramp-rpc--cache-entry-valid-p "tramp-rpc-magit")
 (declare-function tramp-rpc--file-stat-cache-key "tramp-rpc-magit")
 (declare-function tramp-rpc--cache-file-stat-result "tramp-rpc-magit")
 (declare-function tramp-rpc--invalidate-cache-for-path "tramp-rpc-magit")
@@ -608,6 +609,17 @@ ControlMaster socket, so authentication is already handled.
 
 Note: `signal-process' on direct SSH PTY sends signal to the local SSH
 process, which may not propagate to the remote process in all cases."
+  :type 'boolean
+  :group 'tramp-rpc)
+
+(defcustom tramp-rpc-synchronous-pipe-writes nil
+  "Whether pipe process writes wait for remote acknowledgement.
+When nil, `process-send-string' and `process-send-region' enqueue ordered
+writes and return without a network round trip.  Asynchronous failures are
+reported by the next write or by a flush operation such as
+`process-send-eof'.  When non-nil, every write drains its queue before
+returning, providing immediate error reporting at the cost of one or more
+round trips."
   :type 'boolean
   :group 'tramp-rpc)
 
@@ -1927,12 +1939,23 @@ Returns the request ID."
          (id (car id-and-request))
          (request (cdr id-and-request)))
     (tramp-rpc--debug "SEND-ASYNC id=%s method=%s" id method)
-    ;; Register callback with its exact transport generation.
+    ;; Register callback with its exact transport generation.  Roll registration
+    ;; back if the transport rejects the send; no response can arrive for a
+    ;; request that was never accepted by the process object.
     (puthash id callback tramp-rpc--async-callbacks)
     (puthash id process tramp-rpc--async-callback-processes)
-    ;; Send request (binary data with length prefix, no newline)
-    (process-send-string process request)
-    id))
+    (let (sent)
+      (unwind-protect
+          (prog1
+              (progn
+                ;; Send request (binary data with length prefix, no newline)
+                (process-send-string process request)
+                id)
+            (setq sent t))
+        ;; Cover errors, user quits, and any other non-local exit.
+        (unless sent
+          (remhash id tramp-rpc--async-callbacks)
+          (remhash id tramp-rpc--async-callback-processes))))))
 
 (defun tramp-rpc--call (vec method params &optional connection)
   "Call METHOD with PARAMS on the RPC server for VEC.
@@ -2432,18 +2455,23 @@ For symlinks, follows through to the target (like
 If LSTAT is non-nil, don't follow symlinks.
 Uses `tramp-rpc--call' internally but converts file-missing and
 ELOOP errors to nil (the file effectively doesn't exist for stat)."
-  (let* ((cache-key (tramp-rpc--file-stat-cache-key vec localname lstat))
-         (cached (tramp-rpc--cache-lookup tramp-rpc--file-stat-cache cache-key)))
+  (let* ((use-cache (not (eq remote-file-name-inhibit-cache t)))
+         (cache-key (tramp-rpc--file-stat-cache-key vec localname lstat))
+         (cached (if use-cache
+                     (tramp-rpc--cache-lookup tramp-rpc--file-stat-cache cache-key)
+                   'not-cached)))
     (if (not (eq cached 'not-cached))
         cached
       (let ((params (append (tramp-rpc--encode-path localname)
                             (when lstat '((lstat . t))))))
         (condition-case err
             (let ((stat (tramp-rpc--call vec "file.stat" params)))
-              (tramp-rpc--cache-file-stat-result vec localname stat lstat)
+              (when use-cache
+                (tramp-rpc--cache-file-stat-result vec localname stat lstat))
               stat)
           (file-missing
-           (tramp-rpc--cache-file-stat-result vec localname nil lstat)
+           (when use-cache
+             (tramp-rpc--cache-file-stat-result vec localname nil lstat))
            nil)
           (file-error
            ;; Return nil for ELOOP (symlink loop) and ENOTDIR (path component
@@ -2453,23 +2481,26 @@ ELOOP errors to nil (the file effectively doesn't exist for stat)."
              (if (or (string-match-p "Too many levels of symbolic links" message)
                      (string-match-p "Not a directory" message))
                  (progn
-                   (tramp-rpc--cache-file-stat-result vec localname nil lstat)
+                   (when use-cache
+                     (tramp-rpc--cache-file-stat-result vec localname nil lstat))
                    nil)
                (signal (car err) (cdr err))))))))))
 
 (defun tramp-rpc--file-exists-cache-lookup (filename)
   "Return cached `file-exists-p' value for FILENAME, or `not-cached'.
 Unlike `tramp-rpc--cache-get', this preserves cached nil values."
-  (let* ((expanded (expand-file-name filename))
+  (if (eq remote-file-name-inhibit-cache t)
+      'not-cached
+    (let* ((expanded (expand-file-name filename))
          (entry (gethash expanded tramp-rpc--file-exists-cache)))
     (if (not entry)
         'not-cached
       (let ((timestamp (car entry))
             (value (cdr entry)))
-        (if (< (- (float-time) timestamp) tramp-rpc--cache-ttl)
+        (if (tramp-rpc--cache-entry-valid-p timestamp)
             value
           (remhash expanded tramp-rpc--file-exists-cache)
-          'not-cached)))))
+          'not-cached))))))
 
 (defun tramp-rpc-handle-file-exists-p (filename)
   "Like `file-exists-p' for TRAMP-RPC files.
@@ -2491,15 +2522,18 @@ Projectile, project.el, and editorconfig during Magit section expansion."
                       (fa (tramp-get-file-property v localname "file-attributes"))
                       ((not (stringp (car fa)))))))
           (t
-           (pcase (tramp-rpc-magit--file-exists-p filename)
+           (pcase (if (eq remote-file-name-inhibit-cache t)
+                      'not-cached
+                    (tramp-rpc-magit--file-exists-p filename))
              ('not-cached
               (pcase (tramp-rpc--file-exists-cache-lookup filename)
                 ('not-cached
                  (let* ((stat (tramp-rpc--call-file-stat v localname))
                         (exists (if stat t nil)))
-                   (tramp-rpc--cache-put tramp-rpc--file-exists-cache
-                                         (expand-file-name filename)
-                                         exists)
+                   (unless (eq remote-file-name-inhibit-cache t)
+                     (tramp-rpc--cache-put tramp-rpc--file-exists-cache
+                                           (expand-file-name filename)
+                                           exists))
                    exists))
                 (cached cached)))
              (cached cached)))))))))
@@ -2551,8 +2585,9 @@ which would otherwise perform another remote stat."
 Resolves symlinks in the path.  For non-existing files, returns the
 path unchanged (after resolving any symlinks in parent directories)."
   (let* ((expanded (expand-file-name filename))
-         (cached (tramp-rpc--cache-get tramp-rpc--file-truename-cache
-                                      expanded)))
+         (cached (and (not (eq remote-file-name-inhibit-cache t))
+                      (tramp-rpc--cache-get tramp-rpc--file-truename-cache
+                                            expanded))))
     (or cached
         (let ((truename
                ;; Use tramp-skeleton-file-truename which handles:
@@ -2594,7 +2629,8 @@ path unchanged (after resolving any symlinks in parent directories)."
                            v 'file-error
                            "Maximum number (%d) of symlinks exceeded" numchase-limit)))
                       (directory-file-name result)))))))
-          (tramp-rpc--cache-put tramp-rpc--file-truename-cache expanded truename)
+          (unless (eq remote-file-name-inhibit-cache t)
+            (tramp-rpc--cache-put tramp-rpc--file-truename-cache expanded truename))
           truename))))
 
 
@@ -2608,7 +2644,8 @@ path unchanged (after resolving any symlinks in parent directories)."
         ;; for follow semantics.  For symlinks, lstat success does not tell us
         ;; whether the target exists (dangling symlink), so leave file-exists-p
         ;; uncached.
-        (unless (and result (equal (alist-get 'type result) "symlink"))
+        (unless (or (eq remote-file-name-inhibit-cache t)
+                    (and result (equal (alist-get 'type result) "symlink")))
           (let ((expanded (expand-file-name filename)))
             (tramp-rpc--cache-put tramp-rpc--file-exists-cache
                                   expanded (if result t nil))))

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -10,11 +10,13 @@ use rmpv::Value;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::thread;
+use std::process::Stdio;
+use std::sync::Arc;
 use std::time::UNIX_EPOCH;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::sync::Semaphore;
 
 use super::HandlerResult;
 
@@ -22,10 +24,10 @@ use super::HandlerResult;
 /// Prevents resource exhaustion from excessively large batches.
 const MAX_PARALLEL_COMMANDS: usize = 256;
 
-/// Run multiple commands in parallel using OS threads.
+/// Run multiple commands concurrently.
 ///
-/// Each command is spawned as an OS thread via `thread::scope`, giving true
-/// parallelism for I/O-bound operations like git commands.  Returns a map
+/// Each command is driven by Tokio, allowing transport cancellation to stop
+/// its whole process group.  Returns a map
 /// of key -> {exit_code, stdout, stderr} for each command.
 ///
 /// This replaces the old `magit.status` handler: instead of hardcoding
@@ -77,115 +79,108 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
         )));
     }
 
-    // Run all commands in parallel using OS threads (not async tasks)
-    // to get true parallelism for blocking process spawning.
-    tokio::task::spawn_blocking(move || {
-        let results: Vec<(String, Value)> = thread::scope(|s| {
-            let handles: Vec<_> = params
-                .commands
-                .into_iter()
-                .map(|entry| {
-                    s.spawn(move || {
-                        let mut cmd = Command::new(&entry.cmd);
-                        cmd.args(&entry.args);
-                        if let Some(ref cwd) = entry.cwd {
-                            cmd.current_dir(super::expand_tilde(cwd));
+    // This budget is shared by every command in the batch, so one chatty
+    // command cannot push the combined response over the frame limit.
+    let remaining = Arc::new(Semaphore::new(crate::MAX_RESPONSE_OUTPUT_BYTES));
+    let results = futures::future::join_all(params.commands.into_iter().map(|entry| {
+        let remaining = Arc::clone(&remaining);
+        async move {
+            let mut cmd = Command::new(&entry.cmd);
+            cmd.args(&entry.args);
+            if let Some(ref cwd) = entry.cwd {
+                cmd.current_dir(super::expand_tilde(cwd));
+            }
+            cmd.stdin(if entry.stdin.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            });
+            cmd.stdout(Stdio::piped());
+            cmd.stderr(Stdio::piped());
+            cmd.kill_on_drop(true);
+            super::process::configure_process_group(&mut cmd);
+
+            let value = match cmd.spawn() {
+                Ok(mut child) => {
+                    let Some(child_pid) = child.id() else {
+                        return (
+                            entry.key,
+                            msgpack_map! {
+                                "exit_code" => -1i32,
+                                "stdout" => Value::Binary(vec![]),
+                                "stderr" => Value::Binary(b"Spawned process has no PID".to_vec())
+                            },
+                        );
+                    };
+                    let mut process_group = super::process::ProcessGroupGuard::new(child_pid);
+                    let stdin_data = entry.stdin;
+                    let mut stdin = child.stdin.take();
+                    let stdout = child.stdout.take().expect("piped stdout");
+                    let stderr = child.stderr.take().expect("piped stderr");
+                    let write_stdin = async move {
+                        if let Some(data) = stdin_data
+                            && let Some(mut stdin) = stdin.take()
+                            && let Err(error) = stdin.write_all(&data).await
+                            // A child that stops reading early is not an error.
+                            && !super::process::is_benign_stdin_error(&error)
+                        {
+                            return Err(std::io::Error::other(format!(
+                                "Failed to write stdin: {error}"
+                            )));
                         }
-                        cmd.stdin(if entry.stdin.is_some() {
-                            Stdio::piped()
-                        } else {
-                            Stdio::null()
-                        });
-                        cmd.stdout(Stdio::piped());
-                        cmd.stderr(Stdio::piped());
-                        let value = match cmd.spawn() {
-                            Ok(mut child) => {
-                                let stdin_data = entry.stdin;
-                                let stdin = child.stdin.take();
-                                // Keep writing and draining output concurrent: a
-                                // child may fill stdout while it reads stdin.
-                                let write_result = thread::scope(|scope| {
-                                    let writer = scope.spawn(move || {
-                                        if let Some(data) = stdin_data
-                                            && let Some(mut stdin) = stdin
-                                        {
-                                            match stdin.write_all(&data) {
-                                                // A child that stops reading
-                                                // early is not an error.
-                                                Err(error)
-                                                    if super::process::is_benign_stdin_error(
-                                                        &error,
-                                                    ) =>
-                                                {
-                                                    Ok(())
-                                                }
-                                                result => result,
-                                            }
-                                        } else {
-                                            Ok(())
-                                        }
-                                    });
-                                    let output = child.wait_with_output();
-                                    let write_result = writer.join().unwrap_or_else(|_| {
-                                        Err(std::io::Error::other("stdin writer panicked"))
-                                    });
-                                    (output, write_result)
-                                });
-                                match write_result {
-                                    (Ok(output), Ok(())) => msgpack_map! {
-                                        "exit_code" => exit_code_from_status(output.status),
-                                        "stdout" => Value::Binary(output.stdout),
-                                        "stderr" => Value::Binary(output.stderr)
-                                    },
-                                    // Report the failure without discarding
-                                    // what the child already produced.
-                                    (Ok(output), Err(error)) => {
-                                        let mut stderr = output.stderr;
-                                        stderr.extend_from_slice(
-                                            format!("Failed to write stdin: {error}\n").as_bytes(),
-                                        );
-                                        msgpack_map! {
-                                            "exit_code" => -1i32,
-                                            "stdout" => Value::Binary(output.stdout),
-                                            "stderr" => Value::Binary(stderr)
-                                        }
-                                    }
-                                    (Err(error), _) => msgpack_map! {
-                                        "exit_code" => -1i32,
-                                        "stdout" => Value::Binary(vec![]),
-                                        "stderr" => Value::Binary(error.to_string().into_bytes())
-                                    },
-                                }
+                        Ok(())
+                    };
+                    let result = tokio::try_join!(
+                        write_stdin,
+                        super::process::read_sync_output(
+                            stdout,
+                            Arc::clone(&remaining),
+                            crate::MAX_RESPONSE_OUTPUT_BYTES,
+                        ),
+                        super::process::read_sync_output(
+                            stderr,
+                            remaining,
+                            crate::MAX_RESPONSE_OUTPUT_BYTES,
+                        ),
+                        child.wait()
+                    );
+                    match result {
+                        Ok(((), stdout, stderr, status)) => {
+                            process_group.disarm();
+                            msgpack_map! {
+                                "exit_code" => exit_code_from_status(status),
+                                "stdout" => Value::Binary(stdout),
+                                "stderr" => Value::Binary(stderr)
                             }
-                            Err(e) => {
-                                msgpack_map! {
-                                    "exit_code" => -1i32,
-                                    "stdout" => Value::Binary(vec![]),
-                                    "stderr" => Value::Binary(e.to_string().into_bytes())
-                                }
+                        }
+                        Err(error) => {
+                            let _ = child.kill().await;
+                            let _ = child.wait().await;
+                            msgpack_map! {
+                                "exit_code" => -1i32,
+                                "stdout" => Value::Binary(vec![]),
+                                "stderr" => Value::Binary(error.to_string().into_bytes())
                             }
-                        };
-                        (entry.key, value)
-                    })
-                })
-                .collect();
+                        }
+                    }
+                }
+                Err(error) => msgpack_map! {
+                    "exit_code" => -1i32,
+                    "stdout" => Value::Binary(vec![]),
+                    "stderr" => Value::Binary(error.to_string().into_bytes())
+                },
+            };
+            (entry.key, value)
+        }
+    }))
+    .await;
 
-            // Recover from thread panics instead of unwinding
-            handles
-                .into_iter()
-                .filter_map(|h| h.join().ok()) // thread panicked; skip this result
-                .collect()
-        });
-
-        let pairs: Vec<(Value, Value)> = results
+    Ok(Value::Map(
+        results
             .into_iter()
-            .map(|(k, v)| (Value::String(k.into()), v))
-            .collect();
-
-        Ok(Value::Map(pairs))
-    })
-    .await
-    .map_err(|e| RpcError::internal_error(format!("Task join error: {}", e)))?
+            .map(|(key, value)| (Value::String(key.into()), value))
+            .collect(),
+    ))
 }
 
 /// Scan ancestor directories for marker files

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -32,8 +32,8 @@ pub async fn dispatch(request: Request) -> Response {
 }
 
 /// Signal and reap managed async children before a connection task exits.
-pub async fn cleanup_managed_processes() {
-    process::cleanup_managed_processes().await;
+pub async fn cleanup_managed_processes() -> Result<(), RpcError> {
+    process::cleanup_managed_processes().await
 }
 
 pub type HandlerResult = Result<Value, RpcError>;

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -4,6 +4,7 @@ use crate::msgpack_map;
 use crate::protocol::{ProcessResult, RpcError, from_value};
 use nix::pty::{OpenptyResult, openpty};
 use nix::sys::signal::Signal;
+use nix::sys::termios::{LocalFlags, OutputFlags, SetArg, tcgetattr, tcsetattr};
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, tcgetpgrp};
 use rmpv::Value;
@@ -35,26 +36,24 @@ pub(crate) fn is_benign_stdin_error(error: &std::io::Error) -> bool {
     )
 }
 
-async fn read_sync_output<R>(
+pub(crate) async fn read_sync_output<R>(
     mut reader: R,
     remaining: Arc<Semaphore>,
     output_limit: usize,
-) -> Result<Vec<u8>, RpcError>
+) -> std::io::Result<Vec<u8>>
 where
     R: AsyncRead + Unpin,
 {
     let mut output = Vec::new();
     let mut buffer = [0u8; 8192];
     loop {
-        let read = reader.read(&mut buffer).await.map_err(|error| {
-            RpcError::process_error(format!("Failed to read process output: {error}"))
-        })?;
+        let read = reader.read(&mut buffer).await?;
         if read == 0 {
             return Ok(output);
         }
         let permits = u32::try_from(read).expect("output buffer length fits in u32");
         let permit = remaining.try_acquire_many(permits).map_err(|_| {
-            RpcError::process_error(format!("Process output exceeds {output_limit} byte limit"))
+            std::io::Error::other(format!("Process output exceeds {output_limit} byte limit"))
         })?;
         // Consumed permits represent bytes retained in the response buffers.
         permit.forget();
@@ -141,6 +140,51 @@ fn spawn_error(error: std::io::Error, executable_missing: bool) -> RpcError {
     }
 }
 
+/// Own a newly spawned child process group until its request finishes.
+///
+/// Request tasks are aborted when their RPC transport disappears.  Tokio can
+/// kill the direct child on drop, but descendants would otherwise survive, so
+/// this guard synchronously kills the whole group when the request future is
+/// cancelled.  It is disarmed immediately after the direct child is reaped.
+pub(crate) struct ProcessGroupGuard {
+    pgid: Option<u32>,
+}
+
+impl ProcessGroupGuard {
+    pub(crate) fn new(pgid: u32) -> Self {
+        Self { pgid: Some(pgid) }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.pgid = None;
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(pgid) = self.pgid {
+            // Best effort only: Drop cannot report an error and ESRCH means the
+            // group already exited.  Negating PGID targets the whole group.
+            unsafe {
+                libc::kill(-(pgid as i32), libc::SIGKILL);
+            }
+        }
+    }
+}
+
+pub(crate) fn configure_process_group(cmd: &mut Command) {
+    // Keep descendants in a group owned by this request, separate from the
+    // server and unrelated processes.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setpgid(0, 0) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
 #[cfg(test)]
 pub(crate) async fn wait_for_process_exit(pid: i32) {
     for _ in 0..100 {
@@ -194,7 +238,13 @@ pub(crate) async fn test_process_map_lock() -> tokio::sync::MutexGuard<'static, 
 
 #[cfg(test)]
 pub(crate) async fn test_managed_maps_empty() -> bool {
-    get_process_map().lock().await.is_empty() && get_pty_process_map().lock().await.is_empty()
+    get_process_map().lock().await.is_empty()
+        && get_pty_process_map().lock().await.is_empty()
+        && TERMINATED_PTY_STATUSES
+            .get_or_init(|| StdMutex::new(HashMap::new()))
+            .lock()
+            .expect("terminated PTY status lock")
+            .is_empty()
 }
 
 #[cfg(test)]
@@ -203,7 +253,7 @@ pub(crate) async fn test_managed_os_pids() -> Vec<i32> {
         .lock()
         .await
         .values()
-        .filter_map(|managed| managed.child.id().map(|pid| pid as i32))
+        .map(|managed| managed.child_pid as i32)
         .collect();
     pids.extend(
         get_pty_process_map()
@@ -231,6 +281,7 @@ struct ManagedProcess {
     child: Child,
     child_pid: u32,
     lifecycle: Arc<Mutex<()>>,
+    read_lock: Arc<Mutex<()>>,
     exit_status: Option<ExitStatus>,
     shared_exit_status: Arc<StdMutex<Option<ExitStatus>>>,
     stdin: Arc<Mutex<Option<ChildStdin>>>,
@@ -300,6 +351,7 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     cmd.kill_on_drop(true);
+    configure_process_group(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(child) => child,
@@ -314,6 +366,10 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
             return Err(spawn_error(error, executable_missing));
         }
     };
+    let child_pid = child
+        .id()
+        .ok_or_else(|| RpcError::process_error("Spawned process has no PID"))?;
+    let mut process_group = ProcessGroupGuard::new(child_pid);
 
     // Drive stdin, bounded output drains, and child exit concurrently.  A
     // genuine pipe or size error cancels the other operations and kills the
@@ -335,11 +391,11 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
             && let Err(error) = stdin.write_all(&data).await
             && !is_benign_stdin_error(&error)
         {
-            return Err(RpcError::process_error(format!(
+            return Err(std::io::Error::other(format!(
                 "Failed to write stdin: {error}"
             )));
         }
-        Ok::<(), RpcError>(())
+        Ok::<(), std::io::Error>(())
     };
     // This budget is shared by stdout and stderr for this request.  It is
     // intentionally per-run rather than server-wide, so admission permits up
@@ -353,7 +409,7 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
             child
                 .wait()
                 .await
-                .map_err(|e| RpcError::process_error(format!("Failed to wait for process: {e}")))
+                .map_err(|e| std::io::Error::other(format!("Failed to wait for process: {e}")))
         }
     );
     let ((), stdout, stderr, status) = match result {
@@ -361,9 +417,10 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
         Err(error) => {
             let _ = child.kill().await;
             let _ = child.wait().await;
-            return Err(error);
+            return Err(RpcError::process_error(error.to_string()));
         }
     };
+    process_group.disarm();
 
     // Return binary data directly (no encoding needed!)
     let exit_code = crate::protocol::exit_code_from_status(status);
@@ -417,17 +474,12 @@ pub async fn start(params: Value) -> HandlerResult {
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    // If the request is cancelled before registry ownership transfers, dropping
+    // the child must terminate the direct process while the group guard below
+    // terminates descendants.
+    cmd.kill_on_drop(true);
 
-    // Keep descendants in a group we can terminate without affecting the
-    // server or unrelated processes.
-    unsafe {
-        cmd.pre_exec(|| {
-            if libc::setpgid(0, 0) < 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
+    configure_process_group(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(child) => child,
@@ -442,25 +494,30 @@ pub async fn start(params: Value) -> HandlerResult {
             return Err(spawn_error(error, executable_missing));
         }
     };
-
     let child_pid = child
         .id()
         .ok_or_else(|| RpcError::process_error("Spawned process has no PID"))?;
+    let mut process_group = ProcessGroupGuard::new(child_pid);
+
     let pid = get_next_pid().await;
 
     let managed = ManagedProcess {
-        child_pid,
         lifecycle: Arc::new(Mutex::new(())),
+        read_lock: Arc::new(Mutex::new(())),
         exit_status: None,
         shared_exit_status: Arc::new(StdMutex::new(None)),
         stdin: Arc::new(Mutex::new(child.stdin.take())),
         stdout: Arc::new(Mutex::new(child.stdout.take())),
         stderr: Arc::new(Mutex::new(child.stderr.take())),
         child,
+        child_pid,
         cmd: params.cmd.clone(),
     };
 
     get_process_map().lock().await.insert(pid, managed);
+    // The registry now owns termination and reaping.  There are no await points
+    // between insertion and disarming, so cancellation cannot strand the child.
+    process_group.disarm();
 
     Ok(msgpack_map! {
         "pid" => pid
@@ -540,7 +597,7 @@ pub async fn read(params: Value) -> HandlerResult {
 
     let timeout = params.timeout_ms.unwrap_or(0);
 
-    let (stdout, stderr, lifecycle, shared_exit_status) = {
+    let (stdout, stderr, lifecycle, read_lock, shared_exit_status) = {
         let processes = get_process_map().lock().await;
         let managed = processes
             .get(&params.pid)
@@ -549,9 +606,15 @@ pub async fn read(params: Value) -> HandlerResult {
             managed.stdout.clone(),
             managed.stderr.clone(),
             managed.lifecycle.clone(),
+            managed.read_lock.clone(),
             managed.shared_exit_status.clone(),
         )
     };
+
+    // A read owns output consumption through the terminal map-removal decision.
+    // This prevents a concurrent EOF reader from removing bytes another request
+    // has already consumed but not yet returned.
+    let _read_guard = read_lock.lock().await;
 
     // Try to read stdout/stderr (with optional blocking timeout) without
     // holding the global process map lock.  `process.read` is long-polled by
@@ -816,7 +879,27 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
     Ok(Value::Boolean(true))
 }
 
+#[cfg(test)]
+static TEST_PROCESS_GROUP_SIGNAL_ERROR: OnceLock<StdMutex<Option<i32>>> = OnceLock::new();
+
+#[cfg(test)]
+fn set_test_process_group_signal_error(error: Option<i32>) {
+    *TEST_PROCESS_GROUP_SIGNAL_ERROR
+        .get_or_init(|| StdMutex::new(None))
+        .lock()
+        .expect("test process-group signal error lock") = error;
+}
+
 fn signal_process_group(pid: u32, signal: i32) -> std::io::Result<()> {
+    #[cfg(test)]
+    if let Some(error) = *TEST_PROCESS_GROUP_SIGNAL_ERROR
+        .get_or_init(|| StdMutex::new(None))
+        .lock()
+        .expect("test process-group signal error lock")
+    {
+        return Err(std::io::Error::from_raw_os_error(error));
+    }
+
     let result = unsafe { libc::kill(-(pid as libc::pid_t), signal) };
     if result == 0 {
         Ok(())
@@ -887,6 +970,7 @@ async fn wait_pipe_child(os_pid: u32) -> Result<Option<ExitStatus>, nix::errno::
             // lifecycle lock is not held.  The map entry remains until its
             // streams reach EOF, even in that case.
             Err(nix::errno::Errno::ECHILD) => return Ok(None),
+            Err(nix::errno::Errno::EINTR) => continue,
             Err(error) => return Err(error),
             Ok(_) => return Err(nix::errno::Errno::EINVAL),
         }
@@ -934,7 +1018,7 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
             )
         })
     }) else {
-        return Ok(true);
+        return Err(RpcError::process_error(format!("Process not found: {pid}")));
     };
 
     let _lifecycle_guard = lifecycle.lock().await;
@@ -971,13 +1055,14 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
         return Ok(true);
     }
 
-    let mut reap = if let Some(exit_status) = cached {
-        Some(Some(exit_status))
+    let mut reap = if cached.is_some() {
+        cached
     } else {
         tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(os_pid))
             .await
             .ok()
             .and_then(Result::ok)
+            .flatten()
     };
     // Give the whole process group its own grace period after the bounded
     // direct-child reap wait.  Starting this deadline before that wait would
@@ -994,14 +1079,14 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
     if reap.is_none() && escalate {
         reap = tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(os_pid))
             .await
-            .ok()
-            .and_then(Result::ok);
+            .map_err(|_| {
+                RpcError::process_error(format!("Timed out reaping process {pid} after SIGKILL"))
+            })?
+            .map_err(|error| {
+                RpcError::process_error(format!("Failed to reap process {pid}: {error}"))
+            })?;
     }
-    // `reap` is `Some(None)` when the child was already reaped (ECHILD), for
-    // example by an earlier kill.  Never overwrite a recorded status with
-    // `None` in that case: `try_wait` cannot recover it after an external
-    // waitpid, so clobbering it would wedge every subsequent read.
-    if let Some(exit_status) = reap.flatten() {
+    if let Some(exit_status) = reap {
         // Publish before any destructive cleanup so a read which captured the
         // streams before SIGKILL removed the entry can still report its exit.
         *shared_exit_status
@@ -1011,6 +1096,7 @@ async fn terminate_pipe_process(pid: u32, signal: i32, escalate: bool) -> Result
             managed.exit_status = Some(exit_status);
         }
         if signal == libc::SIGKILL {
+            // Explicit SIGKILL is the caller's opt-out from output draining.
             get_process_map().lock().await.remove(&pid);
         }
         return Ok(true);
@@ -1067,11 +1153,18 @@ pub async fn status(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
+    let lifecycle = {
+        let processes = get_process_map().lock().await;
+        processes
+            .get(&params.pid)
+            .map(|managed| managed.lifecycle.clone())
+            .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?
+    };
+    let _lifecycle_guard = lifecycle.lock().await;
     let mut processes = get_process_map().lock().await;
     let managed = processes
         .get_mut(&params.pid)
         .ok_or_else(|| RpcError::process_error(format!("Process not found: {}", params.pid)))?;
-
     let exit_status = poll_exit_status(managed)
         .map_err(|e| RpcError::process_error(format!("Failed to query process status: {e}")))?;
 
@@ -1083,21 +1176,30 @@ pub async fn status(params: Value) -> HandlerResult {
 
 /// List all managed async processes
 pub async fn list(_params: Value) -> HandlerResult {
-    let mut processes = get_process_map().lock().await;
-
-    let list: Vec<Value> = processes
-        .iter_mut()
-        .map(|(pid, managed)| {
-            let exited = poll_exit_status(managed).ok().flatten();
-            msgpack_map! {
-                "pid" => *pid,
-                "os_pid" => managed.child_pid,
-                "cmd" => managed.cmd.clone(),
-                "exited" => exited.is_some(),
-                "exit_code" => exited.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
-            }
-        })
-        .collect();
+    let entries: Vec<(u32, Arc<Mutex<()>>)> = {
+        let processes = get_process_map().lock().await;
+        processes
+            .iter()
+            .map(|(pid, managed)| (*pid, managed.lifecycle.clone()))
+            .collect()
+    };
+    let mut list = Vec::with_capacity(entries.len());
+    for (pid, lifecycle) in entries {
+        let _lifecycle_guard = lifecycle.lock().await;
+        let mut processes = get_process_map().lock().await;
+        let Some(managed) = processes.get_mut(&pid) else {
+            continue;
+        };
+        let exited = poll_exit_status(managed)
+            .map_err(|e| RpcError::process_error(format!("Failed to query process status: {e}")))?;
+        list.push(msgpack_map! {
+            "pid" => pid,
+            "os_pid" => Value::Integer((managed.child_pid as i64).into()),
+            "cmd" => managed.cmd.clone(),
+            "exited" => exited.is_some(),
+            "exit_code" => exited.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        });
+    }
 
     Ok(Value::Array(list))
 }
@@ -1112,10 +1214,39 @@ use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 
 static PTY_PROCESS_MAP: OnceLock<Mutex<HashMap<u32, ManagedPtyProcess>>> = OnceLock::new();
+static TERMINATED_PTY_STATUSES: OnceLock<StdMutex<HashMap<u32, i32>>> = OnceLock::new();
 static PTY_PID_COUNTER: OnceLock<Mutex<u32>> = OnceLock::new();
 
 fn get_pty_process_map() -> &'static Mutex<HashMap<u32, ManagedPtyProcess>> {
     PTY_PROCESS_MAP.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn record_terminated_pty_status(pid: u32, exit_code: i32) {
+    TERMINATED_PTY_STATUSES
+        .get_or_init(|| StdMutex::new(HashMap::new()))
+        .lock()
+        .expect("terminated PTY status lock")
+        .insert(pid, exit_code);
+}
+
+fn take_terminated_pty_status(pid: u32) -> Option<i32> {
+    TERMINATED_PTY_STATUSES
+        .get_or_init(|| StdMutex::new(HashMap::new()))
+        .lock()
+        .expect("terminated PTY status lock")
+        .remove(&pid)
+}
+
+fn discard_terminated_pty_status(pid: u32) {
+    let _ = take_terminated_pty_status(pid);
+}
+
+fn clear_terminated_pty_statuses() {
+    TERMINATED_PTY_STATUSES
+        .get_or_init(|| StdMutex::new(HashMap::new()))
+        .lock()
+        .expect("terminated PTY status lock")
+        .clear();
 }
 
 async fn get_next_pty_pid() -> u32 {
@@ -1160,6 +1291,9 @@ struct ManagedPtyProcess {
     child_pid: Pid,
     cmd: String,
     exit_status: Option<i32>,
+    // Retain an observed terminal status for a read that captured the PTY
+    // before explicit SIGKILL removes its registry entry.
+    shared_exit_status: Arc<StdMutex<Option<i32>>>,
     output_eof: bool,
 }
 
@@ -1307,6 +1441,18 @@ impl Drop for PtyStartupGuard {
 fn do_fork_exec(params: PtyStartParams) -> Result<PtyStartupGuard, RpcError> {
     let OpenptyResult { master, slave } = openpty(None, None)
         .map_err(|e| RpcError::process_error(format!("Failed to open PTY: {}", e)))?;
+
+    // Emacs inserts interactive input into comint buffers itself.  Disable
+    // kernel echo to avoid delivering every input line twice, and preserve LF
+    // output instead of the terminal driver's CRLF conversion.
+    let mut termios = tcgetattr(&slave)
+        .map_err(|e| RpcError::process_error(format!("Failed to read PTY termios: {e}")))?;
+    termios
+        .local_flags
+        .remove(LocalFlags::ECHO | LocalFlags::ECHONL);
+    termios.output_flags.remove(OutputFlags::ONLCR);
+    tcsetattr(&slave, SetArg::TCSANOW, &termios)
+        .map_err(|e| RpcError::process_error(format!("Failed to configure PTY termios: {e}")))?;
 
     set_fd_cloexec(master.as_raw_fd())
         .map_err(|e| RpcError::process_error(format!("Failed to mark PTY CLOEXEC: {}", e)))?;
@@ -1472,6 +1618,7 @@ pub async fn start_pty(params: Value) -> HandlerResult {
         child_pid,
         cmd: params.cmd.clone(),
         exit_status: None,
+        shared_exit_status: Arc::new(StdMutex::new(None)),
         output_eof: false,
     };
 
@@ -1598,30 +1745,42 @@ async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadResult, RpcEr
     // readiness.  Registry removal can then safely close the original fd
     // without invalidating this read or allowing fd-number reuse to target a
     // newly-created PTY.
-    let (lifecycle, io, fd) = {
+    let (lifecycle, io, shared_exit_status, fd) = {
         let processes = get_pty_process_map().lock().await;
         let Some(managed) = processes.get(&pid) else {
             return Ok(PtyReadResult {
                 output: Vec::new(),
                 pending: false,
                 exited: true,
-                exit_code: None,
+                exit_code: take_terminated_pty_status(pid),
             });
         };
         let fd = dup_cloexec(managed.async_fd.get_ref().as_raw_fd())
             .map_err(|e| RpcError::process_error(format!("Failed to duplicate PTY: {e}")))?;
-        (managed.lifecycle.clone(), managed.io.clone(), fd)
+        (
+            managed.lifecycle.clone(),
+            managed.io.clone(),
+            managed.shared_exit_status.clone(),
+            fd,
+        )
     };
     // SAFETY: dup_cloexec returned a fresh descriptor owned by this read.
     let owned_fd = unsafe { OwnedFd::from_raw_fd(fd) };
     let _lifecycle_guard = lifecycle.lock().await;
     let mut processes = get_pty_process_map().lock().await;
     let Some(managed) = processes.get_mut(&pid) else {
+        // Explicit SIGKILL intentionally discards output and removes registry
+        // ownership.  A read already in flight still owns this status handle,
+        // so report the terminal remote result rather than local success.
+        let shared_status = *shared_exit_status
+            .lock()
+            .expect("shared PTY exit status lock");
+        let retained_status = take_terminated_pty_status(pid);
         return Ok(PtyReadResult {
             output: Vec::new(),
             pending: false,
             exited: true,
-            exit_code: None,
+            exit_code: shared_status.or(retained_status),
         });
     };
 
@@ -1691,11 +1850,19 @@ fn check_exit_status(managed: &mut ManagedPtyProcess) -> (bool, Option<i32>) {
         match waitpid(managed.child_pid, Some(WaitPidFlag::WNOHANG)) {
             Ok(WaitStatus::Exited(_, code)) => {
                 managed.exit_status = Some(code);
+                *managed
+                    .shared_exit_status
+                    .lock()
+                    .expect("shared PTY exit status lock") = Some(code);
                 (true, Some(code))
             }
             Ok(WaitStatus::Signaled(_, signal, _)) => {
                 let code = 128 + signal as i32;
                 managed.exit_status = Some(code);
+                *managed
+                    .shared_exit_status
+                    .lock()
+                    .expect("shared PTY exit status lock") = Some(code);
                 (true, Some(code))
             }
             Ok(WaitStatus::StillAlive) => (false, None),
@@ -1853,6 +2020,7 @@ async fn wait_pty_pid(child_pid: Pid) -> Result<Option<i32>, nix::errno::Errno> 
                 tokio::time::sleep(std::time::Duration::from_millis(5)).await;
             }
             Err(nix::errno::Errno::ECHILD) => return Ok(None),
+            Err(nix::errno::Errno::EINTR) => continue,
             Err(error) => return Err(error),
             Ok(_) => return Err(nix::errno::Errno::EINVAL),
         }
@@ -1864,18 +2032,26 @@ async fn terminate_pty_process(
     signal: i32,
     escalate: bool,
     remove: bool,
+    retain_removed_status: bool,
 ) -> Result<bool, RpcError> {
-    let Some((os_pid, lifecycle, io)) = ({
+    let Some((os_pid, lifecycle, io, shared_exit_status)) = ({
         let processes = get_pty_process_map().lock().await;
         processes.get(&pid).map(|managed| {
             (
                 managed.child_pid.as_raw() as u32,
                 managed.lifecycle.clone(),
                 managed.io.clone(),
+                managed.shared_exit_status.clone(),
             )
         })
     }) else {
-        return Ok(true);
+        return if remove {
+            Ok(true)
+        } else {
+            Err(RpcError::process_error(format!(
+                "PTY process not found: {pid}"
+            )))
+        };
     };
     // Explicit teardown and SIGKILL must wake a writer blocked on readiness
     // immediately.  Other forwarded signals (notably SIGINT) are survivable
@@ -1896,25 +2072,33 @@ async fn terminate_pty_process(
         .await
         .get(&pid)
         .and_then(|managed| managed.exit_status);
-    if cached.is_some() && !escalate {
+    if let Some(cached_exit_code) = cached
+        && !escalate
+    {
         // A previously reaped direct child is confirmed terminal death, even
         // when a caller used a non-fatal signal for this request.
         io.cancel();
         if remove {
+            *shared_exit_status
+                .lock()
+                .expect("shared PTY exit status lock") = Some(cached_exit_code);
+            if retain_removed_status {
+                record_terminated_pty_status(pid, cached_exit_code);
+            }
             get_pty_process_map().lock().await.remove(&pid);
         }
         return Ok(true);
     }
 
     // As with pipe children: only wait for death on signals expected to
-    // terminate the child; non-fatal forwarded signals must not stall the
+    // terminate the child; a surviving SIGINT/SIGUSR1 must not stall the
     // client for the wait budget.  Exits are reaped by later read polls.
     if !(escalate || signal == libc::SIGTERM || signal == libc::SIGKILL) {
         return Ok(true);
     }
 
-    let mut reap = if let Some(exit_code) = cached {
-        Some(Some(exit_code))
+    let mut reap = if cached.is_some() {
+        cached
     } else {
         tokio::time::timeout(
             MANAGED_PTY_CHILD_WAIT,
@@ -1923,6 +2107,7 @@ async fn terminate_pty_process(
         .await
         .ok()
         .and_then(Result::ok)
+        .flatten()
     };
     // Start the process-group grace only after the direct-child reap wait.
     // Otherwise a TERM-ignoring child consumes all of its descendants' grace.
@@ -1939,16 +2124,18 @@ async fn terminate_pty_process(
     }
     if reap.is_none() && escalate {
         reap = tokio::time::timeout(
-            MANAGED_PTY_CHILD_WAIT,
+            MANAGED_CHILD_WAIT,
             wait_pty_pid(Pid::from_raw(os_pid as i32)),
         )
         .await
-        .ok()
-        .and_then(Result::ok);
+        .map_err(|_| {
+            RpcError::process_error(format!("Timed out reaping PTY process {pid} after SIGKILL"))
+        })?
+        .map_err(|error| {
+            RpcError::process_error(format!("Failed to reap PTY process {pid}: {error}"))
+        })?;
     }
-    // `reap` is `Some(None)` when the child was already reaped (ECHILD); do
-    // not overwrite a previously recorded exit status in that case.
-    if let Some(exit_code) = reap.flatten() {
+    if let Some(exit_code) = reap {
         // Reaping confirms terminal death, so no further PTY input can be
         // admitted.  This also wakes a writer that was waiting for readiness.
         io.cancel();
@@ -1957,6 +2144,15 @@ async fn terminate_pty_process(
         // explicit close.
         let mut processes = get_pty_process_map().lock().await;
         if remove {
+            // Publish before discarding registry ownership.  An in-flight
+            // read holds this Arc and must report the killed remote process,
+            // not nil/zero local relay success.
+            *shared_exit_status
+                .lock()
+                .expect("shared PTY exit status lock") = Some(exit_code);
+            if retain_removed_status {
+                record_terminated_pty_status(pid, exit_code);
+            }
             processes.remove(&pid);
         } else if let Some(managed) = processes.get_mut(&pid) {
             managed.exit_status = Some(exit_code);
@@ -1965,8 +2161,18 @@ async fn terminate_pty_process(
     }
 
     if remove {
-        // Explicit close discards the PTY even if its status was already
-        // consumed by another status poll.
+        // SIGKILL was delivered but the bounded reap did not observe a status
+        // (for example, another waiter consumed it).  The explicit kill still
+        // has deterministic abnormal process semantics for an in-flight read.
+        let exit_code = {
+            let mut status = shared_exit_status
+                .lock()
+                .expect("shared PTY exit status lock");
+            *status.get_or_insert(128 + libc::SIGKILL)
+        };
+        if retain_removed_status {
+            record_terminated_pty_status(pid, exit_code);
+        }
         get_pty_process_map().lock().await.remove(&pid);
         return Ok(true);
     }
@@ -2003,7 +2209,15 @@ pub async fn kill_pty(params: Value) -> HandlerResult {
     // Match local signal-process semantics: forward the requested signal
     // without turning a survivable signal such as SIGINT into SIGKILL.
     // Explicit close and connection cleanup retain escalation authority.
-    terminate_pty_process(params.pid, params.signal, false, false).await?;
+    // Explicit SIGKILL also opts out of output draining.
+    terminate_pty_process(
+        params.pid,
+        params.signal,
+        false,
+        params.signal == libc::SIGKILL,
+        params.signal == libc::SIGKILL,
+    )
+    .await?;
     Ok(Value::Boolean(true))
 }
 
@@ -2016,35 +2230,42 @@ pub async fn close_pty(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
     // Explicit close is the opt-out from kill's drain-preserving ownership.
-    terminate_pty_process(params.pid, libc::SIGKILL, true, true).await?;
+    terminate_pty_process(params.pid, libc::SIGKILL, true, true, false).await?;
+    discard_terminated_pty_status(params.pid);
     Ok(Value::Boolean(true))
 }
 
 /// List all PTY processes
 pub async fn list_pty(_params: Value) -> HandlerResult {
-    let mut processes = get_pty_process_map().lock().await;
-
-    let list: Vec<Value> = processes
-        .iter_mut()
-        .map(|(pid, managed)| {
-            let (exited, exit_code) = check_exit_status(managed);
-
-            msgpack_map! {
-                "pid" => *pid,
-                "os_pid" => managed.child_pid.as_raw(),
-                "cmd" => managed.cmd.clone(),
-                "exited" => exited,
-                "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
-            }
-        })
-        .collect();
+    let entries: Vec<(u32, Arc<Mutex<()>>)> = {
+        let processes = get_pty_process_map().lock().await;
+        processes
+            .iter()
+            .map(|(pid, managed)| (*pid, managed.lifecycle.clone()))
+            .collect()
+    };
+    let mut list = Vec::with_capacity(entries.len());
+    for (pid, lifecycle) in entries {
+        let _lifecycle_guard = lifecycle.lock().await;
+        let mut processes = get_pty_process_map().lock().await;
+        let Some(managed) = processes.get_mut(&pid) else {
+            continue;
+        };
+        let (exited, exit_code) = check_exit_status(managed);
+        list.push(msgpack_map! {
+            "pid" => pid,
+            "os_pid" => managed.child_pid.as_raw(),
+            "cmd" => managed.cmd.clone(),
+            "exited" => exited,
+            "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        });
+    }
 
     Ok(Value::Array(list))
 }
 
-/// Stop all managed children after the transport is gone.  Signal every group
-/// before awaiting any child so descendants cannot keep another child alive.
-pub async fn cleanup_managed_processes() {
+/// Stop and reap managed children after the transport is gone.
+pub async fn cleanup_managed_processes() -> Result<(), RpcError> {
     let pipe_pids: Vec<(u32, u32)> = {
         let processes = get_process_map().lock().await;
         processes
@@ -2060,25 +2281,51 @@ pub async fn cleanup_managed_processes() {
             .collect()
     };
 
-    for (_, os_pid) in pipe_pids.iter().chain(pty_pids.iter()) {
-        let _ = signal_process_group(*os_pid, libc::SIGTERM);
-    }
-
-    let pipe_reaps = pipe_pids
-        .into_iter()
-        .map(|(pid, _)| terminate_pipe_process(pid, libc::SIGTERM, true));
-    let pty_reaps = pty_pids
-        .into_iter()
-        .map(|(pid, _)| terminate_pty_process(pid, libc::SIGTERM, true, true));
-    tokio::join!(
+    let pipe_reaps = pipe_pids.into_iter().map(|(pid, _)| async move {
+        (pid, terminate_pipe_process(pid, libc::SIGTERM, true).await)
+    });
+    let pty_reaps = pty_pids.into_iter().map(|(pid, _)| async move {
+        (
+            pid,
+            terminate_pty_process(pid, libc::SIGTERM, true, true, false).await,
+        )
+    });
+    let (pipe_results, pty_results) = tokio::join!(
         futures::future::join_all(pipe_reaps),
         futures::future::join_all(pty_reaps)
     );
 
-    // The transport is gone, so there is no reader left to drain these
-    // streams.  Unlike ordinary kill, connection cleanup may discard them.
-    get_process_map().lock().await.clear();
-    get_pty_process_map().lock().await.clear();
+    // The transport is gone, so successful reaps may discard unread pipes.
+    // Failed entries stay registered for the final cleanup pass to retry.
+    let mut failures = Vec::new();
+    {
+        let mut processes = get_process_map().lock().await;
+        for (pid, result) in pipe_results {
+            match result {
+                Ok(_) => {
+                    processes.remove(&pid);
+                }
+                Err(error) => failures.push(format!("pipe process {pid}: {}", error.message)),
+            }
+        }
+    }
+    for (pid, result) in pty_results {
+        if let Err(error) = result {
+            failures.push(format!("PTY process {pid}: {}", error.message));
+        }
+    }
+    // The transport is gone, so no client can consume retained terminal
+    // statuses.  Do not keep tombstones alive for the lifetime of the server.
+    clear_terminated_pty_statuses();
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(RpcError::process_error(format!(
+            "Managed process cleanup failed: {}",
+            failures.join("; ")
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -2105,12 +2352,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unregistered_pipe_start_guard_kills_child() {
+        let _test_lock = test_process_map_lock().await;
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        cmd.kill_on_drop(true);
+        configure_process_group(&mut cmd);
+        let child = cmd.spawn().expect("start unregistered pipe child");
+        let child_pid = child.id().expect("child PID");
+        let guard = ProcessGroupGuard::new(child_pid);
+
+        // This is the cancellation path before insertion into PROCESS_MAP.
+        drop(guard);
+        drop(child);
+        wait_for_process_exit(child_pid as i32).await;
+        assert!(!process_is_running(child_pid as i32));
+    }
+
+    #[tokio::test]
+    async fn cleanup_reports_signal_failure_and_retains_managed_process() {
+        let _test_lock = test_process_map_lock().await;
+        let pid = start_pipe_process("sleep 30").await;
+
+        set_test_process_group_signal_error(Some(libc::EPERM));
+        let result = cleanup_managed_processes().await;
+        set_test_process_group_signal_error(None);
+
+        let error = result.expect_err("cleanup must report an unsignalled process group");
+        assert!(error.message.contains("Operation not permitted"));
+        assert!(get_process_map().lock().await.contains_key(&pid));
+
+        cleanup_managed_processes()
+            .await
+            .expect("cleanup retry after removing injected error");
+        assert!(!get_process_map().lock().await.contains_key(&pid));
+    }
+
+    #[tokio::test]
     async fn synchronous_output_reader_enforces_shared_limit() {
         let error = read_sync_output(&b"oversized"[..], Arc::new(Semaphore::new(4)), 4)
             .await
             .expect_err("output above the remaining response budget should fail");
-        assert_eq!(error.code, RpcError::PROCESS_ERROR);
-        assert!(error.message.contains("output exceeds"));
+        assert!(error.to_string().contains("output exceeds"));
     }
 
     #[tokio::test]
@@ -2772,6 +3055,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_pipe_reads_do_not_lose_consumed_output() {
+        let _test_lock = test_process_map_lock().await;
+        for _ in 0..25 {
+            let pid = start_pipe_process("sleep 0.01; printf final").await;
+            let (first, second) = tokio::join!(
+                read_pipe_process(pid, 65_536, 500),
+                read_pipe_process(pid, 65_536, 500)
+            );
+            let tail = if get_process_map().lock().await.contains_key(&pid) {
+                collect_pipe_output(pid, 65_536).await.0
+            } else {
+                Vec::new()
+            };
+            let mut stdout = Vec::new();
+            for result in [&first, &second] {
+                if let Some(Value::Binary(bytes)) = map_get(result, "stdout") {
+                    stdout.extend_from_slice(bytes);
+                }
+            }
+            stdout.extend_from_slice(&tail);
+            assert_eq!(stdout, b"final");
+        }
+    }
+
+    #[tokio::test]
     async fn kill_default_term_and_explicit_kill_reap_process_group() {
         let _test_lock = test_process_map_lock().await;
         let start_result = start(Value::Map(vec![
@@ -2816,6 +3124,68 @@ mod tests {
         .expect("SIGKILL");
         assert_reaped(os_pid);
         assert!(!get_process_map().lock().await.contains_key(&pid));
+    }
+
+    #[tokio::test]
+    async fn kill_rejects_unknown_pid_and_signal_zero_returns_promptly() {
+        let _test_lock = test_process_map_lock().await;
+        let unknown = kill(Value::Map(vec![(
+            Value::String("pid".into()),
+            Value::Integer(u32::MAX.into()),
+        )]))
+        .await
+        .expect_err("unknown PID must fail");
+        assert_eq!(unknown.code, RpcError::PROCESS_ERROR);
+
+        let pid = start_pipe_process("sleep 30").await;
+        tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            kill(Value::Map(vec![
+                (Value::String("pid".into()), Value::Integer(pid.into())),
+                (Value::String("signal".into()), Value::Integer(0.into())),
+            ])),
+        )
+        .await
+        .expect("signal zero must not wait for process exit")
+        .expect("signal zero");
+        assert!(get_process_map().lock().await.contains_key(&pid));
+        kill(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::Integer((libc::SIGKILL as i64).into()),
+            ),
+        ]))
+        .await
+        .expect("cleanup process");
+    }
+
+    #[tokio::test]
+    async fn status_and_list_serialize_with_kill_reaping() {
+        let _test_lock = test_process_map_lock().await;
+        for _ in 0..25 {
+            let pid = start_pipe_process("sleep 30").await;
+            let kill_params = Value::Map(vec![
+                (Value::String("pid".into()), Value::Integer(pid.into())),
+                (
+                    Value::String("signal".into()),
+                    Value::Integer((libc::SIGTERM as i64).into()),
+                ),
+            ]);
+            let status_params = Value::Map(vec![(
+                Value::String("pid".into()),
+                Value::Integer(pid.into()),
+            )]);
+            let (kill_result, status_result, list_result) = tokio::join!(
+                kill(kill_params),
+                status(status_params),
+                list(Value::Map(vec![]))
+            );
+            kill_result.expect("kill process");
+            status_result.expect("status must not race with reaping");
+            list_result.expect("list must not race with reaping");
+            let _ = collect_pipe_output(pid, 65_536).await;
+        }
     }
 
     async fn wait_for_marker(path: &std::path::Path) {
@@ -3079,6 +3449,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pty_sigkill_publishes_status_for_in_flight_read_after_removal() {
+        let _test_lock = test_process_map_lock().await;
+        let start = start_pty(Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("sleep".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![Value::String("30".into())]),
+            ),
+        ]))
+        .await
+        .expect("start PTY");
+        let pid = map_get(&start, "pid").and_then(Value::as_u64).unwrap() as u32;
+        let (lifecycle, io, shared_exit_status) = {
+            let processes = get_pty_process_map().lock().await;
+            let managed = processes.get(&pid).expect("managed PTY process");
+            (
+                managed.lifecycle.clone(),
+                managed.io.clone(),
+                managed.shared_exit_status.clone(),
+            )
+        };
+        let lifecycle_guard = lifecycle.lock().await;
+        let kill_task = tokio::spawn(kill_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::Integer((libc::SIGKILL as i64).into()),
+            ),
+        ])));
+        for _ in 0..100 {
+            if io.is_closed() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(io.is_closed(), "SIGKILL did not publish PTY cancellation");
+
+        let read_task = tokio::spawn(read_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("timeout_ms".into()),
+                Value::Integer(500.into()),
+            ),
+        ])));
+        for _ in 0..100 {
+            if Arc::strong_count(&shared_exit_status) >= 4 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            Arc::strong_count(&shared_exit_status) >= 4,
+            "read never captured managed PTY state"
+        );
+        drop(lifecycle_guard);
+
+        kill_task.await.expect("join SIGKILL").expect("SIGKILL PTY");
+        assert!(!get_pty_process_map().lock().await.contains_key(&pid));
+        let read_result = read_task.await.expect("join read").expect("read PTY");
+        assert_eq!(map_get(&read_result, "exited"), Some(&Value::Boolean(true)));
+        assert_eq!(
+            map_get(&read_result, "exit_code").and_then(Value::as_i64),
+            Some(128 + libc::SIGKILL as i64)
+        );
+    }
+
+    #[tokio::test]
+    async fn pty_sigkill_retains_status_for_follow_up_read() {
+        let _test_lock = test_process_map_lock().await;
+        let start = start_pty(Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("sleep".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![Value::String("30".into())]),
+            ),
+        ]))
+        .await
+        .expect("start PTY");
+        let pid = map_get(&start, "pid").and_then(Value::as_u64).unwrap() as u32;
+
+        kill_pty(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::Integer((libc::SIGKILL as i64).into()),
+            ),
+        ]))
+        .await
+        .expect("SIGKILL PTY");
+        assert!(!get_pty_process_map().lock().await.contains_key(&pid));
+
+        let read = read_pty(Value::Map(vec![(
+            Value::String("pid".into()),
+            Value::Integer(pid.into()),
+        )]))
+        .await
+        .expect("read retained PTY status");
+        assert_eq!(map_get(&read, "exited"), Some(&Value::Boolean(true)));
+        assert_eq!(
+            map_get(&read, "exit_code").and_then(Value::as_i64),
+            Some(128 + libc::SIGKILL as i64)
+        );
+        assert_eq!(take_terminated_pty_status(pid), None);
+    }
+
+    #[tokio::test]
     async fn pty_kill_ignored_sigterm_then_sigkill_reaps_child() {
         let _test_lock = test_process_map_lock().await;
         let temp = tempfile::tempdir().expect("temporary PTY directory");
@@ -3108,13 +3584,46 @@ mod tests {
         .await
         .expect("SIGKILL should terminate and reap the PTY child");
         assert_reaped(os_pid);
-        close_pty(Value::Map(vec![(
+        assert!(!get_pty_process_map().lock().await.contains_key(&pid));
+        let unknown = kill_pty(Value::Map(vec![(
             Value::String("pid".into()),
             Value::Integer(pid.into()),
         )]))
         .await
-        .expect("close PTY after SIGKILL");
-        assert!(!get_pty_process_map().lock().await.contains_key(&pid));
+        .expect_err("unknown PTY PID must fail");
+        assert_eq!(unknown.code, RpcError::PROCESS_ERROR);
+    }
+
+    #[tokio::test]
+    async fn pty_list_serializes_with_kill_reaping() {
+        let _test_lock = test_process_map_lock().await;
+        for _ in 0..25 {
+            let start = start_pty(Value::Map(vec![
+                (Value::String("cmd".into()), Value::String("sleep".into())),
+                (
+                    Value::String("args".into()),
+                    Value::Array(vec![Value::String("30".into())]),
+                ),
+            ]))
+            .await
+            .expect("start PTY");
+            let pid = map_get(&start, "pid").and_then(Value::as_u64).unwrap() as u32;
+            let (kill_result, list_result) = tokio::join!(
+                kill_pty(Value::Map(vec![(
+                    Value::String("pid".into()),
+                    Value::Integer(pid.into()),
+                )])),
+                list_pty(Value::Map(vec![]))
+            );
+            kill_result.expect("kill PTY");
+            list_result.expect("PTY list must not race with reaping");
+            close_pty(Value::Map(vec![(
+                Value::String("pid".into()),
+                Value::Integer(pid.into()),
+            )]))
+            .await
+            .expect("close PTY");
+        }
     }
 
     #[tokio::test]
@@ -3171,7 +3680,10 @@ mod tests {
         let _test_lock = test_process_map_lock().await;
         let temp = tempfile::tempdir().expect("temporary marker directory");
         let marker = temp.path().join("descendant-pid");
-        let script = format!("sleep 30 & echo $! > '{}'", marker.display());
+        let script = format!(
+            "python3 -c 'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)' & echo $! > '{}'",
+            marker.display()
+        );
         let pid = start_pipe_process(&script).await;
         wait_for_marker(&marker).await;
         wait_for_child_exit(pid).await;
@@ -3183,7 +3695,9 @@ mod tests {
             .expect("parse descendant PID");
         assert_eq!(unsafe { libc::kill(descendant_pid, 0) }, 0);
 
-        cleanup_managed_processes().await;
+        cleanup_managed_processes()
+            .await
+            .expect("cleanup pipe descendants");
         wait_for_process_exit(descendant_pid).await;
     }
 
@@ -3196,7 +3710,9 @@ mod tests {
         let os_pid = pty_os_pid(pid).await;
 
         let started = tokio::time::Instant::now();
-        cleanup_managed_processes().await;
+        cleanup_managed_processes()
+            .await
+            .expect("cleanup PTY group");
         // Direct-child reaping gets one bounded wait and the process group
         // gets a separate one.  Leave scheduling slack while still rejecting
         // the old one-wait escalation behavior.
@@ -3235,7 +3751,9 @@ mod tests {
         wait_for_marker(&marker).await;
 
         let started = tokio::time::Instant::now();
-        cleanup_managed_processes().await;
+        cleanup_managed_processes()
+            .await
+            .expect("cleanup pipe group");
         // Direct-child reaping gets one bounded wait and the process group
         // gets a separate one.  Leave scheduling slack while still rejecting
         // the old one-wait escalation behavior.
@@ -3245,6 +3763,66 @@ mod tests {
         );
         assert_reaped(os_pid);
         assert!(get_process_map().lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_kills_pty_descendants_after_status_reaps_direct_child() {
+        let _test_lock = test_process_map_lock().await;
+        let temp = tempfile::tempdir().expect("temporary PTY marker directory");
+        let marker = temp.path().join("pty-descendant-pid");
+        let script = format!(
+            "import os,signal,time; pid=os.fork(); (open({:?},'w').write(str(pid)), os._exit(0)) if pid else (signal.signal(signal.SIGHUP, signal.SIG_IGN), signal.signal(signal.SIGTERM, signal.SIG_IGN), time.sleep(30))",
+            marker
+        );
+        let start_result = start_pty(Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("python3".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![
+                    Value::String("-c".into()),
+                    Value::String(script.into()),
+                ]),
+            ),
+        ]))
+        .await
+        .expect("start PTY parent");
+        let pid = map_get(&start_result, "pid")
+            .and_then(Value::as_u64)
+            .expect("PTY pid") as u32;
+        wait_for_marker(&marker).await;
+
+        for _ in 0..100 {
+            let exited = {
+                let mut processes = get_pty_process_map().lock().await;
+                let managed = processes.get_mut(&pid).expect("managed PTY");
+                check_exit_status(managed).0
+            };
+            if exited {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            get_pty_process_map()
+                .lock()
+                .await
+                .get(&pid)
+                .and_then(|managed| managed.exit_status)
+                .is_some(),
+            "direct PTY child should be reaped before cleanup"
+        );
+
+        let descendant_pid: i32 = std::fs::read_to_string(&marker)
+            .expect("read PTY descendant PID")
+            .trim()
+            .parse()
+            .expect("parse PTY descendant PID");
+        assert_eq!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+
+        cleanup_managed_processes()
+            .await
+            .expect("cleanup PTY descendants");
+        wait_for_process_exit(descendant_pid).await;
     }
 
     #[tokio::test]
@@ -3721,6 +4299,7 @@ mod tests {
                     child_pid: Pid::from_raw(-1),
                     cmd: String::new(),
                     exit_status: None,
+                    shared_exit_status: Arc::new(StdMutex::new(None)),
                     output_eof: false,
                 },
             );

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -221,7 +221,8 @@ async fn run_connection<R, W>(
     reader: R,
     writer: Arc<Mutex<W>>,
     #[cfg(test)] cleanup_barrier: Option<Arc<CleanupBarrier>>,
-) where
+) -> Result<(), RpcError>
+where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
@@ -296,7 +297,9 @@ async fn run_connection<R, W>(
     // Once the transport is gone no response can be relied on.  Reap managed
     // children before joining request tasks: a task blocked on their pipes or
     // a descendant-held descriptor must not prevent SIGKILL escalation.
-    handlers::cleanup_managed_processes().await;
+    // A failed first pass leaves its map entries registered so the final pass
+    // can retry after all request tasks have stopped.
+    let _ = handlers::cleanup_managed_processes().await;
     drain_tasks_for(&mut tasks, EOF_TASK_JOIN_WAIT).await;
     tasks.abort_all();
     // `spawn_blocking` work cannot be cancelled once it has started.  Do not
@@ -316,9 +319,10 @@ async fn run_connection<R, W>(
         .await
         .expect("test should release the connection cleanup barrier");
     }
-    handlers::cleanup_managed_processes().await;
+    let cleanup_result = handlers::cleanup_managed_processes().await;
     drop(errors);
     let _ = tokio::time::timeout(EOF_TASK_JOIN_WAIT, error_writer).await;
+    cleanup_result
 }
 
 async fn drain_tasks_for(tasks: &mut JoinSet<()>, wait: std::time::Duration) {
@@ -448,7 +452,7 @@ async fn accept_frame<W>(
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> std::process::ExitCode {
     let stdout: WriterHandle = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
 
     // Initialize the filesystem watcher for cache invalidation notifications.
@@ -460,13 +464,19 @@ async fn main() {
         watcher::init(manager);
     }
 
-    run_connection(
+    match run_connection(
         tokio::io::stdin(),
         stdout,
         #[cfg(test)]
         None,
     )
-    .await;
+    .await
+    {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        // stderr shares the SSH transport with the binary protocol, so report
+        // cleanup failure only through the server's nonzero exit status.
+        Err(_) => std::process::ExitCode::FAILURE,
+    }
 }
 
 fn decode_request(payload: &[u8]) -> Result<Request, Box<Response>> {
@@ -603,26 +613,6 @@ mod tests {
         assert_eq!(response.error.unwrap().code, RpcError::INVALID_REQUEST);
     }
 
-    #[test]
-    fn test_blocked_pty_writes_use_dedicated_admission() {
-        let admissions = Admissions::default();
-        let mut general = Vec::new();
-        for _ in 0..GENERAL_TASK_LIMIT {
-            general.push(
-                admissions
-                    .try_acquire(TaskClass::General)
-                    .expect("reserve a general permit"),
-            );
-        }
-
-        assert!(matches!(
-            task_class("process.write_pty"),
-            TaskClass::PtyWrite
-        ));
-        assert!(admissions.try_acquire(TaskClass::PtyWrite).is_some());
-        assert!(admissions.try_acquire(TaskClass::Control).is_some());
-    }
-
     #[tokio::test]
     async fn test_oversized_frame_is_answered_and_drained() {
         let oversized = frame(b"oversized");
@@ -664,8 +654,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_older_batch_blocks_later_general_requests_until_it_fits() {
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_blocked_batch_uses_idle_permits_without_unbounded_bypass() {
         let admissions = Admissions::default();
         let _held = admissions
             .try_acquire_many(
@@ -781,6 +771,18 @@ mod tests {
         tasks.abort_all();
     }
 
+    #[test]
+    fn test_blocked_pty_writes_use_dedicated_admission() {
+        let admissions = Admissions::default();
+        let _general = admissions
+            .try_acquire_many(TaskClass::General, GENERAL_TASK_LIMIT)
+            .expect("reserve every general permit");
+
+        assert_eq!(task_class("process.write_pty"), TaskClass::PtyWrite);
+        assert!(admissions.try_acquire(TaskClass::PtyWrite).is_some());
+        assert!(admissions.try_acquire(TaskClass::Control).is_some());
+    }
+
     /// Malformed frames must always be answered.  A dropped response leaves
     /// the client blocked on its own timeout with no diagnosis.
     #[tokio::test]
@@ -818,7 +820,10 @@ mod tests {
         }
 
         drop(writes.await.unwrap());
-        connection.await.expect("connection task should not panic");
+        connection
+            .await
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
     }
 
     fn frame(payload: &[u8]) -> Vec<u8> {
@@ -877,7 +882,10 @@ mod tests {
         );
 
         drop(client);
-        connection.await.unwrap();
+        connection
+            .await
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
     }
 
     #[tokio::test]
@@ -932,7 +940,10 @@ mod tests {
         );
 
         drop(client);
-        connection.await.unwrap();
+        connection
+            .await
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
     }
 
     #[tokio::test]
@@ -1126,6 +1137,109 @@ mod tests {
     }
 
     #[tokio::test]
+    /// A child that closes stdin early must still report its own output and
+    /// exit status: `tramp-sh' runs `command <infile', where EPIPE never
+    /// reaches Emacs.
+    async fn test_commands_run_parallel_stdin_closed_early_completes() {
+        let command = Value::Map(vec![
+            (Value::String("key".into()), Value::String("closed".into())),
+            (Value::String("cmd".into()), Value::String("/bin/sh".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![
+                    Value::String("-c".into()),
+                    Value::String("exec 0<&-; printf done; exit 7".into()),
+                ]),
+            ),
+            (
+                Value::String("stdin".into()),
+                Value::Binary(vec![b'x'; 1024 * 1024]),
+            ),
+        ]);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            handlers::commands::run_parallel(Value::Map(vec![(
+                Value::String("commands".into()),
+                Value::Array(vec![command]),
+            )])),
+        )
+        .await
+        .expect("closed stdin must not hang")
+        .unwrap();
+        let entry = map_get(&result, "closed").unwrap();
+        assert_eq!(
+            map_get(entry, "stdout"),
+            Some(&Value::Binary(b"done".to_vec()))
+        );
+        assert_eq!(map_get(entry, "exit_code").and_then(Value::as_i64), Some(7));
+        assert_eq!(map_get(entry, "stderr"), Some(&Value::Binary(vec![])));
+    }
+
+    #[tokio::test]
+    async fn test_connection_eof_kills_synchronous_process_groups() {
+        let _test_lock = handlers::process::test_process_map_lock().await;
+        for (index, method) in ["process.run", "commands.run_parallel"]
+            .into_iter()
+            .enumerate()
+        {
+            let temp = tempfile::tempdir().expect("temporary marker directory");
+            let marker = temp.path().join("pid");
+            let args = Value::Array(vec![
+                Value::String("-c".into()),
+                Value::String(
+                    format!(
+                        "import os,time; p={marker:?}; open(p+'.tmp', 'w').write(str(os.getpid())); os.replace(p+'.tmp', p); time.sleep(30)"
+                    )
+                    .into(),
+                ),
+            ]);
+            let command = Value::Map(vec![
+                (Value::String("cmd".into()), Value::String("python3".into())),
+                (Value::String("args".into()), args),
+            ]);
+            let params = if method == "process.run" {
+                command
+            } else {
+                let mut entry = command.as_map().unwrap().clone();
+                entry.push((Value::String("key".into()), Value::String("test".into())));
+                Value::Map(vec![(
+                    Value::String("commands".into()),
+                    Value::Array(vec![Value::Map(entry)]),
+                )])
+            };
+
+            let (mut client, server_reader) = tokio::io::duplex(4096);
+            let (server_writer, _client_reader) = tokio::io::duplex(4096);
+            let connection = tokio::spawn(run_connection(
+                server_reader,
+                Arc::new(Mutex::new(server_writer)),
+                None,
+            ));
+            client
+                .write_all(&frame(&make_request_with_id(
+                    700 + index as i64,
+                    method,
+                    params,
+                )))
+                .await
+                .unwrap();
+            wait_for_marker(&marker).await;
+            let child_pid: i32 = std::fs::read_to_string(&marker)
+                .expect("read child PID")
+                .parse()
+                .expect("parse child PID");
+            drop(client);
+            tokio::time::timeout(std::time::Duration::from_secs(3), connection)
+                .await
+                .expect("connection cleanup should be bounded")
+                .expect("connection task should not panic")
+                .expect("connection cleanup should succeed");
+
+            handlers::process::wait_for_process_exit(child_pid).await;
+        }
+    }
+
+    #[tokio::test]
     async fn test_method_not_found() {
         let params = Value::Map(vec![]);
         let payload = make_request("nonexistent.method", params);
@@ -1194,7 +1308,8 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(3), connection)
             .await
             .expect("second cleanup should be bounded")
-            .expect("connection task should not panic");
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
         assert!(handlers::process::test_managed_maps_empty().await);
         assert!(matches!(
             nix::sys::wait::waitpid(
@@ -1310,7 +1425,8 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(5), connection)
             .await
             .expect("EOF cleanup should be bounded")
-            .expect("connection task should not panic");
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
         assert!(handlers::process::test_managed_maps_empty().await);
         for os_pid in managed_pids {
             assert!(matches!(
@@ -1417,7 +1533,10 @@ mod tests {
         assert_eq!(seen, expected);
 
         drop(client);
-        connection.await.unwrap();
+        connection
+            .await
+            .expect("connection task should not panic")
+            .expect("connection cleanup should succeed");
     }
 
     #[tokio::test]

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1117,6 +1117,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
 
 (declare-function tramp-rpc-magit--file-exists-in-ancestor-scan
                   "tramp-rpc-magit" (filename scan))
+(declare-function tramp-rpc-magit--file-exists-p
+                  "tramp-rpc-magit" (filename))
 (declare-function tramp-rpc-magit--get-cache-key "tramp-rpc-magit" (vec directory))
 (declare-function tramp-rpc-magit--prefetch-git-commands
                   "tramp-rpc-magit" (directory &optional vec))
@@ -1168,6 +1170,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
    'tramp-rpc-magit--process-caches
    'tramp-rpc-magit--ancestor-scan-caches)
   (setq tramp-rpc-magit--ancestors-cache nil
+        tramp-rpc-magit--ancestors-cache-timestamp nil
         tramp-rpc-magit--prefetch-directory nil
         tramp-rpc-magit--allow-process-cache nil))
 
@@ -1420,6 +1423,31 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (kill-buffer buffer)
       (clrhash tramp-rpc--process-write-queues))))
 
+(ert-deftest tramp-rpc-mock-test-process-send-string-write-policy ()
+  "Pipe writes drain only when synchronous write mode is enabled."
+  (let ((process (start-process "tramp-rpc-write-policy" nil "sleep" "10"))
+        (writes 0)
+        (drains 0))
+    (unwind-protect
+        (progn
+          (process-put process :tramp-rpc-pid 1)
+          (process-put process :tramp-rpc-vec 'vec)
+          (cl-letf (((symbol-function 'tramp-rpc--encode-process-input)
+                     (lambda (_process data) data))
+                    ((symbol-function 'tramp-rpc--write-remote-process)
+                     (lambda (&rest _args) (cl-incf writes)))
+                    ((symbol-function 'tramp-rpc--drain-write-queue)
+                     (lambda (&rest _args) (cl-incf drains))))
+            (let ((tramp-rpc-synchronous-pipe-writes nil))
+              (tramp-rpc-handle-process-send-string process "async")
+              (should (= writes 1))
+              (should (= drains 0)))
+            (let ((tramp-rpc-synchronous-pipe-writes t))
+              (tramp-rpc-handle-process-send-string process "sync")
+              (should (= writes 2))
+              (should (= drains 1)))))
+      (when (process-live-p process) (delete-process process)))))
+
 (ert-deftest tramp-rpc-mock-test-process-write-queue-next-operation-signals-failure ()
   "The next `process-send-string' reports an earlier async write failure."
   (let* ((vec (tramp-dissect-file-name "/rpc:queue-next-error:/tmp/"))
@@ -1490,6 +1518,38 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (kill-buffer buffer-b)
       (clrhash tramp-rpc--process-write-queues))))
 
+(ert-deftest tramp-rpc-mock-test-rpc-pty-write-uses-creation-generation ()
+  "An RPC PTY write after reconnect stays on its creation generation."
+  (let* ((vec (tramp-dissect-file-name "/rpc:pty-reconnect:/tmp/"))
+         (connection-a (list :process 'connection-a))
+         (connection-b (list :process 'connection-b))
+         (current-connection connection-a)
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         process write-connection)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--get-terminal-size)
+                   (lambda (_buffer) '(80 . 24)))
+                  ((symbol-function 'tramp-rpc--get-connection)
+                   (lambda (_vec) current-connection))
+                  ((symbol-function 'tramp-rpc--pty-start-async-read) #'ignore)
+                  ((symbol-function 'tramp-rpc--call)
+                   (lambda (_vec method _params &optional connection)
+                     (if (equal method "process.start_pty")
+                         '((pid . 42) (tty_name . "/dev/pts/mock"))
+                       (setq write-connection connection)))))
+          (setq process
+                (tramp-rpc--make-rpc-pty-process
+                 vec "tramp-rpc-pty-reconnect" nil '("cat") nil t
+                 nil nil "/tmp/"))
+          (setq current-connection connection-b)
+          (tramp-rpc-handle-process-send-string process "input")
+          (should (eq write-connection connection-a)))
+      (when (processp process)
+        (remhash process tramp-rpc--pty-processes)
+        (set-process-sentinel process nil)
+        (when (process-live-p process)
+          (delete-process process))))))
+
 (ert-deftest tramp-rpc-mock-test-cleanup-async-processes-preserves-replacement-generation ()
   "Old cleanup for one vector must not remove its replacement generation."
   (let* ((vec (tramp-dissect-file-name "/rpc:cleanup-generation:/tmp/"))
@@ -1519,6 +1579,23 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (dolist (process (list relay-a relay-b connection-a connection-b))
         (when (process-live-p process)
           (delete-process process))))))
+
+(ert-deftest tramp-rpc-mock-test-call-async-send-failure-rolls-back-callback ()
+  "A rejected async send must not leave callback state behind."
+  (let ((tramp-rpc--async-callbacks (make-hash-table :test 'eql))
+        (tramp-rpc--async-callback-processes (make-hash-table :test 'eql))
+        (process 'dead-transport))
+    (cl-letf (((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+               (lambda (_method _params) (cons 77 "request")))
+              ((symbol-function 'process-send-string)
+               (lambda (_process _request)
+                 (error "transport is dead"))))
+      (should-error
+       (tramp-rpc--call-async nil "test" nil #'ignore
+                              (list :process process))
+       :type 'error)
+      (should-not (gethash 77 tramp-rpc--async-callbacks))
+      (should-not (gethash 77 tramp-rpc--async-callback-processes)))))
 
 (ert-deftest tramp-rpc-mock-test-transport-death-cleans-one-generation ()
   "A dead RPC transport wakes waiters and removes only its generation."
@@ -1604,6 +1681,28 @@ This matches the behavior expected by `tramp-test28-process-file'."
                                    :poll-timer)))
         (remhash process tramp-rpc--pty-processes)
         (when (process-live-p process) (delete-process process))))))
+
+(ert-deftest tramp-rpc-mock-test-pty-sigkill-status-reaches-sentinel-and-exit-status ()
+  "A terminal SIGKILL result remains abnormal through the local PTY relay."
+  (let* ((process (start-process "tramp-rpc-pty-sigkill-status" nil "cat"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         events)
+    (unwind-protect
+        (progn
+          (process-put process :tramp-rpc-pid 42)
+          (process-put process :tramp-rpc-user-sentinel
+                       (lambda (_process event) (push event events)))
+          (puthash process '(:poll-timer nil) tramp-rpc--pty-processes)
+          (set-process-sentinel process #'tramp-rpc--pty-sentinel)
+          ;; This is the read response after explicit remote SIGKILL removed
+          ;; the PTY registry.  Its status must not become local exit 0.
+          (tramp-rpc--pty-handle-async-response
+           process '(:result ((output . nil) (exited . t) (exit_code . 137))))
+          (accept-process-output process 0.1)
+          (should (= (tramp-rpc-handle-process-exit-status process) 137))
+          (should (equal events '("exited abnormally with code 137\n"))))
+      (remhash process tramp-rpc--pty-processes)
+      (when (process-live-p process) (delete-process process)))))
 
 (ert-deftest tramp-rpc-mock-test-pty-terminal-read-error-calls-user-sentinel-once ()
   "A terminal PTY read error invokes the real user sentinel exactly once."
@@ -2247,12 +2346,33 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (equal calls
                      '((dired-compress-file ("/rpc:mock:/tmp/file"))))))))
 
+(ert-deftest tramp-rpc-mock-test-ancestor-scan-honors-cache-inhibition ()
+  "Ancestor marker scans honor numeric and timestamp invalidation."
+  (let* ((tramp-rpc-magit--ancestor-scan-caches
+          (make-hash-table :test 'equal))
+         (tramp-rpc-magit--ancestors-cache nil)
+         (tramp-rpc-magit--prefetch-directory nil)
+         (tramp-rpc--cache-ttl 300)
+         (vec (tramp-dissect-file-name "/rpc:mock:/repo/sub/"))
+         (key (cons (tramp-rpc--connection-key-string vec) "/repo/sub/"))
+         (scan '((".git" . "/repo"))))
+    (dolist (inhibition (list 1 (current-time)))
+      (clrhash tramp-rpc-magit--ancestor-scan-caches)
+      (puthash key (cons (- (float-time) 2) scan)
+               tramp-rpc-magit--ancestor-scan-caches)
+      (let ((remote-file-name-inhibit-cache inhibition))
+        (should (eq (tramp-rpc-magit--file-exists-p
+                     "/rpc:mock:/repo/.git")
+                    'not-cached))))))
+
 (ert-deftest tramp-rpc-mock-test-prefetch-ancestor-cache-isolates-connections ()
   "A global prefetch scan must not answer for another connection."
-  (let ((tramp-rpc-magit--ancestor-scan-caches
-         (make-hash-table :test 'equal))
-        (tramp-rpc-magit--ancestors-cache '((".git" . "/repo")))
-        (tramp-rpc-magit--prefetch-directory "/rpc:host-a:/repo/sub/"))
+  (let* ((tramp-rpc-magit--ancestor-scan-caches
+          (make-hash-table :test 'equal))
+         (tramp-rpc-magit--ancestors-cache '((".git" . "/repo")))
+         (tramp-rpc-magit--ancestors-cache-timestamp (float-time))
+         (tramp-rpc-magit--prefetch-directory "/rpc:host-a:/repo/sub/")
+         (tramp-rpc--cache-ttl 300))
     (should (tramp-rpc-magit--file-exists-p "/rpc:host-a:/repo/.git"))
     (should (eq (tramp-rpc-magit--file-exists-p "/rpc:host-b:/repo/.git")
                 'not-cached))))
@@ -3420,6 +3540,44 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (set-file-modes "/rpc:mockhost:/tmp/file" #o644)
       (should (equal (nreverse calls) '("file.set_modes"))))))
 
+(ert-deftest tramp-rpc-mock-test-metadata-cache-honors-numeric-remote-ttl ()
+  "Numeric `remote-file-name-inhibit-cache' caps custom metadata TTLs."
+  (let ((cache (make-hash-table :test 'equal))
+        (remote-file-name-inhibit-cache 1)
+        (tramp-rpc--cache-ttl 300))
+    (puthash 'key (cons (- (float-time) 2) 'stale) cache)
+    (should (eq (tramp-rpc--cache-lookup cache 'key) 'not-cached))
+    (should-not (gethash 'key cache))))
+
+(ert-deftest tramp-rpc-mock-test-metadata-cache-honors-timestamp-invalidation ()
+  "Timestamp cache inhibition rejects entries created before the threshold."
+  (let ((cache (make-hash-table :test 'equal))
+        (remote-file-name-inhibit-cache (current-time))
+        (tramp-rpc--cache-ttl 300))
+    (puthash 'old (cons (- (float-time) 1) 'stale) cache)
+    (puthash 'new (cons (+ (float-time) 1) 'fresh) cache)
+    (should (eq (tramp-rpc--cache-lookup cache 'old) 'not-cached))
+    (should (eq (tramp-rpc--cache-lookup cache 'new) 'fresh))))
+
+(ert-deftest tramp-rpc-mock-test-file-stat-honors-remote-cache-inhibition ()
+  "A cache-inhibited stat must ignore stale custom metadata entries."
+  (let* ((vec (tramp-dissect-file-name "/rpc:cache-inhibit:/tmp/file"))
+         (localname "/tmp/file")
+         (key (tramp-rpc--file-stat-cache-key vec localname nil))
+         (tramp-rpc--file-stat-cache (make-hash-table :test 'equal))
+         (remote-file-name-inhibit-cache t)
+         (calls 0))
+    (tramp-rpc--cache-put tramp-rpc--file-stat-cache key nil)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method _params &optional _connection)
+                 (should (equal method "file.stat"))
+                 (setq calls (1+ calls))
+                 '((type . "file")))))
+      (should (equal (alist-get 'type
+                                (tramp-rpc--call-file-stat vec localname))
+                     "file"))
+      (should (= calls 1)))))
+
 (ert-deftest tramp-rpc-mock-test-set-file-modes-invalidates-metadata-caches ()
   "`set-file-modes' clears cached metadata that depends on file mode bits."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
@@ -4462,6 +4620,101 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should (tramp-rpc-deploy--remote-binary-exists-p vec))
       (should (equal command
                      "test -f /tmp/server && ! test -L /tmp/server && test -x /tmp/server")))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-replaces-mismatched-existing-binary ()
+  "An executable at the expected path is reused only after checksum verification."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/ssh:host:/"))
+         (tramp-rpc-deploy-never-deploy nil)
+         (tramp-rpc-deploy-auto-deploy t)
+         transferred)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+               (lambda (_vec) vec))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+               (lambda (_vec) "/ssh:host:/tmp/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-exists-p)
+               (lambda (_vec) t))
+              ((symbol-function 'tramp-rpc-deploy--detect-remote-arch)
+               (lambda (_vec) "x86_64-linux"))
+              ((symbol-function 'tramp-rpc-deploy--ensure-local-binary)
+               (lambda (_arch) "/tmp/local-server"))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-matches-p)
+               (lambda (_vec _local) nil))
+              ((symbol-function 'tramp-rpc-deploy--transfer-binary)
+               (lambda (_vec local)
+                 (setq transferred local)
+                 "/ssh:host:/tmp/tramp-rpc-server")))
+      (should (equal (tramp-rpc-deploy-ensure-binary vec)
+                     "/tmp/tramp-rpc-server"))
+      (should (equal transferred "/tmp/local-server")))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-reuses-existing-binary-without-local-artifact ()
+  "An existing executable remains usable when local artifact acquisition fails."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/ssh:host:/"))
+         (tramp-rpc-deploy-never-deploy nil)
+         (tramp-rpc-deploy-auto-deploy t)
+         compared transferred)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+               (lambda (_vec) vec))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+               (lambda (_vec) "/ssh:host:/tmp/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-exists-p)
+               (lambda (_vec) t))
+              ((symbol-function 'tramp-rpc-deploy--detect-remote-arch)
+               (lambda (_vec) "x86_64-linux"))
+              ((symbol-function 'tramp-rpc-deploy--ensure-local-binary)
+               (lambda (_arch) (signal 'remote-file-error '("artifact unavailable"))))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-matches-p)
+               (lambda (&rest _) (setq compared t)))
+              ((symbol-function 'tramp-rpc-deploy--transfer-binary)
+               (lambda (&rest _) (setq transferred t))))
+      (should (equal (tramp-rpc-deploy-ensure-binary vec)
+                     "/tmp/tramp-rpc-server"))
+      (should-not compared)
+      (should-not transferred))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-existing-binary-does-not-mask-programming-errors ()
+  "Only artifact-availability failures permit unverified remote reuse."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/ssh:host:/"))
+         (tramp-rpc-deploy-never-deploy nil)
+         (tramp-rpc-deploy-auto-deploy t))
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+               (lambda (_vec) vec))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+               (lambda (_vec) "/ssh:host:/tmp/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-exists-p)
+               (lambda (_vec) t))
+              ((symbol-function 'tramp-rpc-deploy--detect-remote-arch)
+               (lambda (_vec) "x86_64-linux"))
+              ((symbol-function 'tramp-rpc-deploy--ensure-local-binary)
+               (lambda (_arch) (error "unexpected implementation failure"))))
+      (should-error (tramp-rpc-deploy-ensure-binary vec)
+                    :type 'error))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-missing-binary-still-reports-local-artifact-failure ()
+  "A missing remote binary never uses the existing-binary fallback."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/ssh:host:/"))
+         (tramp-rpc-deploy-never-deploy nil)
+         (tramp-rpc-deploy-auto-deploy t))
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+               (lambda (_vec) vec))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+               (lambda (_vec) "/ssh:host:/tmp/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy--remote-binary-exists-p)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc-deploy--detect-remote-arch)
+               (lambda (_vec) "x86_64-linux"))
+              ((symbol-function 'tramp-rpc-deploy--ensure-local-binary)
+               (lambda (_arch) (signal 'remote-file-error '("artifact unavailable")))))
+      (should-error (tramp-rpc-deploy-ensure-binary vec)
+                    :type 'remote-file-error))))
 
 (ert-deftest tramp-rpc-mock-test-deploy-checksum-required ()
   "A missing checksum prevents a release binary from reaching the cache."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -143,10 +143,23 @@ Value is a cons cell (CHECKED . RESULT).")
      (let* ((proc (plist-get conn :process))
             (vec (and proc (process-get proc :tramp-rpc-vec))))
        (when vec
-         (tramp-flush-directory-properties vec "/")
-         (tramp-flush-connection-properties vec)
+         ;; Keep the startup system.info response warm.  It is connection
+         ;; metadata, not a file-operation cache, and refetching it makes call
+         ;; counts depend on whether this connection was just replaced.
+         (let ((system-info
+                (tramp-get-connection-property
+                 vec tramp-rpc--system-info-property nil)))
+           (tramp-flush-directory-properties vec "/")
+           (tramp-flush-connection-properties vec)
+           (when system-info
+             (tramp-rpc--cache-system-info vec system-info)))
          (tramp-rpc--clear-file-caches-for-connection vec))))
    tramp-rpc--connections))
+
+(defun tramp-rpc-test--flush-file-properties (filename)
+  "Flush TRAMP file properties for FILENAME."
+  (with-parsed-tramp-file-name filename nil
+    (tramp-flush-file-properties v localname)))
 
 (defun tramp-rpc-test--run-with-call-count (thunk)
   "Run THUNK and return (RESULT . RPC-CALL-COUNT)."
@@ -389,6 +402,8 @@ The directory is deleted after BODY completes."
   (skip-unless (tramp-rpc-test-enabled))
 
   (let ((vec (tramp-dissect-file-name (tramp-rpc-test--remote-directory))))
+    ;; This test alone measures the cold connection-metadata lookup.
+    (tramp-flush-connection-properties vec)
     (let ((result (tramp-rpc-test--with-call-count 1
                     (list (tramp-get-remote-uid vec 'integer)
                           (tramp-get-remote-gid vec 'integer)
@@ -472,9 +487,10 @@ The directory is deleted after BODY completes."
   "Test `file-writable-p' for TRAMP RPC files."
   (skip-unless (tramp-rpc-test-enabled))
 
-  ;; Existing file.  TRAMP's generic writable check probes access and metadata.
+  ;; Existing file.  TRAMP's generic writable check probes access and file
+  ;; metadata; one-time connection system information is primed separately.
   (tramp-rpc-test--with-temp-file tmp "test content"
-    (should (tramp-rpc-test--with-call-count 3
+    (should (tramp-rpc-test--with-call-count 2
               (file-writable-p tmp))))
 
   ;; Non-existent file in writable directory
@@ -1785,6 +1801,9 @@ This matches the upstream `tramp-test28-process-file' test."
     (write-region "" nil (concat dir "/file-aab.txt"))
     (write-region "" nil (concat dir "/other.txt"))
 
+    ;; The completion skeleton first checks that DIR is a directory.  Flush the
+    ;; exact predicate cache so this cold-call assertion is order-independent.
+    (tramp-rpc-test--flush-file-properties dir)
     (let ((completions (tramp-rpc-test--with-call-count 2
                          (file-name-all-completions "file-" dir))))
       (should (member "file-aaa.txt" completions))
@@ -1800,6 +1819,8 @@ This matches the upstream `tramp-test28-process-file' test."
           (link-dir (concat dir "/link-dir")))
       (make-directory real-dir t)
       (make-symbolic-link "real-dir" link-dir)
+      ;; Keep the RPC-count assertion independent of earlier directory probes.
+      (tramp-rpc-test--flush-file-properties dir)
       (let ((completions (tramp-rpc-test--with-call-count 2
                            (file-name-all-completions "" dir))))
         (should (member "real-dir/" completions))


### PR DESCRIPTION
## Summary

Finish process-group cancellation, deployment verification, synchronous PTY writes, terminal settings, and TRAMP cache-inhibition semantics.

## Stack

Part **11 of 11** in the TRAMP RPC remediation stack.

- Base: `remediation/10-request-finalization`
- Next PRs build on `remediation/11-final-hardening`

Each PR contains only the incremental changes since its base branch.

## Full-stack validation

- Rust: 105/105 tests
- Mock ERT: 229/229
- Protocol ERT: 8/8
- Server ERT: 16/16
- Autoload ERT: 11/11
- Remote integration: 99 passed, 3 expected skips, 0 unexpected
- Upstream TRAMP: 73 passed, 38 feature-dependent skips, 0 unexpected
- Rustfmt, Clippy, strict byte compilation, and static musl build passed

Independent Terra validation and Luna adversarial review completed with no remaining blockers on the complete stack.
