### PR TITLE
release: bump server version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "tramp-rpc-server"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["server"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 authors = ["Arthur Heymans <arthur@aheymans.xyz>"]

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -63,7 +63,7 @@ straight/repos..., which contains Cargo.toml and the Rust server sources."
   "Deployment settings for TRAMP-RPC."
   :group 'tramp)
 
-(defconst tramp-rpc-deploy-version "0.12.0"
+(defconst tramp-rpc-deploy-version "0.12.1"
   "Current version of tramp-rpc-server.")
 
 (defconst tramp-rpc-deploy-binary-name "tramp-rpc-server"

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
-;; Version: 0.12.0
+;; Version: 0.12.1
 ;; Keywords: comm, processes, files
 ;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1") (tramp "2.8.1.4"))
 


### PR DESCRIPTION
## Summary

- bump the package and server version to 0.13.0
- force release/package installs to deploy a fresh server binary instead of reusing v0.12.0
- prepare the major process, protocol, deployment, and file-operation changes merged since v0.12.0 for release

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (144 tests)
- byte-compiled all `lisp/*.el` with warnings treated as errors
