### PR TITLE
fix: suppress idle process poll debug noise

### DIFF
--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -33,6 +33,45 @@
 (defvar tramp-rpc-protocol--message-target nil
   "TRAMP vector or process used for level-6 protocol debug messages.")
 
+(defvar tramp-rpc-protocol--deferred-poll-messages (make-hash-table :test 'eql)
+  "Idle polling requests awaiting a response, keyed by request ID.
+Each value is a cons cell containing the target connection and request.")
+
+(defun tramp-rpc-protocol--clear-deferred-polls-for-target (target)
+  "Discard deferred poll messages associated with TARGET."
+  (let (ids)
+    (maphash
+     (lambda (id target-and-request)
+       (when (eq target (car target-and-request))
+         (push id ids)))
+     tramp-rpc-protocol--deferred-poll-messages)
+    (dolist (id ids)
+      (remhash id tramp-rpc-protocol--deferred-poll-messages))))
+
+(defun tramp-rpc-protocol--clear-deferred-polls ()
+  "Discard all deferred poll messages."
+  (clrhash tramp-rpc-protocol--deferred-poll-messages))
+
+(defun tramp-rpc-protocol--polling-method-p (method)
+  "Return non-nil when METHOD is a long-polling process read method."
+  (member method '("process.read" "process.read_pty")))
+
+(defun tramp-rpc-protocol--empty-poll-response-p (method response)
+  "Return non-nil when RESPONSE is an uneventful poll for METHOD."
+  (let ((result (plist-get response :result)))
+    (and (not (plist-get response :error))
+         (not (alist-get 'exited result))
+         (pcase method
+           ("process.read"
+            (and (assq 'stdout result)
+                 (assq 'stderr result)
+                 (not (alist-get 'stdout result))
+                 (not (alist-get 'stderr result))))
+           ("process.read_pty"
+            (and (assq 'output result)
+                 (not (alist-get 'output result))))
+           (_ nil)))))
+
 (defun tramp-rpc-protocol--message (object)
   "Log OBJECT as a level-6 Tramp debug message when possible."
   (when (and tramp-rpc-protocol--message-target
@@ -57,7 +96,13 @@ Returns a cons cell (ID . BYTES) for pipelining support."
                     (method . ,method)
                     (params . ,params)))
          (payload (msgpack-encode request)))
-    (tramp-rpc-protocol--message request)
+    ;; Idle process reads are continuous long polls.  Defer their request log
+    ;; until the response is known so empty polls produce no debug noise while
+    ;; output, exits, and errors still retain the complete request/response pair.
+    (if (tramp-rpc-protocol--polling-method-p method)
+        (puthash id (cons tramp-rpc-protocol--message-target request)
+                 tramp-rpc-protocol--deferred-poll-messages)
+      (tramp-rpc-protocol--message request))
     (cons id (tramp-rpc-protocol--length-prefix payload))))
 
 (defun tramp-rpc-protocol-decode-response (buffer start)
@@ -89,7 +134,17 @@ with :notification t, :method, and :params keys."
                              (list :code (alist-get 'code error-obj)
                                    :message (alist-get 'message error-obj)
                                    :data (alist-get 'data error-obj))))))))
-    (tramp-rpc-protocol--message result)
+    (if-let* ((target-and-request
+               (gethash id tramp-rpc-protocol--deferred-poll-messages))
+              (request (cdr target-and-request)))
+        (let ((tramp-rpc-protocol--message-target
+               (car target-and-request)))
+          (remhash id tramp-rpc-protocol--deferred-poll-messages)
+          (unless (tramp-rpc-protocol--empty-poll-response-p
+                   (alist-get 'method request) result)
+            (tramp-rpc-protocol--message request)
+            (tramp-rpc-protocol--message result)))
+      (tramp-rpc-protocol--message result))
     result))
 
 (defun tramp-rpc-protocol-error-p (response)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -477,7 +477,13 @@ proxy hops remain."
 ;; Silence byte-compiler warnings for functions defined elsewhere
 ;; (vterm variables are declared in tramp-rpc-process.el)
 
-;; Forward declarations for cache/watch functions (tramp-rpc-magit.el)
+;; Forward declarations for protocol and cache/watch functions.
+(declare-function tramp-rpc-protocol--clear-deferred-polls-for-target
+                  "tramp-rpc-protocol" (target))
+(declare-function tramp-rpc-protocol--clear-deferred-polls
+                  "tramp-rpc-protocol" ())
+
+;; Cache/watch functions (tramp-rpc-magit.el).
 (defvar tramp-rpc--cache-ttl)
 (defvar tramp-rpc--file-exists-cache)
 (defvar tramp-rpc--file-truename-cache)
@@ -1087,7 +1093,11 @@ hop."
 (defun tramp-rpc--remove-connection (vec)
   "Remove the RPC connection for VEC.
 Also clears the executable, exec-path, and login shell caches."
-  (let ((key (tramp-rpc--connection-key vec)))
+  (let* ((key (tramp-rpc--connection-key vec))
+         (conn (gethash key tramp-rpc--connections))
+         (process (plist-get conn :process)))
+    (when process
+      (tramp-rpc-protocol--clear-deferred-polls-for-target process))
     (remhash key tramp-rpc--connections)
     (remhash key tramp-rpc--exec-path-cache)
     (remhash key tramp-rpc--login-shell-cache))
@@ -1316,6 +1326,11 @@ Returns non-nil on success."
     (sleep-for 0.1)
     t))
 
+(defun tramp-rpc--connection-sentinel (process _event)
+  "Discard deferred protocol state when RPC connection PROCESS closes."
+  (unless (process-live-p process)
+    (tramp-rpc-protocol--clear-deferred-polls-for-target process)))
+
 (defun tramp-rpc--start-server-process (vec binary-path &optional sudo-password)
   "Start the RPC server on VEC at BINARY-PATH and verify it responds.
 BINARY-PATH is the remote localname of the server binary (may contain ~).
@@ -1386,10 +1401,16 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
     ;; if they are mixed into the stdout buffer the length-prefixed reader loses
     ;; framing and every call waits for the full RPC timeout.
     (with-current-buffer buffer
+      ;; This internal transport buffer is continuously appended to and
+      ;; drained by the process filter.  Recording those binary changes in an
+      ;; undo list wastes memory and can exceed `undo-outer-limit'.  Disable
+      ;; undo before clearing a reused buffer so that erase is not recorded.
+      (buffer-disable-undo)
       (erase-buffer)
       (set-buffer-multibyte nil)
       (set-marker (mark-marker) (point-min)))
     (with-current-buffer stderr-buffer
+      (buffer-disable-undo)
       (erase-buffer))
 
     ;; Start the process with pipe connection (not PTY).  PTYs have line
@@ -1405,7 +1426,8 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
            :coding 'binary
            :noquery t
            :stderr stderr-buffer
-           :filter #'tramp-rpc--connection-filter))
+           :filter #'tramp-rpc--connection-filter
+           :sentinel #'tramp-rpc--connection-sentinel))
 
     ;; If sudo is reading the password from stdin, send it before the RPC
     ;; server starts.  sudo consumes this line; after exec, the same pipe
@@ -5066,6 +5088,7 @@ cleanup of all connections has run."
   ;; Clear all RPC-specific caches.
   (clrhash tramp-rpc--pending-responses)
   (clrhash tramp-rpc--async-callbacks)
+  (tramp-rpc-protocol--clear-deferred-polls)
   (clrhash tramp-rpc--executable-cache)
   (tramp-rpc--clear-direnv-cache)
   (tramp-rpc--clear-file-metadata-caches)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -109,7 +109,7 @@ run_mock_selector() {
 
 run_protocol_tests() {
     echo -e "${YELLOW}Running protocol tests...${NC}"
-    run_mock_selector "^tramp-rpc-mock-test-protocol" 8
+    run_mock_selector "^tramp-rpc-mock-test-protocol" 9
 }
 
 server_available() {

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -76,6 +76,11 @@
 
 (require 'tramp-rpc-protocol)
 
+(declare-function tramp-rpc-protocol--clear-deferred-polls-for-target
+                  "tramp-rpc-protocol" (target))
+(declare-function tramp-rpc-protocol--clear-deferred-polls
+                  "tramp-rpc-protocol" ())
+
 (defun tramp-rpc-mock-test--bytes-string (data)
   "Return DATA as a plain byte string, unwrapping MessagePack bin."
   (if (and tramp-rpc-mock-test--msgpack-available (msgpack-bin-p data))
@@ -144,6 +149,74 @@
         (should (tramp-rpc-protocol-error-p response))
         (should (= (tramp-rpc-protocol-error-code response) -32001))
         (should (equal (tramp-rpc-protocol-error-message response) "File not found"))))))
+
+(ert-deftest tramp-rpc-mock-test-protocol-suppresses-empty-process-polls ()
+  "Empty process polls do not flood level-6 protocol logging."
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (let ((tramp-rpc-protocol--deferred-poll-messages
+         (make-hash-table :test 'eql))
+        (tramp-rpc-protocol--message-target 'target-a)
+        logged)
+    (cl-labels
+        ((roundtrip
+          (method response-fields)
+          (let* ((encoded (tramp-rpc-protocol-encode-request-with-id
+                           method '((pid . 1) (timeout_ms . 200))))
+                 (id (car encoded))
+                 (response-bytes
+                  (msgpack-encode
+                   (append `((version . "2.0") (id . ,id))
+                           response-fields))))
+            (with-temp-buffer
+              (set-buffer-multibyte nil)
+              (insert response-bytes)
+              ;; Deferred messages must use the target captured when the
+              ;; request was encoded, not the decoder's dynamic target.
+              (let ((tramp-rpc-protocol--message-target 'decode-target))
+                (tramp-rpc-protocol-decode-response
+                 (current-buffer) (point-min)))))))
+      (cl-letf (((symbol-function 'tramp-message)
+                 (lambda (target _level _format object)
+                   (push (cons target object) logged))))
+        ;; Successful empty pipe and PTY polls are omitted entirely.
+        (roundtrip "process.read"
+                   '((result . ((stdout) (stderr) (exited) (exit_code)))))
+        (roundtrip "process.read_pty"
+                   '((result . ((output) (exited) (exit_code)))))
+        (should-not logged)
+
+        ;; Output, exit, and error responses retain both sides of the trace.
+        (roundtrip "process.read"
+                   '((result . ((stdout . "output") (stderr)
+                                (exited) (exit_code)))))
+        (should (= 2 (length logged)))
+        (roundtrip "process.read_pty"
+                   '((result . ((output . "output") (exited) (exit_code)))))
+        (should (= 4 (length logged)))
+        (roundtrip "process.read"
+                   '((result . ((stdout) (stderr) (exited . t)
+                                (exit_code . 0)))))
+        (should (= 6 (length logged)))
+        (roundtrip "process.read"
+                   '((error . ((code . -32000) (message . "read failed")))))
+        (should (= 8 (length logged)))
+        (should (cl-every (lambda (entry) (eq (car entry) 'target-a))
+                          logged))
+        (should (= 0 (hash-table-count
+                      tramp-rpc-protocol--deferred-poll-messages)))
+
+        ;; Connection cleanup removes only that connection's pending polls.
+        (tramp-rpc-protocol-encode-request-with-id "process.read" nil)
+        (let ((tramp-rpc-protocol--message-target 'target-b))
+          (tramp-rpc-protocol-encode-request-with-id "process.read_pty" nil))
+        (should (= 2 (hash-table-count
+                      tramp-rpc-protocol--deferred-poll-messages)))
+        (tramp-rpc-protocol--clear-deferred-polls-for-target 'target-a)
+        (should (= 1 (hash-table-count
+                      tramp-rpc-protocol--deferred-poll-messages)))
+        (tramp-rpc-protocol--clear-deferred-polls)
+        (should (= 0 (hash-table-count
+                      tramp-rpc-protocol--deferred-poll-messages)))))))
 
 (ert-deftest tramp-rpc-mock-test-protocol-batch-encode ()
   "Test MessagePack-RPC batch request encoding."
@@ -243,8 +316,8 @@
         (puthash id t ids)))))
 
 (ert-deftest tramp-rpc-mock-test-runner-protocol-selector ()
-  "The protocol runner selector covers the eight protocol regressions."
-  (should (= (length (ert-select-tests "^tramp-rpc-mock-test-protocol" t)) 8)))
+  "The protocol runner selector covers the nine protocol regressions."
+  (should (= (length (ert-select-tests "^tramp-rpc-mock-test-protocol" t)) 9)))
 
 ;;; ============================================================================
 ;;; Mode String Conversion Tests
@@ -910,7 +983,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (set-file-modes wrapper #o755)
           (with-temp-file skipped
             (insert "(require 'ert)\n"
-                    "(dotimes (n 8)\n"
+                    "(dotimes (n 9)\n"
                     "  (eval `(ert-deftest ,(intern (format \"tramp-rpc-mock-test-protocol-skip-%d\" n)) () (ert-skip \"simulated\"))))\n"))
           (with-temp-file empty (insert "(require 'ert)\n"))
           (make-directory (expand-file-name "lisp" unsupported) t)
@@ -937,7 +1010,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
             (pcase-let ((`(,status ,output) (run skipped supported-source)))
               (should (/= status 0))
               (should (string-match-p
-                       "ERT counts: selected=8 executed=0 skipped=8" output)))
+                       "ERT counts: selected=9 executed=0 skipped=9" output)))
             (pcase-let ((`(,status ,output) (run empty supported-source)))
               (should (/= status 0))
               (should (string-match-p "selected zero tests" output)))


### PR DESCRIPTION
## Summary

- suppress successful empty `process.read` and `process.read_pty` request/response pairs at `tramp-verbose` 6
- preserve full protocol traces when polls return output, process exit, or an RPC error
- disable undo recording in the internal RPC stdout/stderr transport buffers
- add a protocol regression test and update the test-runner selector count

The logging change keeps level 6 aligned with TRAMP's sent/received protocol tracing without allowing idle long polls to fill the debug buffer. Disabling undo separately addresses the reported `undo-outer-limit` warning in the RPC connection buffer.

Fixes #253.

## Tests

- `TRAMP_SOURCE=/home/arthur/src/tramp ./test/run-tests.sh --protocol`
- `TRAMP_SOURCE=/home/arthur/src/tramp ./test/run-tests.sh --mock` (172 passed)
- byte-compiled all `lisp/*.el` with `byte-compile-error-on-warn`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced noisy debug logging by deferring and conditionally emitting logs for idle long-polling `process.read` / `process.read_pty` requests.
  - Cleared deferred polling state more reliably during per-target removal, connection shutdown, RPC process exit, and global cleanup.
  - Improved RPC startup buffer handling for binary stdout/stderr transport stability.

- **Tests**
  - Added a regression test confirming “empty poll” responses don’t create deferred log entries and that deferred state is cleaned up correctly.
  - Updated protocol mock test expectations (8 → 9).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->