### PR TITLE
Improve git checkout binary deployment UX

### DIFF
--- a/README.org
+++ b/README.org
@@ -139,7 +139,7 @@ Access remote files using the ~rpc~ method:
 On first connection, the server binary is automatically obtained and deployed:
 
 1. *Release/package installs*: download from GitHub Releases first (fastest, ~850KB download), then build from source if Rust is installed and download fails.
-2. *Git checkout installs*: build from the checked-out source by default and cache the result under a source-tree keyed id.  This avoids reusing a stale release binary when latest git contains server changes without a version bump.
+2. *Git checkout installs*: reuse a fresh source build or source-tree keyed cache.  Automatic file operations do not prompt when a binary is missing; run ~M-x tramp-rpc-deploy-install-binary~ to choose whether to download a checksum-verified release binary, build the checkout with Cargo, or skip.  A downloaded fallback remains keyed to that source tree, while strict ~build~ policy uses a separate identity.
 
 The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cache/emacs/tramp-rpc/= on the remote host.
 
@@ -147,6 +147,7 @@ The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cach
 
 | Command                          | Description                    |
 |----------------------------------+--------------------------------|
+| ~M-x tramp-rpc-deploy-install-binary~ | Choose and deploy a missing git-checkout binary; use ~C-u~ to replace one |
 | ~M-x tramp-rpc-deploy-status~    | Show binary deployment status  |
 | ~M-x tramp-rpc-deploy-clear-cache~ | Clear local binary cache     |
 | ~M-x tramp-rpc-deploy-remove-binary~ | Remove binary from remote  |
@@ -354,8 +355,17 @@ cargo build --release --target aarch64-unknown-linux-gnu
 * Configuration
 
 #+begin_src elisp
-;; Prefer building from source over downloading (default: nil)
+;; Prefer building from source over downloading for release/package installs
+;; (default: nil)
 (setq tramp-rpc-deploy-prefer-build t)
