### PR TITLE
Properly support i686

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -321,6 +321,7 @@ Returns a string like \"x86_64-linux\" or \"aarch64-darwin\"."
                  ("amd64" "x86_64")
                  ("aarch64" "aarch64")
                  ("arm64" "aarch64")
+                 ("i686" "i686")
                  (_ uname-m)))
          (os (pcase (downcase uname-s)
                ("linux" "linux")
@@ -340,6 +341,7 @@ Returns a string like \"x86_64-linux\" or \"aarch64-darwin\"."
                                ("x86_64" "x86_64")
                                ("aarch64" "aarch64")
                                ("arm64" "aarch64")
+                               ("i686" "i686")
                                (_ machine))))
     (format "%s-%s" normalized-machine arch)))
 
@@ -350,6 +352,7 @@ Linux targets use musl for fully static binaries."
   (pcase arch
     ("x86_64-linux" "x86_64-unknown-linux-musl")
     ("aarch64-linux" "aarch64-unknown-linux-musl")
+    ("i686-linux" "i686-unknown-linux-musl")
     ("x86_64-darwin" "x86_64-apple-darwin")
     ("aarch64-darwin" "aarch64-apple-darwin")
     (_ (signal 'remote-file-error (list "Unknown architecture" arch)))))
@@ -1117,7 +1120,7 @@ binary lookup, and remote installation target."
 
       (insert "Cached Binaries:\n")
       (insert "----------------\n")
-      (dolist (arch '("x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"))
+      (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
         (let ((path (tramp-rpc-deploy--local-cache-path arch)))
           (insert (format "  %s: %s\n"
                           arch
@@ -1129,7 +1132,7 @@ binary lookup, and remote installation target."
       (insert "\n")
       (insert "Download URLs:\n")
       (insert "--------------\n")
-      (dolist (arch '("x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"))
+      (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
         (insert (format "  %s:\n    %s\n" arch (tramp-rpc-deploy--download-url arch)))))
     (display-buffer buf)))
 
@@ -1241,7 +1244,7 @@ This helps troubleshoot deployment issues."
         ;; Local binary availability
         (cl-incf test-num)
         (insert (format "\n%d. Checking local binary cache...\n" test-num))
-        (dolist (arch '("x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"))
+        (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
           (let ((path (tramp-rpc-deploy--local-cache-path arch))
                 (bundled (tramp-rpc-deploy--bundled-binary-path arch)))
             (cond

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -11,6 +11,7 @@ OUTPUT_DIR="$PROJECT_DIR/lisp/binaries"
 TARGETS=(
     "x86_64-unknown-linux-musl"
     "aarch64-unknown-linux-musl"
+    "i686-unknown-linux-musl"
     "x86_64-apple-darwin"
     "aarch64-apple-darwin"
 )
@@ -20,6 +21,8 @@ target_to_dir() {
     case "$1" in
         x86_64-unknown-linux-musl) echo "x86_64-linux" ;;
         aarch64-unknown-linux-musl) echo "aarch64-linux" ;;
+        i686-unknown-linux-musl) echo "i686-linux" ;;
+        i586-unknown-linux-musl) echo "i586-linux" ;;
         x86_64-apple-darwin) echo "x86_64-darwin" ;;
         aarch64-apple-darwin) echo "aarch64-darwin" ;;
         *) echo "$1" ;;
@@ -84,6 +87,16 @@ build() {
                 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
             else
                 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld
+            fi
+            ;;
+        i686-unknown-linux-musl)
+            rustflags="-C target-feature=+crt-static $rustflags"
+            if command -v i686-unknown-linux-musl-gcc &> /dev/null; then
+                export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER=i686-unknown-linux-musl-gcc
+            elif command -v musl-gcc &> /dev/null; then
+                export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+            else
+                export CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER=rust-lld
             fi
             ;;
         aarch64-unknown-linux-musl)
@@ -155,6 +168,7 @@ main() {
             echo "  (none)                       Build for x86_64-unknown-linux-musl"
             echo "  x86_64-unknown-linux-musl    Build for x86_64 Linux (static)"
             echo "  aarch64-unknown-linux-musl   Build for aarch64 Linux (static)"
+            echo "  i686-unknown-linux-musl      Build for i686 Linux (static)"
             echo "  x86_64-apple-darwin          Build for x86_64 macOS"
             echo "  aarch64-apple-darwin         Build for aarch64 macOS (Apple Silicon)"
             echo "  --all                        Build for all targets"


### PR DESCRIPTION
Only the CI side was done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 32-bit x86 Linux environments, including improved architecture detection and resolution of matching binaries.
  * Expanded status/diagnostics views to include `i686-linux`, and added support for `i686-unknown-linux-musl` builds for static linking.

* **Bug Fixes**
  * Improved handling of `i686/i586/i486/i386`-style architecture identifiers to ensure correct matching and download/build target selection, preventing “unknown architecture” outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->