### PR TITLE
Fix getent fallback

### DIFF
--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -351,9 +351,9 @@ fn resolve_nss_name(
         }
 
         if ret == 0 && result_null {
-            // Definitive miss: id is absent from all NSS databases libc
-            // can reach. No need to try getent.
-            break Ok(None);
+            // Some NSS stacks can report a libc miss here while
+            // `getent` still resolves through another backend.
+            break getent_name(database, id);
         }
 
         if ret != 0 {


### PR DESCRIPTION
After #258 I found a regression where NSS libc would report a miss but `getent` would still work. This adds getent back as a fallback in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name resolution by falling back to an alternate system lookup when the primary lookup returns no result.
  * Prevented valid identifiers from being incorrectly treated as unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->