+
+;; Git checkout policy (default: auto):
+;; - auto: reuse source-keyed artifacts; use
+;;   M-x tramp-rpc-deploy-install-binary when one must be obtained;
+;;   use C-u M-x tramp-rpc-deploy-install-binary to replace an existing one
+;; - build: strictly build from source, using a build-only binary identity
+;; - release: use release-version binaries and paths
+(setq tramp-rpc-deploy-git-build-policy 'build)
 
 ;; Local cache directory (default: ~/.emacs.d/tramp-rpc/)
 (setq tramp-rpc-deploy-local-cache-directory "~/.cache/emacs/tramp-rpc-binaries")

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -168,9 +168,11 @@ By default, downloading is attempted first as it's faster."
 This only applies when `tramp-rpc-deploy-source-directory' points at a
 git checkout that contains the Rust server sources.
 
-`auto' means use release binaries for release/package installs, but build
-from source for git checkouts.  This keeps latest-git users from using a
-stale release binary whose version number has not been bumped yet.
+`auto' means use release binaries for release/package installs.  For git
+checkouts, existing source builds and caches are reused; when a binary must
+be obtained, `tramp-rpc-deploy-install-binary' asks whether to download a
+release binary, build from source, or stop.  Automatic file operations never
+prompt; they report how to run that command instead.
 
 `release' always uses the release-oriented versioned binary id and obtain
 order, preserving the historical behavior.
@@ -181,6 +183,45 @@ only builds from source; release downloads are not used as a fallback."
                  (const :tag "Release binaries" release)
                  (const :tag "Build from source" build))
   :group 'tramp-rpc-deploy)
+
+(defvar tramp-rpc-deploy--allow-prompt nil
+  "Non-nil while deploying the target of an explicit installation.
+Only `tramp-rpc-deploy-ensure-binary' binds this, and only for the remote
+that `tramp-rpc-deploy-install-binary' was invoked for.")
+
+(defvar tramp-rpc-deploy--force-obtain nil
+  "Non-nil while the current deploy must replace existing artifacts.
+Scoped exactly like `tramp-rpc-deploy--allow-prompt'.")
+
+(defvar tramp-rpc-deploy--explicit-target nil
+  "Target key of the in-progress explicit installation, or nil.
+Explicit installation can block for a long time in `read-char-choice',
+downloads, or builds, during which timers may deploy to other remotes.
+Keying the request to one target keeps those reentrant deploys automatic.")
+
+(defvar tramp-rpc-deploy--explicit-force nil
+  "Non-nil when the in-progress explicit installation must replace artifacts.")
+
+(defvar tramp-rpc-deploy--pre-explicit-auto-deploy nil
+  "Value of `tramp-rpc-deploy-auto-deploy' before the explicit installation.
+Reentrant deploys for other remotes during an explicit installation use this
+value so the explicit auto-deploy override does not leak to them.")
+
+(defun tramp-rpc-deploy--target-key (vec)
+  "Return a comparable deployment target key for VEC."
+  (if (tramp-file-name-p vec)
+      (list (tramp-file-name-method vec)
+            (tramp-file-name-user vec)
+            (tramp-file-name-host vec)
+            (tramp-file-name-port vec)
+            (tramp-file-name-hop vec))
+    vec))
+
+(defun tramp-rpc-deploy--explicit-target-p (vec)
+  "Return non-nil when VEC is the target of the explicit installation."
+  (and tramp-rpc-deploy--explicit-target
+       (equal tramp-rpc-deploy--explicit-target
+              (tramp-rpc-deploy--target-key vec))))
 
 (defcustom tramp-rpc-deploy-bootstrap-method "scpx"
   "TRAMP method to use for bootstrapping (deploying the binary).
@@ -440,9 +481,12 @@ preserve timestamps."
   "Return a binary id derived from the current git checkout contents."
   (let ((hash (tramp-rpc-deploy--source-tree-hash)))
     (when hash
-      (format "git-%s-%s"
+      (format "git-%s-%s%s"
               (or (tramp-rpc-deploy--git-revision) "unknown")
-              (substring hash 0 12)))))
+              (substring hash 0 12)
+              (if (eq tramp-rpc-deploy-git-build-policy 'build)
+                  "-build"
+                "")))))
 
 (defun tramp-rpc-deploy--binary-id ()
   "Return the id used for cache and remote binary paths.
@@ -800,14 +844,54 @@ Returns the path to the binary on success, nil on failure."
 ;;; Main logic: ensure local binary exists
 ;;; ============================================================================
 
-(defun tramp-rpc-deploy--obtain-methods ()
-  "Return the methods to use for obtaining a missing local binary."
+(defun tramp-rpc-deploy--ask-git-install-action (arch)
+  "Ask how to obtain a git-checkout server binary for ARCH.
+Return `download', `build', or nil.  Building is offered only when Cargo is
+available and ARCH can be built natively."
+  (unless tramp-rpc-deploy--allow-prompt
+    (signal
+     'remote-file-error
+     (list
+      "TRAMP-RPC needs a server binary for this git checkout.  Run M-x tramp-rpc-deploy-install-binary to choose whether to download or build it, or customize `tramp-rpc-deploy-git-build-policy' to `release' or `build'")))
+  (let* ((can-build (and (tramp-rpc-deploy--cargo-available-p)
+                         (tramp-rpc-deploy--can-build-for-arch-p arch)))
+         (choices (if can-build '(?d ?b ?s) '(?d ?s)))
+         (build-line
+          (cond
+           (can-build "  [b] Build the checked-out sources with Cargo\n")
+           ((not (tramp-rpc-deploy--cargo-available-p))
+            "      Build unavailable: Cargo was not found\n")
+           (t
+            (format "      Build unavailable: cannot build %s natively\n" arch))))
+         (choice
+          (read-char-choice
+           (concat
+            "TRAMP-RPC needs a server binary for this git checkout.\n\n"
+            "  [d] Download the checksum-verified release binary\n"
+            "      Warning: it may not exactly match the checked-out sources\n"
+            build-line
+            "  [s] Skip and install the server manually\n\n"
+            "Choice: ")
+           choices)))
+    (pcase choice
+      (?d 'download)
+      (?b 'build)
+      (?s nil))))
+
+(defun tramp-rpc-deploy--git-install-action (arch)
+  "Ask for the action used to obtain a git binary for ARCH."
+  (or (tramp-rpc-deploy--ask-git-install-action arch)
+      (signal
+       'remote-file-error
+       (list "TRAMP-RPC server installation skipped; install it manually or run M-x tramp-rpc-deploy-install-binary again"))))
+
+(defun tramp-rpc-deploy--obtain-methods (arch)
+  "Return the methods to use for obtaining a missing binary for ARCH."
   (cond
-   ;; Git checkouts should not silently fall back to release artifacts: the
-   ;; release binary may be stale when the lisp/server protocol changed without
-   ;; a version bump.
    ((tramp-rpc-deploy--use-source-binary-id-p)
-    '(build))
+    (list (if (eq tramp-rpc-deploy-git-build-policy 'build)
+              'build
+            (tramp-rpc-deploy--git-install-action arch))))
    (tramp-rpc-deploy-prefer-build
     '(build download))
    (t
@@ -834,7 +918,8 @@ Returns the path to the local binary."
      ;; source-id mode, only trust a bundled binary when it is newer than the
      ;; source files; otherwise a stale bundled artifact can be deployed under
      ;; the fresh git hash and recreate the exact mismatch source-id mode avoids.
-     ((and bundled-path
+     ((and (not tramp-rpc-deploy--force-obtain)
+           bundled-path
            (or (not (tramp-rpc-deploy--use-source-binary-id-p))
                (tramp-rpc-deploy--newer-than-source-p bundled-path)))
       (message "Using bundled binary for %s" arch)
@@ -842,12 +927,13 @@ Returns the path to the local binary."
 
      ;; Check source-tree build output.  This supports CI jobs that download a
      ;; just-built server artifact into target/<triple>/release/.
-     (source-build-path
+     ((and (not tramp-rpc-deploy--force-obtain) source-build-path)
       (message "Using source-tree build output for %s" arch)
       source-build-path)
 
      ;; Check cache
-     ((and (file-exists-p cache-path)
+     ((and (not tramp-rpc-deploy--force-obtain)
+           (file-exists-p cache-path)
            (file-executable-p cache-path)
            (tramp-rpc-deploy--cached-binary-trusted-p cache-path))
       (message "Using cached binary for %s" arch)
@@ -855,7 +941,7 @@ Returns the path to the local binary."
 
      ;; Need to obtain binary
      (t
-      (let ((methods (tramp-rpc-deploy--obtain-methods))
+      (let ((methods (tramp-rpc-deploy--obtain-methods arch))
             (result nil)
             (errors nil))
 
@@ -888,9 +974,9 @@ Returns the path to the local binary."
   (let ((local-arch (tramp-rpc-deploy--detect-local-arch)))
     (if (tramp-rpc-deploy--use-source-binary-id-p)
         (concat
-         "This installation is using a git-checkout binary id, so release\n"
-         "artifacts are not used as a fallback.  This avoids running a stale\n"
-         "server binary when latest-git Lisp changed without a version bump.\n\n"
+         "This installation is using a git-checkout binary id.  Automatic\n"
+         "release fallback is disabled because the release server may be stale\n"
+         "when checkout sources changed without a version bump.\n\n"
          "To resolve this, you can:\n\n"
          (if (string= arch local-arch)
              (concat
@@ -901,7 +987,9 @@ Returns the path to the local binary."
             "1. Build on a %s machine and copy to:\n   %s\n\n"
             arch
             (tramp-rpc-deploy--local-cache-path arch)))
-         "2. To force release artifacts instead, customize:\n"
+         "2. Run M-x tramp-rpc-deploy-install-binary and choose download.\n"
+         "   The release fallback will remain keyed to this source tree.\n\n"
+         "3. To always use release-version paths for checkouts, customize:\n"
          "   (setq tramp-rpc-deploy-git-build-policy 'release)\n\n"
          (format "Binary should be placed at:\n   %s"
                  (tramp-rpc-deploy--local-cache-path arch)))
@@ -1161,13 +1249,28 @@ an explicit error.  A missing remote binary never uses this fallback."
                       tramp-rpc-deploy-binary-name)))
         (message "tramp-rpc: never-deploy mode, using %s on remote" path)
         path)
-    ;; Normal deployment flow
-    (let* ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
+    ;; Normal deployment flow.  Prompting and forced replacement apply only to
+    ;; the remote an explicit installation was requested for; deploys that run
+    ;; reentrantly for other remotes stay fully automatic.
+    (let* ((explicit (tramp-rpc-deploy--explicit-target-p vec))
+           (tramp-rpc-deploy--allow-prompt explicit)
+           (tramp-rpc-deploy--force-obtain
+            (and explicit tramp-rpc-deploy--explicit-force))
+           (tramp-rpc-deploy-auto-deploy
+            (cond (explicit t)
+                  ;; Inside another remote's explicit installation window:
+                  ;; use the pre-override value so the explicit auto-deploy
+                  ;; override does not leak to unrelated remotes.
+                  (tramp-rpc-deploy--explicit-target
+                   tramp-rpc-deploy--pre-explicit-auto-deploy)
+                  (t tramp-rpc-deploy-auto-deploy)))
+           (bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
 	   ;; For simplified Tramp syntax.
 	   (tramp-default-method (tramp-file-name-method bootstrap-vec))
 	   tramp-default-method-alist)
       (let* ((remote-present
-              (tramp-rpc-deploy--remote-binary-exists-p bootstrap-vec))
+              (and (not tramp-rpc-deploy--force-obtain)
+                   (tramp-rpc-deploy--remote-binary-exists-p bootstrap-vec)))
              (remote-local
               (tramp-file-local-name
                (tramp-rpc-deploy--remote-binary-path bootstrap-vec))))
@@ -1219,6 +1322,28 @@ an explicit error.  A missing remote binary never uses this fallback."
                  (list "Existing tramp-rpc-server on"
                        (tramp-file-name-host vec)
                        "failed checksum verification and auto-deploy is disabled"))))))))))))
+
+;;;###autoload
+(defun tramp-rpc-deploy-install-binary (vec &optional force)
+  "Interactively obtain and deploy tramp-rpc-server for remote VEC.
+For git checkouts using the `auto' policy, this is the only entry point that
+may ask whether to download a release binary or build the checked-out sources.
+Automatic file operations never open this prompt.
+
+With prefix argument FORCE, replace an existing remote or cached artifact and
+ask again in `auto' mode.  Explicit installation overrides
+`tramp-rpc-deploy-auto-deploy', but refuses to run when
+`tramp-rpc-deploy-never-deploy' is non-nil."
+  (interactive
+   (list (tramp-dissect-file-name
+          (read-file-name "Remote TRAMP-RPC host: " "/rpc:"))
+         current-prefix-arg))
+  (when tramp-rpc-deploy-never-deploy
+    (user-error "Deployment is disabled by `tramp-rpc-deploy-never-deploy'"))
+  (let ((tramp-rpc-deploy--explicit-target (tramp-rpc-deploy--target-key vec))
+        (tramp-rpc-deploy--explicit-force force)
+        (tramp-rpc-deploy--pre-explicit-auto-deploy tramp-rpc-deploy-auto-deploy))
+    (tramp-rpc-deploy-ensure-binary vec)))
 
 (defun tramp-rpc-deploy-remove-binary (vec)
   "Remove the tramp-rpc-server binary from remote VEC."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -4481,6 +4481,258 @@ This matches the behavior expected by `tramp-test28-process-file'."
                            (file-name-as-directory repo)))))
       (delete-directory dir t))))
 
+(ert-deftest tramp-rpc-mock-test-deploy-git-install-ask-without-cargo ()
+  "Test the git install prompt offers download but not build without Cargo."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-rpc-deploy--allow-prompt t)
+        prompt choices)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--cargo-available-p)
+               (lambda () nil))
+              ((symbol-function 'read-char-choice)
+               (lambda (text allowed)
+                 (setq prompt text
+                       choices allowed)
+                 ?d)))
+      (should (eq (tramp-rpc-deploy--ask-git-install-action "x86_64-linux")
+                  'download))
+      (should (equal choices '(?d ?s)))
+      (should (string-match-p "Cargo was not found" prompt))
+      (should (string-match-p "may not exactly match" prompt)))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-git-install-ask-build-available ()
+  "Test the git install prompt offers a source build when available."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-rpc-deploy--allow-prompt t)
+        choices)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--cargo-available-p)
+               (lambda () t))
+              ((symbol-function 'tramp-rpc-deploy--can-build-for-arch-p)
+               (lambda (_arch) t))
+              ((symbol-function 'read-char-choice)
+               (lambda (_text allowed)
+                 (setq choices allowed)
+                 ?b)))
+      (should (eq (tramp-rpc-deploy--ask-git-install-action "x86_64-linux")
+                  'build))
+      (should (equal choices '(?d ?b ?s))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-git-install-never-prompts-implicitly ()
+  "Test automatic deployment reports the explicit install command."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-rpc-deploy--allow-prompt nil))
+    (let ((err (should-error
+                (tramp-rpc-deploy--ask-git-install-action "x86_64-linux")
+                :type 'remote-file-error)))
+      (should (string-match-p "tramp-rpc-deploy-install-binary"
+                              (error-message-string err))))))
+
+(defmacro tramp-rpc-mock-test--with-deploy-stubs (record &rest body)
+  "Run BODY with deploy stubs recording per-deploy flags into RECORD.
+Each entry is (HOST ALLOW-PROMPT FORCE-OBTAIN AUTO-DEPLOY)."
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+              (lambda (vec) vec))
+             ((symbol-function 'tramp-rpc-deploy--remote-binary-exists-p)
+              (lambda (_vec) t))
+             ((symbol-function 'tramp-rpc-deploy--remote-binary-path)
+              (lambda (vec)
+                (tramp-make-tramp-file-name vec "/tmp/tramp-rpc-server")))
+             ((symbol-function 'tramp-rpc-deploy--remote-binary-matches-p)
+              (lambda (vec _binary)
+                (push (list (tramp-file-name-host vec)
+                            tramp-rpc-deploy--allow-prompt
+                            tramp-rpc-deploy--force-obtain
+                            tramp-rpc-deploy-auto-deploy)
+                      ,record)
+                t))
+             ((symbol-function 'tramp-rpc-deploy--detect-remote-arch)
+              (lambda (_vec) "x86_64-linux"))
+             ((symbol-function 'tramp-rpc-deploy--ensure-local-binary)
+              (lambda (_arch) "/tmp/local-server"))
+             ((symbol-function 'tramp-rpc-deploy--transfer-binary)
+              (lambda (vec _binary)
+                (push (list (tramp-file-name-host vec)
+                            tramp-rpc-deploy--allow-prompt
+                            tramp-rpc-deploy--force-obtain
+                            tramp-rpc-deploy-auto-deploy)
+                      ,record)
+                (tramp-make-tramp-file-name vec "/tmp/tramp-rpc-server"))))
+     ,@body))
+
+(ert-deftest tramp-rpc-mock-test-deploy-install-command-overrides-auto-deploy ()
+  "Test explicit installation enables prompts, forcing, and deployment."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:user@target:/"))
+        (tramp-rpc-deploy-auto-deploy nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        (deploys nil))
+    (tramp-rpc-mock-test--with-deploy-stubs deploys
+      (tramp-rpc-deploy-install-binary vec t))
+    (should (equal deploys '(("target" t t t))))
+    (should-not tramp-rpc-deploy--allow-prompt)
+    (should-not tramp-rpc-deploy--force-obtain)
+    (should-not tramp-rpc-deploy--explicit-target)
+    (should-not tramp-rpc-deploy-auto-deploy)))
+
+(ert-deftest tramp-rpc-mock-test-deploy-install-flags-scoped-to-target ()
+  "Test reentrant deploys for other remotes stay automatic and unforced."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:user@target:/"))
+        (other (tramp-dissect-file-name "/rpc:user@other:/"))
+        (tramp-rpc-deploy-auto-deploy t)
+        (tramp-rpc-deploy-never-deploy nil)
+        (deploys nil))
+    (let ((tramp-rpc-deploy--explicit-target
+           (tramp-rpc-deploy--target-key vec))
+          (tramp-rpc-deploy--explicit-force t)
+          (tramp-rpc-deploy--pre-explicit-auto-deploy t))
+      (tramp-rpc-mock-test--with-deploy-stubs deploys
+        (tramp-rpc-deploy-ensure-binary other)))
+    (should (equal deploys '(("other" nil nil t))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-install-auto-deploy-does-not-leak ()
+  "Test the explicit auto-deploy override is invisible to other remotes."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:user@target:/"))
+        (other (tramp-dissect-file-name "/rpc:user@other:/"))
+        (tramp-rpc-deploy-never-deploy nil)
+        (deploys nil))
+    ;; Simulate the dynamic environment inside an explicit installation for
+    ;; "target" invoked while the user has auto-deploy disabled:
+    ;; `tramp-rpc-deploy-ensure-binary' has already rebound
+    ;; `tramp-rpc-deploy-auto-deploy' to t for the explicit target when a
+    ;; reentrant deploy for "other" runs.
+    (let ((tramp-rpc-deploy--explicit-target
+           (tramp-rpc-deploy--target-key vec))
+          (tramp-rpc-deploy--explicit-force nil)
+          (tramp-rpc-deploy--pre-explicit-auto-deploy nil)
+          (tramp-rpc-deploy-auto-deploy t))
+      (tramp-rpc-mock-test--with-deploy-stubs deploys
+        (tramp-rpc-deploy-ensure-binary other)))
+    (should (equal deploys '(("other" nil nil nil))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-install-command-rejects-never-deploy ()
+  "Test explicit installation respects the absolute deployment prohibition."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((tramp-rpc-deploy-never-deploy t))
+    (should-error (tramp-rpc-deploy-install-binary
+                   (tramp-dissect-file-name "/rpc:user@target:/"))
+                  :type 'user-error)))
+
+(ert-deftest tramp-rpc-mock-test-deploy-force-replaces-cached-binary ()
+  "Test a forced install obtains a new artifact instead of reusing cache."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((binary (make-temp-file "tramp-rpc-cached"))
+        (replacement "replacement")
+        (tramp-rpc-deploy--force-obtain t))
+    (unwind-protect
+        (progn
+          (set-file-modes binary #o755)
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--bundled-binary-path)
+                     (lambda (_arch) nil))
+                    ((symbol-function 'tramp-rpc-deploy--source-build-output-path)
+                     (lambda (_arch) nil))
+                    ((symbol-function 'tramp-rpc-deploy--local-cache-path)
+                     (lambda (_arch) binary))
+                    ((symbol-function 'tramp-rpc-deploy--obtain-methods)
+                     (lambda (_arch) '(download)))
+                    ((symbol-function 'tramp-rpc-deploy--download-binary)
+                     (lambda (_arch) replacement)))
+            (should (equal (tramp-rpc-deploy--ensure-local-binary
+                            "x86_64-linux")
+                           replacement))))
+      (delete-file binary))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-git-obtain-method-follows-policy ()
+  "Test strict build bypasses the prompt while auto uses its answer."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (cl-letf (((symbol-function 'tramp-rpc-deploy--use-source-binary-id-p)
+             (lambda () t)))
+    (let ((tramp-rpc-deploy-git-build-policy 'auto))
+      (cl-letf (((symbol-function 'tramp-rpc-deploy--git-install-action)
+                 (lambda (_arch) 'download)))
+        (should (equal (tramp-rpc-deploy--obtain-methods "x86_64-linux")
+                       '(download)))))
+    (let ((tramp-rpc-deploy-git-build-policy 'build))
+      (cl-letf (((symbol-function 'tramp-rpc-deploy--git-install-action)
+                 (lambda (_arch) (ert-fail "Strict build prompted"))))
+        (should (equal (tramp-rpc-deploy--obtain-methods "x86_64-linux")
+                       '(build)))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-release-checksum-is-strict ()
+  "Test checksum metadata contains exactly one matching sha256sum record."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((asset "server.tar.gz")
+         (digest (make-string 64 ?a)))
+    (should (equal (tramp-rpc-deploy--release-checksum
+                    (format "%s  %s\n" digest asset) asset)
+                   digest))
+    (should-error
+     (tramp-rpc-deploy--release-checksum "abcd  server.tar.gz\n" asset)
+     :type 'remote-file-error)
+    (should-error
+     (tramp-rpc-deploy--release-checksum
+      (format "%s  other.tar.gz\n" digest) asset)
+     :type 'remote-file-error)
+    (should-error
+     (tramp-rpc-deploy--release-checksum
+      (format "%s  %s\n%s  other.tar.gz\n" digest asset digest) asset)
+     :type 'remote-file-error)))
+
+(ert-deftest tramp-rpc-mock-test-deploy-download-requires-checksum ()
+  "Test release artifacts are rejected when checksum retrieval fails."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((cache (make-temp-file "tramp-rpc-cache" t)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc-deploy--local-cache-path)
+                   (lambda (_arch) (expand-file-name "server" cache)))
+                  ((symbol-function 'tramp-rpc-deploy--download-file)
+                   (lambda (_url _dest) nil))
+                  ((symbol-function 'tramp-rpc-deploy--extract-tarball)
+                   (lambda (&rest _args)
+                     (ert-fail "Unverified artifact was extracted"))))
+          (should-error
+           (tramp-rpc-deploy--download-binary "x86_64-linux")
+           :type 'remote-file-error))
+      (delete-directory cache t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-cached-binary-does-not-prompt ()
+  "Test a usable cache is returned before resolving interactive policy."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((binary (make-temp-file "tramp-rpc-cached")))
+    (unwind-protect
+        (progn
+          (set-file-modes binary #o755)
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--bundled-binary-path)
+                     (lambda (_arch) nil))
+                    ((symbol-function 'tramp-rpc-deploy--source-build-output-path)
+                     (lambda (_arch) nil))
+                    ((symbol-function 'tramp-rpc-deploy--local-cache-path)
+                     (lambda (_arch) binary))
+                    ((symbol-function 'tramp-rpc-deploy--use-source-binary-id-p)
+                     (lambda () t))
+                    ((symbol-function 'tramp-rpc-deploy--cached-binary-trusted-p)
+                     (lambda (_path) t))
+                    ((symbol-function 'tramp-rpc-deploy--obtain-methods)
+                     (lambda (_arch)
+                       (ert-fail "Install policy was consulted for cached binary"))))
+            (should (equal (tramp-rpc-deploy--ensure-local-binary
+                            "x86_64-linux")
+                           binary))))
+      (delete-file binary))))
+
 (ert-deftest tramp-rpc-mock-test-deploy-skips-stale-bundled-source-binary ()
   "Test source-id mode does not deploy stale bundled binaries."
   :tags '(:deploy)
@@ -4503,7 +4755,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
           (set-file-modes bundled #o755)
           (set-file-times bundled (seconds-to-time 0))
           (let ((tramp-rpc-deploy-source-directory dir)
-                (tramp-rpc-deploy-git-build-policy 'auto)
+                (tramp-rpc-deploy-git-build-policy 'build)
                 (tramp-rpc-deploy-bundled-binary-directory bundled-dir)
                 (tramp-rpc-deploy-local-cache-directory
                  (expand-file-name "cache" dir)))
@@ -4538,9 +4790,14 @@ This matches the behavior expected by `tramp-test28-process-file'."
                       (mtime (file-attribute-modification-time
                               (file-attributes source))))
                   (should (string-prefix-p "git-abcdef123456-" id1))
+                  (should-not (string-suffix-p "-build" id1))
                   (should (string-match-p
                            (concat "tramp-rpc-server-" (regexp-quote id1))
                            (tramp-rpc-deploy-expected-binary-localname)))
+                  (let ((tramp-rpc-deploy-git-build-policy 'build))
+                    (let ((build-id (tramp-rpc-deploy--binary-id)))
+                      (should (string-suffix-p "-build" build-id))
+                      (should-not (equal id1 build-id))))
                   ;; Equal-length content with the original timestamp must not
                   ;; reuse a metadata-only source identity.
                   (with-temp-file source


### PR DESCRIPTION
## Summary

Improve the first-use deployment experience for git checkout installations.

When a source-keyed server binary is missing, automatic file operations now give a clear next step instead of failing because Cargo is unavailable or unexpectedly opening a prompt. Running `M-x tramp-rpc-deploy-install-binary` presents a focused choice to:

- download the checksum-verified release binary,
- build the checked-out server with Cargo, or
- skip and install it manually.

`C-u M-x tramp-rpc-deploy-install-binary` replaces an existing cached or remote artifact and asks again.

## UX and policy cleanup

- Keep `tramp-rpc-deploy-git-build-policy` as the single git-checkout policy option.
- Never prompt from implicit/background file operations.
- Let explicit installation override `tramp-rpc-deploy-auto-deploy`, while respecting `tramp-rpc-deploy-never-deploy`.
- Give strict source builds a separate binary identity so they cannot reuse a downloaded fallback.
- Preserve existing `auto` binary IDs for compatibility.
- Require one exact SHA256 record naming the requested release asset before extraction.
- Document the interactive flow and configuration choices.

## Testing

- 23 deployment ERT tests pass.
- All Elisp files byte-compile with warnings treated as errors.

Fixes #252.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive binary installation flow supporting release downloads, local builds, or skipping.
  * Added configurable Git build policies: `auto`, `build`, and `release`.
  * Added target-specific installation and forced replacement controls.

* **Bug Fixes**
  * Release installations now require a valid, matching SHA-256 checksum.
  * Automatic deployment no longer prompts when binaries are unavailable.

* **Documentation**
  * Updated guidance for installation behavior, caching, replacement, and build policies.

* **Tests**
  * Expanded coverage for prompts, forced replacement, checksum validation, and build policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->