### PR TITLE
fix: Properly format insert-directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ running "file-exists" and "file-read" benchmarks with rpc
     --eval '(tramp-rpc-benchmark-run-subset (quote ("file-exists" "file-read")) (quote ("rpc")))'
 ```
 
-# After changing rust code
+# Before pushing Rust changes
 After any changes to the rust source code, ALWAYS run `cargo fmt` and `cargo clippy` on the project. Fix any clippy or build warnings.
 
 # Before pushing Elisp changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ running "file-exists" and "file-read" benchmarks with rpc
     --eval '(tramp-rpc-benchmark-run-subset (quote ("file-exists" "file-read")) (quote ("rpc")))'
 ```
 
+# After changing rust code
+After any changes to the rust source code, ALWAYS run `cargo fmt` and `cargo clippy` on the project. Fix any clippy or build warnings.
+
 # Before pushing Elisp changes
 
 Always byte-compile all `.el` files before pushing to catch cross-module reference errors that CI will fail on. The project uses `byte-compile-error-on-warn`, so any missing `declare-function` for cross-module calls will fail the build.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2616,8 +2616,24 @@ so a single RPC can both validate and list the directory."
         (setq entries (seq-take entries count)))
       entries)))
 
+;; Declared in ls-lisp.el; dynamically rebound for rpc dired formatting.
+(defvar ls-lisp-format-time-list)
+(defvar ls-lisp-use-localized-time-format)
 ;; Declared in Tramp 2.8.1.3+; forward-declare so byte compiler treats it as dynamic.
 (defvar tramp-fnac-add-trailing-slash)
