### PR TITLE
fix: Support EMACSCLIENT_TRAMP environment variable propagation

### DIFF
--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -57,6 +57,7 @@
 (declare-function tramp-rpc--merge-environments "tramp-rpc")
 (declare-function tramp-rpc--remote-path-environment "tramp-rpc")
 (declare-function tramp-rpc--tramp-remote-process-environment "tramp-rpc")
+(declare-function tramp-rpc--emacsclient-tramp-environment "tramp-rpc")
 (declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc--ssh-detail-user "tramp-rpc")
 (declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
@@ -563,6 +564,7 @@ Resolves program path and loads direnv environment from working directory."
                             (tramp-rpc--merge-environments
                              (tramp-rpc--remote-path-environment v)
                              (tramp-rpc--tramp-remote-process-environment)
+                             (tramp-rpc--emacsclient-tramp-environment v)
                              (tramp-rpc--get-direnv-environment v localname)
                              (tramp-rpc--caller-environment)))))
           (if use-pty

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -898,7 +898,8 @@ entry is appended."
 ENV is an alist of (KEY . VALUE) string pairs, or nil.
 If INSIDE_EMACS is not already present, it is added with the value
 from `tramp-inside-emacs'.  Returns the (possibly augmented) alist."
-  (if (assoc "INSIDE_EMACS" env)
+  (if-let* ((ie (cdr (assoc "INSIDE_EMACS" env)))
+	    ((string-match-p "tramp" ie)))
       env
     (tramp-rpc--environment-with env "INSIDE_EMACS" (tramp-inside-emacs))))
 
@@ -963,6 +964,13 @@ stdout/stderr."
         (unless (member elt baseline)
           (push elt dynamic)))
       (tramp-rpc--environment-list-to-alist (nreverse dynamic)))))
+
+(defun tramp-rpc--emacsclient-tramp-environment (vec)
+  "Return an EMACSCLIENT_TRAMP entry for VEC.
+Depends on `tramp-propagate-emacsclient-tramp' being non-nil."
+  ;; `tramp-propagate-emacsclient-tramp' exists since Tramp 2.8.1.5.
+  (when (bound-and-true-p tramp-propagate-emacsclient-tramp)
+    `(("EMACSCLIENT_TRAMP" . ,(tramp-make-tramp-file-name vec 'noloc)))))
 
 (defun tramp-rpc--caller-environment ()
   "Extract environment variable overrides from `process-environment'.
@@ -3835,6 +3843,7 @@ refresh), git commands are served from the prefetch cache when possible."
                      (tramp-rpc--merge-environments
                       (tramp-rpc--remote-path-environment v)
                       (tramp-rpc--tramp-remote-process-environment)
+                      (tramp-rpc--emacsclient-tramp-environment v)
                       (tramp-rpc--get-direnv-environment v localname)
                       (tramp-rpc--caller-environment))))
                (stdin-content (when (and infile (not (eq infile t)))

--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -183,8 +183,10 @@ before exiting.  Do not use `kill-emacs-hook' for this: upstream
 (setf (symbol-function #'tramp--test-supports-processes-p) #'always)
 ;; tramp-rpc supports set-file-modes via file.set_modes RPC
 (setf (symbol-function #'tramp--test-supports-set-file-modes-p) #'always)
-;; tramp-rpc supports set-file-modes via file.set_times RPC
+;; tramp-rpc supports set-file-times via file.set_times RPC
 (setf (symbol-function #'tramp--test-supports-set-file-times-p) #'always)
+;; tramp-rpc supports setting environment variables
+(setf (symbol-function #'tramp--test-supports-environment-variables-p) #'always)
 
 (provide 'run-tramp-tests)
 ;;; run-tramp-tests.el ends here


### PR DESCRIPTION
Add `tramp-rpc--emacsclient-tramp-environment` which returns an
EMACSCLIENT_TRAMP entry for the remote vector when
`tramp-propagate-emacsclient-tramp` is non-nil (Tramp >= 2.8.1.5).

Also fix `tramp-rpc--ensure-inside-emacs-env` to check whether an
existing INSIDE_EMACS value already contains "tramp" before overriding
it, preventing loss of tramp version info during Tramp regression tests.

Patch by Michael Albinus <michael.albinus@gmx.de>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote processes can now inherit Emacsclient-specific TRAMP environment settings (via `EMACSCLIENT_TRAMP` when enabled).

* **Bug Fixes**
  * Improved `INSIDE_EMACS` handling for TRAMP connections by preserving it only when it already contains `tramp`; otherwise it is set appropriately.

* **Tests**
  * Updated TRAMP RPC test harness predicates to cover environment-variable propagation and file timestamp support (`file.set_times`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->