### PR TITLE
fix: honor remote path during executable lookup

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -42,6 +42,7 @@
 (declare-function tramp-rpc--call-batch "tramp-rpc")
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
+(declare-function tramp-rpc--resolve-executable "tramp-rpc")
 (declare-function tramp-rpc--decode-string "tramp-rpc")
 (declare-function tramp-rpc--encode-path "tramp-rpc")
 (declare-function tramp-rpc--convert-file-attributes "tramp-rpc")
@@ -729,17 +730,31 @@ the gitdir) and the results are cached in `tramp-rpc--file-exists-cache'.")
       (cmd . "test")
       (args . ["-e" ,full-path]))))
 
-(defun tramp-rpc-magit--prefetch-git-commands (directory)
+(defun tramp-rpc-magit--git-program (&optional vec)
+  "Return the git executable to use for prefetch commands on VEC.
+
+`commands.run_parallel' spawns commands directly on the server, which
+inherits the SSH session PATH and knows nothing about `tramp-remote-path'.
+Resolve git against the configured remote PATH (cached per connection) so
+prefetched output comes from the same git that `process-file' would use.
+Falls back to \"git\" when VEC is nil or lookup fails."
+  (if vec
+      (tramp-rpc--resolve-executable vec "git")
+    "git"))
+
+(defun tramp-rpc-magit--prefetch-git-commands (directory &optional vec)
   "Build the list of git commands to prefetch for DIRECTORY.
 Returns a vector of command entries for commands.run_parallel.
 Each entry has key, cmd, args, and cwd fields.  Git command keys
 match what `tramp-rpc-magit--process-cache-lookup' will look up.
-State file checks use \"state_file:PATH\" keys."
+State file checks use \"state_file:PATH\" keys.
+VEC resolves git against the configured remote PATH."
   (let ((cmds nil)
+        (git (tramp-rpc-magit--git-program vec))
         (gitdir (concat (file-name-as-directory directory) ".git")))
     (cl-flet ((add-git (&rest args)
                 (push `((key . ,(apply #'tramp-rpc-magit--process-cache-key args))
-                        (cmd . "git")
+                        (cmd . ,git)
                         (args . ,(vconcat (append tramp-rpc-magit--git-prefetch-prefix-args
                                                    args)))
                         (cwd . ,directory))
@@ -841,10 +856,11 @@ State file checks use \"state_file:PATH\" keys."
 
     (vconcat (nreverse cmds))))
 
-(defun tramp-rpc-magit--git-command-entry (directory args)
-  "Return a commands.run_parallel entry for git ARGS in DIRECTORY."
+(defun tramp-rpc-magit--git-command-entry (directory args &optional vec)
+  "Return a commands.run_parallel entry for git ARGS in DIRECTORY.
+VEC resolves git against the configured remote PATH."
   `((key . ,(apply #'tramp-rpc-magit--process-cache-key args))
-    (cmd . "git")
+    (cmd . ,(tramp-rpc-magit--git-program vec))
     (args . ,(vconcat (append tramp-rpc-magit--git-prefetch-prefix-args args)))
     (cwd . ,directory)))
 
@@ -1056,7 +1072,7 @@ upstream names, and commands used to wash already-expanded file sections."
            (add-git (&rest args)
              (let ((key (apply #'tramp-rpc-magit--process-cache-key args)))
                (unless (gethash key cache)
-                 (push (tramp-rpc-magit--git-command-entry root-local args)
+                 (push (tramp-rpc-magit--git-command-entry root-local args vec)
                        commands))))
            (add-state-dir (gitdir)
              (dolist (sf tramp-rpc-magit--state-files)
@@ -1162,7 +1178,7 @@ when the status cache has expired but TAB is expanding a single file section."
               v "commands.run_parallel"
               `((commands . ,(vector
                               (tramp-rpc-magit--git-command-entry
-                               root-local '("rev-parse" "HEAD"))))))))
+                               root-local '("rev-parse" "HEAD") v)))))))
           (setq cache (tramp-rpc-magit--get-process-cache))
           (let* ((head-entry (and cache
                                   (gethash (tramp-rpc-magit--process-cache-key
@@ -1173,7 +1189,7 @@ when the status cache has expired but TAB is expanding a single file section."
                  (commands nil))
             (cl-labels ((add (&rest args)
                           (push (tramp-rpc-magit--git-command-entry
-                                 root-local args)
+                                 root-local args v)
                                 commands)))
               (add "diff" "--quiet" "--cached" "--submodule=short"
                    "--" rel-file)
@@ -1293,7 +1309,7 @@ as the process-file cache.  Also fetches ancestor markers."
         ;; --refresh' is intentionally not part of this prefetch; it is run by
         ;; Magit in the real refresh sequence, and `tramp-rpc-handle-process-file'
         ;; triggers this prefetch immediately after that command completes.
-        (let* ((commands (tramp-rpc-magit--prefetch-git-commands localname))
+        (let* ((commands (tramp-rpc-magit--prefetch-git-commands localname v))
                (results (tramp-rpc--call v "commands.run_parallel"
                                          `((commands . ,commands)))))
           (when results

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1016,33 +1016,25 @@ Results are cached per connection."
            (or found program)))))))
 
 (defun tramp-rpc--find-executable (vec program)
-  "Find PROGRAM in the remote PATH on VEC.
-Returns the absolute path or nil.
-Uses `command -v` via the user's login shell for lookup, so that
-executables in shell-specific PATH entries are found.
-Uses a unique marker to separate MOTD/banner text from actual output,
-following the pattern used by standard TRAMP."
+  "Find PROGRAM in the configured remote PATH on VEC.
+Returns the absolute path or nil."
   (condition-case err
-      (let* (;; Use a unique marker (MD5 hash) to delimit output from MOTD text
-             ;; This is the same approach used by tramp-sh.el
-             (marker (md5 (format "tramp-rpc-%s-%s" program (float-time))))
-             (shell (tramp-rpc--get-remote-login-shell vec))
-             (result (tramp-rpc--call vec "process.run"
-                                       `((cmd . ,shell)
-                                         (args . ["-l" "-c"
-                                                  ,(format "echo %s; command -v %s"
-                                                            marker (tramp-shell-quote-argument program))])
-                                         (cwd . "/"))))
+      (let* ((shell (tramp-rpc--get-remote-login-shell vec))
+             (result (tramp-rpc--call
+                      vec "process.run"
+                      `((cmd . ,shell)
+                        (args . ["-c" ,(format "command -v %s"
+                                               (tramp-shell-quote-argument program))])
+                        (cwd . "/")
+                        (env . ,(tramp-rpc--remote-path-environment vec)))))
              (exit-code (alist-get 'exit_code result))
              (stdout (tramp-rpc--decode-output
                       (alist-get 'stdout result)
-                      (alist-get 'stdout_encoding result))))
-        (when (and (eq exit-code 0) (> (length stdout) 0))
-          ;; Find the marker and extract the path after it
-          (when (string-match (concat (regexp-quote marker) "\n\\([^\n]+\\)") stdout)
-            (let ((path (string-trim (match-string 1 stdout))))
-              (when (string-prefix-p "/" path)
-                path)))))
+                      (alist-get 'stdout_encoding result)))
+             (path (string-trim stdout)))
+        (and (eq exit-code 0)
+             (string-prefix-p "/" path)
+             path))
     (error
      (tramp-rpc--debug "find-executable failed for %s: %S" program err)
      nil)))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1017,12 +1017,18 @@ Results are cached per connection."
 
 (defun tramp-rpc--find-executable (vec program)
   "Find PROGRAM in the configured remote PATH on VEC.
-Returns the absolute path or nil."
+Returns the absolute path or nil.
+
+Lookup runs `command -v' under \"/bin/sh\" rather than the user's login
+shell: the PATH to search is supplied explicitly via the environment, so
+the login shell adds nothing but risk.  Non-POSIX login shells (csh, tcsh,
+fish) do not implement `command -v' with these semantics, and shells such
+as zsh still read startup files (.zshenv) for non-interactive `-c'
+invocations, which could both rewrite PATH and print output."
   (condition-case err
-      (let* ((shell (tramp-rpc--get-remote-login-shell vec))
-             (result (tramp-rpc--call
+      (let* ((result (tramp-rpc--call
                       vec "process.run"
-                      `((cmd . ,shell)
+                      `((cmd . "/bin/sh")
                         (args . ["-c" ,(format "command -v %s"
                                                (tramp-shell-quote-argument program))])
                         (cwd . "/")
@@ -1031,8 +1037,14 @@ Returns the absolute path or nil."
              (stdout (tramp-rpc--decode-output
                       (alist-get 'stdout result)
                       (alist-get 'stdout_encoding result)))
-             (path (string-trim stdout)))
+             ;; Accept only a single absolute path: shell startup noise or a
+             ;; `command -v' result naming a builtin/alias must not be taken
+             ;; for an executable.
+             (lines (and (stringp stdout)
+                         (split-string (string-trim stdout) "\n" t "[ \t\r]+")))
+             (path (and (= (length lines) 1) (car lines))))
         (and (eq exit-code 0)
+             path
              (string-prefix-p "/" path)
              path))
     (error

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -3868,6 +3868,31 @@ discard it for being unreadable."
       (should (equal (tramp-rpc--remote-path-environment vec)
                      '(("PATH" . "/login/bin:/custom/bin")))))))
 
+(ert-deftest tramp-rpc-mock-test-find-executable-uses-configured-remote-path ()
+  "Executable lookup must preserve `tramp-remote-path' ordering."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
+                                   :localname "/")))
+    (cl-letf (((symbol-function 'tramp-rpc--get-remote-login-shell)
+               (lambda (_vec) "/bin/zsh"))
+              ((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec)
+                 '(("PATH" . "/tool/git/bin:/usr/bin"))))
+              ((symbol-function 'tramp-rpc--decode-output)
+               (lambda (output _encoding) output))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (equal method "process.run"))
+                 (should (equal (alist-get 'cmd params) "/bin/zsh"))
+                 (should (equal (alist-get 'env params)
+                                '(("PATH" . "/tool/git/bin:/usr/bin"))))
+                 (should (equal (alist-get 'args params)
+                                ["-c" "command -v git"]))
+                 '((exit_code . 0)
+                   (stdout . "/tool/git/bin/git\n")))))
+      (should (equal (tramp-rpc--find-executable vec "git")
+                     "/tool/git/bin/git")))))
+
 (ert-deftest tramp-rpc-mock-test-fetch-remote-exec-path-ignores-banner ()
   "Test login shell PATH parsing ignores startup output before the marker."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -867,6 +867,10 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (declare-function tramp-rpc-magit--file-exists-in-ancestor-scan
                   "tramp-rpc-magit" (filename scan))
 (declare-function tramp-rpc-magit--get-cache-key "tramp-rpc-magit" (vec directory))
+(declare-function tramp-rpc-magit--prefetch-git-commands
+                  "tramp-rpc-magit" (directory &optional vec))
+(declare-function tramp-rpc-magit--git-command-entry
+                  "tramp-rpc-magit" (directory args &optional vec))
 (declare-function tramp-rpc-magit--process-cache-key "tramp-rpc-magit" (&rest args))
 (declare-function tramp-rpc-magit--process-cache-lookup "tramp-rpc-magit" (program args))
 (declare-function tramp-rpc-magit--process-cache-store "tramp-rpc-magit" (program args exit-code stdout))
@@ -3883,7 +3887,10 @@ discard it for being unreadable."
               ((symbol-function 'tramp-rpc--call)
                (lambda (_vec method params)
                  (should (equal method "process.run"))
-                 (should (equal (alist-get 'cmd params) "/bin/zsh"))
+                 ;; Lookup must not go through the user's login shell: a
+                 ;; non-POSIX shell has no `command -v', and zsh reads
+                 ;; .zshenv even for non-interactive -c invocations.
+                 (should (equal (alist-get 'cmd params) "/bin/sh"))
                  (should (equal (alist-get 'env params)
                                 '(("PATH" . "/tool/git/bin:/usr/bin"))))
                  (should (equal (alist-get 'args params)
@@ -3891,6 +3898,54 @@ discard it for being unreadable."
                  '((exit_code . 0)
                    (stdout . "/tool/git/bin/git\n")))))
       (should (equal (tramp-rpc--find-executable vec "git")
+                     "/tool/git/bin/git")))))
+
+(ert-deftest tramp-rpc-mock-test-find-executable-rejects-noisy-output ()
+  "Shell startup noise must not be mistaken for an executable path."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
+                                   :localname "/")))
+    (dolist (stdout '("/etc/profile: some warning\n/tool/git/bin/git\n"
+                      "git: aliased to hub\n"
+                      "\n"))
+      (cl-letf (((symbol-function 'tramp-rpc--remote-path-environment)
+                 (lambda (_vec) '(("PATH" . "/tool/git/bin:/usr/bin"))))
+                ((symbol-function 'tramp-rpc--decode-output)
+                 (lambda (output _encoding) output))
+                ((symbol-function 'tramp-rpc--call)
+                 (lambda (_vec _method _params)
+                   `((exit_code . 0) (stdout . ,stdout)))))
+        (should-not (tramp-rpc--find-executable vec "git"))))))
+
+(ert-deftest tramp-rpc-mock-test-magit-prefetch-uses-resolved-git ()
+  "Magit prefetch must run the git found on the configured remote PATH.
+`commands.run_parallel' has no environment support, so the program name
+itself has to carry the resolution."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-magit-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
+                                   :localname "/")))
+    (cl-letf (((symbol-function 'tramp-rpc--resolve-executable)
+               (lambda (_vec program)
+                 (should (equal program "git"))
+                 "/tool/git/bin/git")))
+      ;; Full status prefetch.
+      (let ((entries (append (tramp-rpc-magit--prefetch-git-commands
+                              "/home/user/repo/" vec)
+                             nil)))
+        (should entries)
+        (let ((git-entries (seq-filter
+                            (lambda (e)
+                              (not (string-prefix-p "state_file:"
+                                                    (alist-get 'key e))))
+                            entries)))
+          (should git-entries)
+          (dolist (entry git-entries)
+            (should (equal (alist-get 'cmd entry) "/tool/git/bin/git")))))
+      ;; Incremental entries (dynamic status, file sections).
+      (should (equal (alist-get 'cmd (tramp-rpc-magit--git-command-entry
+                                      "/home/user/repo/" '("rev-parse" "HEAD")
+                                      vec))
                      "/tool/git/bin/git")))))
 
 (ert-deftest tramp-rpc-mock-test-fetch-remote-exec-path-ignores-banner ()


### PR DESCRIPTION
## Summary

- make `tramp-rpc--find-executable` search the configured `tramp-remote-path`
- preserve user-defined PATH ordering instead of using the login shell PATH
- add regression coverage for preferring a configured Git installation over `/usr/bin/git`

This completes the PATH handling introduced in #198, which covered process execution but left direct executable lookup using the old login-shell behavior.

Fixes #238

## Tests

- `TRAMP_SOURCE=/home/arthur/src/tramp ./test/run-tests.sh --mock` (173 passed)
- byte-compiled all `lisp/*.el` with warnings treated as errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of remote executables by using the configured remote PATH when running `command -v`.
  - Hardened resolution to ignore noisy startup output and only accept a single absolute path on success.
  - Updated Magit status prefetch to use the resolved remote `git` executable for command batches.

- **Tests**
  - Added ERT coverage for remote PATH ordering, robust executable resolution, and Magit prefetch behavior using the resolved `git` path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->