+
+(defun tramp-rpc-handle-insert-directory
+    (filename switches &optional wildcard full-directory-p)
+  "Like `insert-directory' for TRAMP-RPC files.
+Use `ls-lisp' via TRAMP, but force GNU ls-like date strings so rpc dired
+matches ssh dired output style."
+  ;; `ls-lisp-format-time-list' is honored only for the C/POSIX locale unless
+  ;; `ls-lisp-use-localized-time-format' is non-nil; force it so the GNU-style
+  ;; format applies regardless of the local locale.
+  (let ((ls-lisp-format-time-list '("%b %e %H:%M" "%b %e  %Y"))
+        (ls-lisp-use-localized-time-format t))
+    (tramp-handle-insert-directory
+     filename switches wildcard full-directory-p)))
 
 (defun tramp-rpc-handle-file-name-all-completions (filename directory)
   "Like `file-name-all-completions' for TRAMP-RPC files."
@@ -4827,7 +4843,7 @@ Also controls process exit detection latency."
     (make-directory . tramp-rpc-handle-make-directory)
     (delete-directory . tramp-rpc-handle-delete-directory)
     (dired-compress-file . tramp-rpc-handle-dired-compress-file)
-    (insert-directory . tramp-handle-insert-directory)
+    (insert-directory . tramp-rpc-handle-insert-directory)
     (copy-directory . tramp-rpc-handle-copy-directory)
 
     ;; =========================================================================

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -235,6 +235,7 @@ This is called from `tramp-multi-hop-p-hook'."
 ;; Silence byte-compiler warnings for functions defined in with-eval-after-load
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
+(declare-function tramp-handle-insert-directory "tramp")
 (declare-function dired-compress-file "dired-aux")
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -133,11 +133,22 @@ fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
     }
 }
 
+/// Selects whether to resolve a user (uid) or group (gid) name.
+#[derive(Clone, Copy)]
+enum NssKind {
+    User,
+    Group,
+}
+
 /// Cache of uid -> resolved name. A cached `None` records a *definitive*
 /// miss (the uid is absent from all NSS databases). Transient failures
 /// (timeout, backend unavailable) are not cached so a later lookup can
 /// succeed once the directory service recovers.
 static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Cache of gid -> resolved name. Same caching semantics as `USER_NAMES`.
+static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Initial buffer size hint from sysconf, or a reasonable default.
@@ -146,9 +157,10 @@ fn sysconf_bufsize(name: libc::c_int, fallback: usize) -> usize {
     if ret > 0 { ret as usize } else { fallback }
 }
 
-/// Maximum buffer size we will attempt before giving up (1 MiB).
-/// Used for both getpwuid_r and getgrgid_r retry loops.
-const MAX_NSS_BUFSIZE: usize = 1024 * 1024;
+/// Maximum buffer size we will attempt before giving up (64 KiB).
+/// Even large LDAP group records with many members stay well below this;
+/// if a record genuinely exceeds 64 KiB the getent fallback will handle it.
+const MAX_NSS_BUFSIZE: usize = 64 * 1024;
 
 /// Maximum wall-clock time to wait for a `getent` fallback lookup before
 /// giving up. NSS backends (LDAP, SSSD) can hang indefinitely when the
@@ -232,42 +244,79 @@ fn getent_name(database: &str, id: u32) -> Result<Option<String>, ()> {
     }
 }
 
-/// Get user name from uid using thread-safe getpwuid_r.
+/// Shared NSS name resolution for both uid and gid.
 ///
-/// Uses `sysconf(_SC_GETPW_R_SIZE_MAX)` for the initial buffer size and
-/// retries with a doubled buffer on `ERANGE`, which can happen when user
-/// records are served by LDAP or other NSS backends that return large
-/// entries.
-///
-/// The mutex is only held for cache lookups/inserts, not during the
-/// (potentially slow) NSS syscall, to avoid blocking other threads
-/// when the directory backend is slow.
-pub fn get_user_name(uid: u32) -> Option<String> {
+/// Uses `getpwuid_r` or `getgrgid_r` (selected by `kind`) with a
+/// sysconf-hinted buffer that doubles on `ERANGE`, falls back to `getent`
+/// on libc errors, and caches only definitive results so transient failures
+/// (timeout, backend unavailable) can be retried on a later lookup.
+fn resolve_nss_name(
+    cache: &'static Mutex<HashMap<u32, Option<String>>>,
+    kind: NssKind,
+    id: u32,
+) -> Option<String> {
     // Fast path: check cache under lock, release immediately.
     {
-        let cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(result) = cache.get(&uid) {
+        let c = cache.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(result) = c.get(&id) {
             return result.clone();
         }
     }
 
-    // Slow path: perform the syscall without holding the lock.
-    let init_size = sysconf_bufsize(libc::_SC_GETPW_R_SIZE_MAX, 1024);
-    let mut bufsize = init_size;
+    let (bufsize_hint, database) = match kind {
+        NssKind::User => (libc::_SC_GETPW_R_SIZE_MAX, "passwd"),
+        NssKind::Group => (libc::_SC_GETGR_R_SIZE_MAX, "group"),
+    };
+
+    let mut bufsize = sysconf_bufsize(bufsize_hint, 1024);
 
     let name_result: Result<Option<String>, ()> = loop {
         let mut buf = vec![0u8; bufsize];
-        let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
-        let mut result_ptr: *mut libc::passwd = std::ptr::null_mut();
 
-        let ret = unsafe {
-            libc::getpwuid_r(
-                uid,
-                &mut pwd,
-                buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len(),
-                &mut result_ptr,
-            )
+        // Perform the appropriate libc call and extract (ret, name_string).
+        // The name pointer is converted to an owned String within the match
+        // arm while `buf` is still in scope, so no raw pointer escapes.
+        let (ret, result_null, name_str) = match kind {
+            NssKind::User => {
+                let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+                let mut result_ptr: *mut libc::passwd = std::ptr::null_mut();
+                let ret = unsafe {
+                    libc::getpwuid_r(
+                        id,
+                        &mut pwd,
+                        buf.as_mut_ptr() as *mut libc::c_char,
+                        buf.len(),
+                        &mut result_ptr,
+                    )
+                };
+                let name_str = if !result_ptr.is_null() {
+                    let cname = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
+                    cname.to_str().ok().map(|s| s.to_string())
+                } else {
+                    None
+                };
+                (ret, result_ptr.is_null(), name_str)
+            }
+            NssKind::Group => {
+                let mut grp: libc::group = unsafe { std::mem::zeroed() };
+                let mut result_ptr: *mut libc::group = std::ptr::null_mut();
+                let ret = unsafe {
+                    libc::getgrgid_r(
+                        id,
+                        &mut grp,
+                        buf.as_mut_ptr() as *mut libc::c_char,
+                        buf.len(),
+                        &mut result_ptr,
+                    )
+                };
+                let name_str = if !result_ptr.is_null() {
+                    let cname = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };
+                    cname.to_str().ok().map(|s| s.to_string())
+                } else {
+                    None
+                };
+                (ret, result_ptr.is_null(), name_str)
+            }
         };
 
         if ret == libc::ERANGE && bufsize < MAX_NSS_BUFSIZE {
@@ -275,107 +324,38 @@ pub fn get_user_name(uid: u32) -> Option<String> {
             continue;
         }
 
-        if ret == 0 && result_ptr.is_null() {
-            // Definitive miss: uid is absent from all NSS databases libc
+        if ret == 0 && result_null {
+            // Definitive miss: id is absent from all NSS databases libc
             // can reach. No need to try getent.
             break Ok(None);
         }
 
         if ret != 0 {
             // libc error (backend unavailable, etc.): try getent fallback.
-            break getent_name("passwd", uid);
+            break getent_name(database, id);
         }
 
-        let cname = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
-        break Ok(cname.to_str().ok().map(|s| s.to_string()));
+        break Ok(name_str);
     };
 
     // Cache only definitive results. Transient failures (Err) are not
     // cached so a later lookup can succeed once the service recovers.
     match name_result {
         Ok(name) => {
-            let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-            cache.insert(uid, name.clone());
+            let mut c = cache.lock().unwrap_or_else(|e| e.into_inner());
+            c.insert(id, name.clone());
             name
         }
         Err(()) => None,
     }
 }
 
-/// Cache of gid -> resolved name. A cached `None` records a *definitive*
-/// miss (the gid is absent from all NSS databases). Transient failures
-/// (timeout, backend unavailable) are not cached so a later lookup can
-/// succeed once the directory service recovers.
-static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+pub fn get_user_name(uid: u32) -> Option<String> {
+    resolve_nss_name(&USER_NAMES, NssKind::User, uid)
+}
 
-/// Get group name from gid using thread-safe getgrgid_r.
-///
-/// Uses `sysconf(_SC_GETGR_R_SIZE_MAX)` for the initial buffer size and
-/// retries with a doubled buffer on `ERANGE`, which can happen when group
-/// records are served by LDAP or other NSS backends that return large
-/// entries (e.g. groups with many members).
-///
-/// The mutex is only held for cache lookups/inserts, not during the
-/// (potentially slow) NSS syscall.
 pub fn get_group_name(gid: u32) -> Option<String> {
-    // Fast path: check cache under lock, release immediately.
-    {
-        let cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(result) = cache.get(&gid) {
-            return result.clone();
-        }
-    }
-
-    // Slow path: perform the syscall without holding the lock.
-    let init_size = sysconf_bufsize(libc::_SC_GETGR_R_SIZE_MAX, 1024);
-    let mut bufsize = init_size;
-
-    let name_result: Result<Option<String>, ()> = loop {
-        let mut buf = vec![0u8; bufsize];
-        let mut grp: libc::group = unsafe { std::mem::zeroed() };
-        let mut result_ptr: *mut libc::group = std::ptr::null_mut();
-
-        let ret = unsafe {
-            libc::getgrgid_r(
-                gid,
-                &mut grp,
-                buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len(),
-                &mut result_ptr,
-            )
-        };
-
-        if ret == libc::ERANGE && bufsize < MAX_NSS_BUFSIZE {
-            bufsize = bufsize.saturating_mul(2).min(MAX_NSS_BUFSIZE);
-            continue;
-        }
-
-        if ret == 0 && result_ptr.is_null() {
-            // Definitive miss: gid is absent from all NSS databases libc
-            // can reach. No need to try getent.
-            break Ok(None);
-        }
-
-        if ret != 0 {
-            // libc error (backend unavailable, etc.): try getent fallback.
-            break getent_name("group", gid);
-        }
-
-        let cname = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };
-        break Ok(cname.to_str().ok().map(|s| s.to_string()));
-    };
-
-    // Cache only definitive results. Transient failures (Err) are not
-    // cached so a later lookup can succeed once the service recovers.
-    match name_result {
-        Ok(name) => {
-            let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-            cache.insert(gid, name.clone());
-            name
-        }
-        Err(()) => None,
-    }
+    resolve_nss_name(&GROUP_NAMES, NssKind::Group, gid)
 }
 
 pub fn map_io_error(err: std::io::Error, path: &str) -> RpcError {

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
+use std::process::Command;
 use std::sync::Mutex;
 use tokio::fs;
 
@@ -136,6 +137,27 @@ fn sysconf_bufsize(name: libc::c_int, fallback: usize) -> usize {
 /// Used for both getpwuid_r and getgrgid_r retry loops.
 const MAX_NSS_BUFSIZE: usize = 1024 * 1024;
 
+fn getent_name(database: &str, id: u32) -> Option<String> {
+    let output = Command::new("getent")
+        .arg(database)
+        .arg(id.to_string())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = std::str::from_utf8(&output.stdout)
+        .ok()?
+        .lines()
+        .next()?;
+    let name = line.split(':').next()?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
 /// Get user name from uid using thread-safe getpwuid_r.
 ///
 /// Uses `sysconf(_SC_GETPW_R_SIZE_MAX)` for the initial buffer size and
@@ -180,7 +202,7 @@ pub fn get_user_name(uid: u32) -> Option<String> {
         }
 
         if ret != 0 || result_ptr.is_null() {
-            return None;
+            break getent_name("passwd", uid);
         }
 
         let cname = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
@@ -242,7 +264,7 @@ pub fn get_group_name(gid: u32) -> Option<String> {
         }
 
         if ret != 0 || result_ptr.is_null() {
-            return None;
+            break getent_name("group", gid);
         }
 
         let cname = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -146,10 +146,7 @@ fn getent_name(database: &str, id: u32) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    let line = std::str::from_utf8(&output.stdout)
-        .ok()?
-        .lines()
-        .next()?;
+    let line = std::str::from_utf8(&output.stdout).ok()?.lines().next()?;
     let name = line.split(':').next()?;
     if name.is_empty() {
         None

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -86,13 +86,20 @@ pub async fn get_file_attributes(path: &Path, lstat: bool) -> Result<FileAttribu
     let uid = metadata.uid();
     let gid = metadata.gid();
 
+    // Name resolution can block (libc NSS + getent subprocess): run it on a
+    // dedicated blocking thread so Tokio worker threads are not stalled.
+    let (uname, gname) =
+        tokio::task::spawn_blocking(move || (get_user_name(uid), get_group_name(gid)))
+            .await
+            .unwrap_or((None, None));
+
     Ok(FileAttributes {
         file_type,
         nlinks: metadata.nlink(),
         uid,
         gid,
-        uname: get_user_name(uid),
-        gname: get_group_name(gid),
+        uname,
+        gname,
         atime: metadata.atime(),
         mtime: metadata.mtime(),
         ctime: metadata.ctime(),
@@ -126,9 +133,10 @@ fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
     }
 }
 
-/// Cache of uid -> resolved name. A cached `None` records a *failed*
-/// resolution so repeated lookups of an unknown uid neither re-enter the
-/// libc NSS call nor re-spawn `getent`.
+/// Cache of uid -> resolved name. A cached `None` records a *definitive*
+/// miss (the uid is absent from all NSS databases). Transient failures
+/// (timeout, backend unavailable) are not cached so a later lookup can
+/// succeed once the directory service recovers.
 static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -154,12 +162,17 @@ const GETENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Resolve a uid/gid to a name via the `getent` command, used only as a
 /// fallback when the reentrant libc lookup fails.
 ///
-/// The child runs on this (dedicated blocking) thread but is bounded by a
-/// finite deadline: if `getent` does not exit within `GETENT_TIMEOUT` the
-/// child is killed and `None` is returned, so a hung NSS backend can never
-/// block attribute generation indefinitely. The `Option`-based contract of
-/// the previous implementation is preserved.
-fn getent_name(database: &str, id: u32) -> Option<String> {
+/// Returns a tri-state:
+/// - `Ok(Some(name))`: id resolved successfully.
+/// - `Ok(None)`: id is definitively absent (getent exited non-zero cleanly).
+/// - `Err(())`: transient failure (spawn error, timeout, I/O error); the
+///   caller must *not* cache this result so a later lookup can succeed once
+///   the directory service recovers.
+///
+/// Stdout is drained on a dedicated thread so the child can never block
+/// when its output exceeds the pipe buffer (e.g. `getent group` with many
+/// members). The deadline kills the child if it does not exit in time.
+fn getent_name(database: &str, id: u32) -> Result<Option<String>, ()> {
     let mut child = Command::new("getent")
         .arg(database)
         .arg(id.to_string())
@@ -167,7 +180,16 @@ fn getent_name(database: &str, id: u32) -> Option<String> {
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .ok()?;
+        .map_err(|_| ())?;
+
+    // Drain stdout on a separate thread so the child is never blocked
+    // writing when its output exceeds the pipe buffer.
+    let mut stdout = child.stdout.take().ok_or(())?;
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        stdout.read_to_end(&mut buf).ok();
+        buf
+    });
 
     let deadline = Instant::now() + GETENT_TIMEOUT;
     let status = loop {
@@ -178,31 +200,35 @@ fn getent_name(database: &str, id: u32) -> Option<String> {
                     // Deadline expired: terminate the child and give up.
                     let _ = child.kill();
                     let _ = child.wait();
-                    return None;
+                    let _ = reader.join();
+                    return Err(()); // transient: timeout
                 }
                 std::thread::sleep(GETENT_POLL_INTERVAL);
             }
             Err(_) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return None;
+                let _ = reader.join();
+                return Err(()); // transient: I/O error on try_wait
             }
         }
     };
 
+    let buf = reader.join().map_err(|_| ())?;
+
     if !status.success() {
-        return None;
+        return Ok(None); // definitive: id does not exist in any NSS database
     }
 
-    let mut stdout = child.stdout.take()?;
-    let mut buf = Vec::new();
-    stdout.read_to_end(&mut buf).ok()?;
-    let line = std::str::from_utf8(&buf).ok()?.lines().next()?;
-    let name = line.split(':').next()?;
+    let line = std::str::from_utf8(&buf)
+        .ok()
+        .and_then(|s| s.lines().next())
+        .ok_or(())?;
+    let name = line.split(':').next().ok_or(())?;
     if name.is_empty() {
-        None
+        Ok(None)
     } else {
-        Some(name.to_string())
+        Ok(Some(name.to_string()))
     }
 }
 
@@ -229,7 +255,7 @@ pub fn get_user_name(uid: u32) -> Option<String> {
     let init_size = sysconf_bufsize(libc::_SC_GETPW_R_SIZE_MAX, 1024);
     let mut bufsize = init_size;
 
-    let name = loop {
+    let name_result: Result<Option<String>, ()> = loop {
         let mut buf = vec![0u8; bufsize];
         let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
         let mut result_ptr: *mut libc::passwd = std::ptr::null_mut();
@@ -249,27 +275,37 @@ pub fn get_user_name(uid: u32) -> Option<String> {
             continue;
         }
 
-        if ret != 0 || result_ptr.is_null() {
+        if ret == 0 && result_ptr.is_null() {
+            // Definitive miss: uid is absent from all NSS databases libc
+            // can reach. No need to try getent.
+            break Ok(None);
+        }
+
+        if ret != 0 {
+            // libc error (backend unavailable, etc.): try getent fallback.
             break getent_name("passwd", uid);
         }
 
         let cname = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
-        break cname.to_str().ok().map(|s| s.to_string());
+        break Ok(cname.to_str().ok().map(|s| s.to_string()));
     };
 
-    // Re-acquire lock to cache the result -- including a failed (`None`)
-    // resolution, so an unknown uid is not looked up repeatedly.
-    {
-        let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        cache.insert(uid, name.clone());
+    // Cache only definitive results. Transient failures (Err) are not
+    // cached so a later lookup can succeed once the service recovers.
+    match name_result {
+        Ok(name) => {
+            let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+            cache.insert(uid, name.clone());
+            name
+        }
+        Err(()) => None,
     }
-
-    name
 }
 
-/// Cache of gid -> resolved name. A cached `None` records a *failed*
-/// resolution so repeated lookups of an unknown gid neither re-enter the
-/// libc NSS call nor re-spawn `getent`.
+/// Cache of gid -> resolved name. A cached `None` records a *definitive*
+/// miss (the gid is absent from all NSS databases). Transient failures
+/// (timeout, backend unavailable) are not cached so a later lookup can
+/// succeed once the directory service recovers.
 static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -295,7 +331,7 @@ pub fn get_group_name(gid: u32) -> Option<String> {
     let init_size = sysconf_bufsize(libc::_SC_GETGR_R_SIZE_MAX, 1024);
     let mut bufsize = init_size;
 
-    let name = loop {
+    let name_result: Result<Option<String>, ()> = loop {
         let mut buf = vec![0u8; bufsize];
         let mut grp: libc::group = unsafe { std::mem::zeroed() };
         let mut result_ptr: *mut libc::group = std::ptr::null_mut();
@@ -315,22 +351,31 @@ pub fn get_group_name(gid: u32) -> Option<String> {
             continue;
         }
 
-        if ret != 0 || result_ptr.is_null() {
+        if ret == 0 && result_ptr.is_null() {
+            // Definitive miss: gid is absent from all NSS databases libc
+            // can reach. No need to try getent.
+            break Ok(None);
+        }
+
+        if ret != 0 {
+            // libc error (backend unavailable, etc.): try getent fallback.
             break getent_name("group", gid);
         }
 
         let cname = unsafe { std::ffi::CStr::from_ptr(grp.gr_name) };
-        break cname.to_str().ok().map(|s| s.to_string());
+        break Ok(cname.to_str().ok().map(|s| s.to_string()));
     };
 
-    // Re-acquire lock to cache the result -- including a failed (`None`)
-    // resolution, so an unknown gid is not looked up repeatedly.
-    {
-        let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        cache.insert(gid, name.clone());
+    // Cache only definitive results. Transient failures (Err) are not
+    // cached so a later lookup can succeed once the service recovers.
+    match name_result {
+        Ok(name) => {
+            let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
+            cache.insert(gid, name.clone());
+            name
+        }
+        Err(()) => None,
     }
-
-    name
 }
 
 pub fn map_io_error(err: std::io::Error, path: &str) -> RpcError {

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -4,10 +4,12 @@ use crate::protocol::{FileAttributes, FileType, RpcError, from_value};
 use rmpv::Value;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::io::Read;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tokio::fs;
 
 use super::HandlerResult;
@@ -124,7 +126,10 @@ fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
     }
 }
 
-static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, String>>> =
+/// Cache of uid -> resolved name. A cached `None` records a *failed*
+/// resolution so repeated lookups of an unknown uid neither re-enter the
+/// libc NSS call nor re-spawn `getent`.
+static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Initial buffer size hint from sysconf, or a reasonable default.
@@ -137,16 +142,62 @@ fn sysconf_bufsize(name: libc::c_int, fallback: usize) -> usize {
 /// Used for both getpwuid_r and getgrgid_r retry loops.
 const MAX_NSS_BUFSIZE: usize = 1024 * 1024;
 
+/// Maximum wall-clock time to wait for a `getent` fallback lookup before
+/// giving up. NSS backends (LDAP, SSSD) can hang indefinitely when the
+/// directory service is unreachable; without a bound this would stall
+/// attribute generation for every unresolved id.
+const GETENT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Poll interval while waiting for the child to exit.
+const GETENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Resolve a uid/gid to a name via the `getent` command, used only as a
+/// fallback when the reentrant libc lookup fails.
+///
+/// The child runs on this (dedicated blocking) thread but is bounded by a
+/// finite deadline: if `getent` does not exit within `GETENT_TIMEOUT` the
+/// child is killed and `None` is returned, so a hung NSS backend can never
+/// block attribute generation indefinitely. The `Option`-based contract of
+/// the previous implementation is preserved.
 fn getent_name(database: &str, id: u32) -> Option<String> {
-    let output = Command::new("getent")
+    let mut child = Command::new("getent")
         .arg(database)
         .arg(id.to_string())
-        .output()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .ok()?;
-    if !output.status.success() {
+
+    let deadline = Instant::now() + GETENT_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // Deadline expired: terminate the child and give up.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(GETENT_POLL_INTERVAL);
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+
+    if !status.success() {
         return None;
     }
-    let line = std::str::from_utf8(&output.stdout).ok()?.lines().next()?;
+
+    let mut stdout = child.stdout.take()?;
+    let mut buf = Vec::new();
+    stdout.read_to_end(&mut buf).ok()?;
+    let line = std::str::from_utf8(&buf).ok()?.lines().next()?;
     let name = line.split(':').next()?;
     if name.is_empty() {
         None
@@ -170,7 +221,7 @@ pub fn get_user_name(uid: u32) -> Option<String> {
     {
         let cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(result) = cache.get(&uid) {
-            return Some(result.clone());
+            return result.clone();
         }
     }
 
@@ -206,16 +257,20 @@ pub fn get_user_name(uid: u32) -> Option<String> {
         break cname.to_str().ok().map(|s| s.to_string());
     };
 
-    // Re-acquire lock to insert into cache.
-    if let Some(ref n) = name {
+    // Re-acquire lock to cache the result -- including a failed (`None`)
+    // resolution, so an unknown uid is not looked up repeatedly.
+    {
         let mut cache = USER_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        cache.insert(uid, n.clone());
+        cache.insert(uid, name.clone());
     }
 
     name
 }
 
-static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, String>>> =
+/// Cache of gid -> resolved name. A cached `None` records a *failed*
+/// resolution so repeated lookups of an unknown gid neither re-enter the
+/// libc NSS call nor re-spawn `getent`.
+static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Get group name from gid using thread-safe getgrgid_r.
@@ -232,7 +287,7 @@ pub fn get_group_name(gid: u32) -> Option<String> {
     {
         let cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(result) = cache.get(&gid) {
-            return Some(result.clone());
+            return result.clone();
         }
     }
 
@@ -268,10 +323,11 @@ pub fn get_group_name(gid: u32) -> Option<String> {
         break cname.to_str().ok().map(|s| s.to_string());
     };
 
-    // Re-acquire lock to insert into cache.
-    if let Some(ref n) = name {
+    // Re-acquire lock to cache the result -- including a failed (`None`)
+    // resolution, so an unknown gid is not looked up repeatedly.
+    {
         let mut cache = GROUP_NAMES.lock().unwrap_or_else(|e| e.into_inner());
-        cache.insert(gid, n.clone());
+        cache.insert(gid, name.clone());
     }
 
     name

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -171,6 +171,32 @@ const GETENT_TIMEOUT: Duration = Duration::from_secs(2);
 /// Poll interval while waiting for the child to exit.
 const GETENT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// Maximum time to wait for the reader thread to finish after killing the child.
+/// Bounds `reader.join()` in case an orphaned process inherited the pipe write-end.
+const GETENT_READER_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Join the reader thread with a bounded timeout.
+///
+/// After `child.kill()` + `child.wait()` the direct child's write-end of the
+/// pipe is closed, but an orphaned subprocess that inherited the fd would keep
+/// `read_to_end` (and therefore `join`) blocked forever.  We poll
+/// `is_finished` for up to `GETENT_READER_TIMEOUT`; if it doesn't complete we
+/// leak the thread (it will eventually unblock once the orphan exits or the
+/// pipe is otherwise closed).
+fn bounded_join_reader(reader: std::thread::JoinHandle<Vec<u8>>) {
+    let deadline = Instant::now() + GETENT_READER_TIMEOUT;
+    loop {
+        if reader.is_finished() {
+            let _ = reader.join();
+            return;
+        }
+        if Instant::now() >= deadline {
+            return; // leak thread; unblocks once all pipe write-ends close
+        }
+        std::thread::sleep(GETENT_POLL_INTERVAL);
+    }
+}
+
 /// Resolve a uid/gid to a name via the `getent` command, used only as a
 /// fallback when the reentrant libc lookup fails.
 ///
@@ -212,7 +238,7 @@ fn getent_name(database: &str, id: u32) -> Result<Option<String>, ()> {
                     // Deadline expired: terminate the child and give up.
                     let _ = child.kill();
                     let _ = child.wait();
-                    let _ = reader.join();
+                    bounded_join_reader(reader);
                     return Err(()); // transient: timeout
                 }
                 std::thread::sleep(GETENT_POLL_INTERVAL);
@@ -220,7 +246,7 @@ fn getent_name(database: &str, id: u32) -> Result<Option<String>, ()> {
             Err(_) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                let _ = reader.join();
+                bounded_join_reader(reader);
                 return Err(()); // transient: I/O error on try_wait
             }
         }

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -280,7 +280,7 @@ pub async fn read(params: Value) -> HandlerResult {
 
     // Check if process has exited.  Reacquire the map briefly; do not hold it
     // across any await points above.
-    let exit_status = {
+    let mut exit_status = {
         let mut processes = get_process_map().lock().await;
         let managed = processes
             .get_mut(&params.pid)
@@ -288,6 +288,27 @@ pub async fn read(params: Value) -> HandlerResult {
         poll_exit_status(managed)
             .map_err(|e| RpcError::process_error(format!("Failed to query process status: {e}")))?
     };
+
+    // When both pipes are at EOF the child has already closed all its file
+    // descriptors, which means it has exited (or is in the act of exiting).
+    // There is a tiny race on Linux between the child closing its fds and
+    // the kernel updating its wait table: try_wait() may return None for a
+    // brief window even though the pipes are done.  Yield to the runtime a
+    // few times so it can process the SIGCHLD notification, then retry.
+    if exit_status.is_none() && stdout_eof && stderr_eof {
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+            let mut processes = get_process_map().lock().await;
+            if let Some(managed) = processes.get_mut(&params.pid) {
+                exit_status = poll_exit_status(managed).map_err(|e| {
+                    RpcError::process_error(format!("Failed to query process status: {e}"))
+                })?;
+                if exit_status.is_some() {
+                    break;
+                }
+            }
+        }
+    }
 
     // Child exit and pipe EOF are separate events.  A child can exit after a
     // read returns data while additional bytes are still buffered in either


### PR DESCRIPTION
Currently tramp-rpc will use the ID's for groups and users in dired. This changes enables it to match the behavior of ssh and local dired by using the group and user names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRAMP-RPC directory listings by standardizing `ls` date formatting for more consistent RPC dired output.
  * Improved UID/GID-to-name resolution by avoiding async stalls, adding a bounded `getent` fallback, and caching definitive misses.
* **Documentation / Chores**
  * Updated contribution guidance to run `cargo fmt` and `cargo clippy` after Rust changes and resolve any warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->