### PR TITLE
[12/12] Fix remote trash and process environments

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -43,7 +43,7 @@
 (declare-function tramp-rpc--call-batch "tramp-rpc")
 (declare-function tramp-rpc--connection-key "tramp-rpc")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
-(declare-function tramp-rpc--resolve-executable "tramp-rpc")
+(declare-function tramp-rpc--process-environment "tramp-rpc")
 (declare-function tramp-rpc--decode-string "tramp-rpc")
 (declare-function tramp-rpc--encode-path "tramp-rpc")
 (declare-function tramp-rpc--convert-file-attributes "tramp-rpc")
@@ -804,31 +804,18 @@ the gitdir) and the results are cached in `tramp-rpc--file-exists-cache'.")
       (cmd . "test")
       (args . ["-e" ,full-path]))))
 
-(defun tramp-rpc-magit--git-program (&optional vec)
-  "Return the git executable to use for prefetch commands on VEC.
-
-`commands.run_parallel' spawns commands directly on the server, which
-inherits the SSH session PATH and knows nothing about `tramp-remote-path'.
-Resolve git against the configured remote PATH (cached per connection) so
-prefetched output comes from the same git that `process-file' would use.
-Falls back to \"git\" when VEC is nil or lookup fails."
-  (if vec
-      (tramp-rpc--resolve-executable vec "git")
-    "git"))
-
-(defun tramp-rpc-magit--prefetch-git-commands (directory &optional vec)
+(defun tramp-rpc-magit--prefetch-git-commands (directory &optional _vec)
   "Build the list of git commands to prefetch for DIRECTORY.
 Returns a vector of command entries for commands.run_parallel.
 Each entry has key, cmd, args, and cwd fields.  Git command keys
 match what `tramp-rpc-magit--process-cache-lookup' will look up.
 State file checks use \"state_file:PATH\" keys.
-VEC resolves git against the configured remote PATH."
+The batch RPC supplies the same effective environment as `process-file'."
   (let ((cmds nil)
-        (git (tramp-rpc-magit--git-program vec))
         (gitdir (concat (file-name-as-directory directory) ".git")))
     (cl-flet ((add-git (&rest args)
                 (push `((key . ,(apply #'tramp-rpc-magit--process-cache-key args))
-                        (cmd . ,git)
+                        (cmd . "git")
                         (args . ,(vconcat (append tramp-rpc-magit--git-prefetch-prefix-args
                                                    args)))
                         (cwd . ,directory))
@@ -930,11 +917,10 @@ VEC resolves git against the configured remote PATH."
 
     (vconcat (nreverse cmds))))
 
-(defun tramp-rpc-magit--git-command-entry (directory args &optional vec)
-  "Return a commands.run_parallel entry for git ARGS in DIRECTORY.
-VEC resolves git against the configured remote PATH."
+(defun tramp-rpc-magit--git-command-entry (directory args &optional _vec)
+  "Return a commands.run_parallel entry for git ARGS in DIRECTORY."
   `((key . ,(apply #'tramp-rpc-magit--process-cache-key args))
-    (cmd . ,(tramp-rpc-magit--git-program vec))
+    (cmd . "git")
     (args . ,(vconcat (append tramp-rpc-magit--git-prefetch-prefix-args args)))
     (cwd . ,directory)))
 
@@ -972,6 +958,15 @@ existing one."
 The server currently rejects batches above 256; keep headroom so dynamic
 prefetch growth does not trip that hard limit.")
 
+(defun tramp-rpc-magit--run-parallel (vec directory commands)
+  "Run COMMANDS on VEC in DIRECTORY with the normal RPC process environment."
+  (let ((localname (or (file-remote-p (expand-file-name directory) 'localname)
+                       directory)))
+    (tramp-rpc--call
+     vec "commands.run_parallel"
+     `((commands . ,commands)
+       (env . ,(tramp-rpc--process-environment vec localname))))))
+
 (defun tramp-rpc-magit--run-command-entries (vec directory commands)
   "Run COMMANDS in chunks and merge their results into DIRECTORY's cache."
   (let ((remaining (append commands nil))
@@ -987,8 +982,8 @@ prefetch growth does not trip that hard limit.")
         (setq cache
               (tramp-rpc-magit--store-command-results
                vec directory
-               (tramp-rpc--call vec "commands.run_parallel"
-                                `((commands . ,(vconcat chunk))))))))
+               (tramp-rpc-magit--run-parallel
+                vec directory (vconcat chunk))))))
     cache))
 
 (defun tramp-rpc-magit--cached-git-stdout (cache &rest args)
@@ -1258,11 +1253,10 @@ when the status cache has expired but TAB is expanding a single file section."
                                       cache))
             (tramp-rpc-magit--store-command-results
              v directory
-             (tramp-rpc--call
-              v "commands.run_parallel"
-              `((commands . ,(vector
-                              (tramp-rpc-magit--git-command-entry
-                               root-local '("rev-parse" "HEAD") v)))))))
+             (tramp-rpc-magit--run-parallel
+              v directory
+              (vector (tramp-rpc-magit--git-command-entry
+                       root-local '("rev-parse" "HEAD") v)))))
           (setq cache (tramp-rpc-magit--get-process-cache))
           (let* ((head-entry (and cache
                                   (gethash (tramp-rpc-magit--process-cache-key
@@ -1289,8 +1283,8 @@ when the status cache has expired but TAB is expanding a single file section."
                 (add "cat-file" "-p" (format "%s:%s" head rel-file))))
             (tramp-rpc-magit--store-command-results
              v directory
-             (tramp-rpc--call v "commands.run_parallel"
-                              `((commands . ,(vconcat (nreverse commands))))))))))))
+             (tramp-rpc-magit--run-parallel
+              v directory (vconcat (nreverse commands))))))))))
 
 (defun tramp-rpc-magit--strip-git-prefix-args (args)
   "Strip cache-neutral Magit git prefix flags from ARGS.
@@ -1394,8 +1388,8 @@ as the process-file cache.  Also fetches ancestor markers."
         ;; Magit in the real refresh sequence, and `tramp-rpc-handle-process-file'
         ;; triggers this prefetch immediately after that command completes.
         (let* ((commands (tramp-rpc-magit--prefetch-git-commands localname v))
-               (results (tramp-rpc--call v "commands.run_parallel"
-                                         `((commands . ,commands)))))
+               (results (tramp-rpc-magit--run-parallel
+                         v directory commands)))
           (when results
             ;; Each result entry is (key . {exit_code, stdout, stderr}).  Git
             ;; command results are stored as (exit-code . decoded-stdout), while

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -47,18 +47,12 @@
 (declare-function tramp-rpc--call "tramp-rpc" (vec method params &optional connection))
 (declare-function tramp-rpc--call-fast "tramp-rpc")
 (declare-function tramp-rpc--call-async "tramp-rpc" (vec method params callback &optional connection))
-(declare-function tramp-rpc--get-direnv-environment "tramp-rpc")
 (declare-function tramp-rpc--get-remote-login-shell "tramp-rpc")
+(declare-function tramp-rpc--process-environment "tramp-rpc")
 (declare-function tramp-rpc--binary-bytes "tramp-rpc")
 (declare-function tramp-rpc--controlmaster-socket-path "tramp-rpc")
 (declare-function tramp-rpc--hops-to-proxyjump "tramp-rpc")
 (declare-function tramp-rpc--port-to-string "tramp-rpc")
-(declare-function tramp-rpc--ensure-inside-emacs-env "tramp-rpc")
-(declare-function tramp-rpc--merge-environments "tramp-rpc")
-(declare-function tramp-rpc--remote-path-environment "tramp-rpc")
-(declare-function tramp-rpc--tramp-remote-process-environment "tramp-rpc")
-(declare-function tramp-rpc--emacsclient-tramp-environment "tramp-rpc")
-(declare-function tramp-rpc--caller-environment "tramp-rpc")
 (declare-function tramp-rpc--ssh-detail-user "tramp-rpc")
 (declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
@@ -843,16 +837,9 @@ Resolves program path and loads direnv environment from working directory."
                                     (cdr command))))))
         (when use-pty
           (setq command (tramp-rpc--maybe-login-shell-command v command)))
-        ;; Get the remote process environment: PATH from `tramp-remote-path'
-        ;; (or deprecated `tramp-rpc-remote-path'), direnv for this directory,
-        ;; INSIDE_EMACS, and caller-set env vars (e.g. GIT_INDEX_FILE from magit).
-        (let ((process-env (tramp-rpc--ensure-inside-emacs-env
-                            (tramp-rpc--merge-environments
-                             (tramp-rpc--remote-path-environment v)
-                             (tramp-rpc--tramp-remote-process-environment)
-                             (tramp-rpc--emacsclient-tramp-environment v)
-                             (tramp-rpc--get-direnv-environment v localname)
-                             (tramp-rpc--caller-environment)))))
+        ;; Use the same effective environment as synchronous and parallel RPC
+        ;; processes, including configured PATH, direnv, and caller overrides.
+        (let ((process-env (tramp-rpc--process-environment v localname)))
           (if use-pty
               ;; PTY mode - start async process with PTY.  Do not add -n or
               ;; pre-authenticate here; sudo owns the terminal prompt.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -4292,7 +4292,7 @@ refresh), git commands are served from the prefetch cache when possible."
                                    (set-buffer-multibyte nil)
                                    (insert-file-contents-literally infile)
                                    (buffer-string))))
-               (result (condition-case nil
+               (result (condition-case err
                            (tramp-rpc--call v "process.run"
                                             `((cmd . ,program)
                                               (args . ,(vconcat args))
@@ -4301,8 +4301,13 @@ refresh), git commands are served from the prefetch cache when possible."
                                               ,@(when stdin-content
                                                   `((stdin . ,stdin-content)))))
                          ;; The server marks confirmed spawn ENOENT as
-                         ;; `file-missing'; other RPC failures must propagate.
-                         (file-missing 127))))
+                         ;; `file-missing'.  Shell-based TRAMP returns status
+                         ;; 127 and leaves the diagnostic on stderr, so preserve
+                         ;; both parts of that contract for split destinations.
+                         (file-missing
+                          (tramp-rpc--route-process-file-output
+                           destination "" (concat (error-message-string err) "\n"))
+                          127))))
           (if (eq result 127)
               127
             (if result

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3862,12 +3862,16 @@ returns a destination when that branch resolves to a local directory."
             (setq new-fn (car (find-backup-file-name new-fn)))))
         new-fn))))
 
+(defvar tramp-rpc--move-file-to-trash-function
+  (symbol-function 'move-file-to-trash)
+  "Original `move-file-to-trash' function, captured before TRAMP advice.")
+
 (defun tramp-rpc--fallback-move-file-to-trash (filename)
-  "Run the real `move-file-to-trash' for FILENAME without this external op."
-  (let ((inhibit-file-name-handlers
-         (cons #'tramp-rpc-file-name-handler inhibit-file-name-handlers))
-        (inhibit-file-name-operation 'move-file-to-trash))
-    (move-file-to-trash filename)))
+  "Run the original `move-file-to-trash' implementation for FILENAME.
+Bypass only TRAMP's external-operation advice.  File operations performed by
+the original implementation must still dispatch through the TRAMP-RPC file
+name handler."
+  (funcall tramp-rpc--move-file-to-trash-function filename))
 
 (defun tramp-rpc--delete-local-trash-copy (filename)
   "Best-effort removal of a partial local trash copy at FILENAME."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -974,27 +974,6 @@ Otherwise clear all entries."
     (clrhash tramp-rpc--direnv-cache)
     (clrhash tramp-rpc--direnv-available-cache)))
 
-(defvar tramp-rpc--executable-cache (make-hash-table :test 'equal)
-  "Cache of executable paths keyed by (connection-key . program).
-Value is the full path or :not-found.")
-
-(defun tramp-rpc--clear-executable-cache (&optional vec)
-  "Clear the executable cache.
-If VEC is provided, only clear entries for that connection.
-Otherwise clear all entries."
-  (if vec
-      (let ((conn-key (tramp-rpc--connection-key vec))
-            (keys-to-remove nil))
-        ;; Collect keys first (can't modify hash table during maphash)
-        (maphash (lambda (key _value)
-                   (when (equal (car key) conn-key)
-                     (push key keys-to-remove)))
-                 tramp-rpc--executable-cache)
-        ;; Now remove them
-        (dolist (key keys-to-remove)
-          (remhash key tramp-rpc--executable-cache)))
-    (clrhash tramp-rpc--executable-cache)))
-
 ;; Forward-declare caches used by tramp-rpc--remove-connection (defined
 ;; later in the exec-path section).  The byte-compiler needs to see
 ;; these defvars before their first reference.
@@ -1114,57 +1093,18 @@ by `with-environment-variables') are returned as an alist of
         (push (cons (match-string 1 elt) (match-string 2 elt)) env)))
     (nreverse env)))
 
-(defun tramp-rpc--resolve-executable (vec program)
-  "Resolve PROGRAM to its full path on VEC.
-Returns the full path if found, otherwise the original PROGRAM.
-Results are cached per connection."
-  (if (file-name-absolute-p program)
-      program
-    (let* ((cache-key (cons (tramp-rpc--connection-key vec) program))
-           (cached (gethash cache-key tramp-rpc--executable-cache)))
-      (cond
-       ((stringp cached) cached)  ; Cached full path
-       ((eq cached :not-found) program)  ; Known not found, use original
-       (t  ; Not cached, look it up
-        (let ((found (tramp-rpc--find-executable vec program)))
-          (puthash cache-key (or found :not-found) tramp-rpc--executable-cache)
-           (or found program)))))))
-
-(defun tramp-rpc--find-executable (vec program)
-  "Find PROGRAM in the configured remote PATH on VEC.
-Returns the absolute path or nil.
-
-Lookup runs `command -v' under \"/bin/sh\" rather than the user's login
-shell: the PATH to search is supplied explicitly via the environment, so
-the login shell adds nothing but risk.  Non-POSIX login shells (csh, tcsh,
-fish) do not implement `command -v' with these semantics, and shells such
-as zsh still read startup files (.zshenv) for non-interactive `-c'
-invocations, which could both rewrite PATH and print output."
-  (condition-case err
-      (let* ((result (tramp-rpc--call
-                      vec "process.run"
-                      `((cmd . "/bin/sh")
-                        (args . ["-c" ,(format "command -v %s"
-                                               (tramp-shell-quote-argument program))])
-                        (cwd . "/")
-                        (env . ,(tramp-rpc--remote-path-environment vec)))))
-             (exit-code (alist-get 'exit_code result))
-             (stdout (tramp-rpc--decode-output
-                      (alist-get 'stdout result)
-                      (alist-get 'stdout_encoding result)))
-             ;; Accept only a single absolute path: shell startup noise or a
-             ;; `command -v' result naming a builtin/alias must not be taken
-             ;; for an executable.
-             (lines (and (stringp stdout)
-                         (split-string (string-trim stdout) "\n" t "[ \t\r]+")))
-             (path (and (= (length lines) 1) (car lines))))
-        (and (eq exit-code 0)
-             path
-             (string-prefix-p "/" path)
-             path))
-    (error
-     (tramp-rpc--debug "find-executable failed for %s: %S" program err)
-     nil)))
+(defun tramp-rpc--process-environment (vec localname)
+  "Return the effective child environment for LOCALNAME on VEC.
+The configured remote PATH is the baseline.  Dynamic TRAMP environment,
+EMACSCLIENT_TRAMP, direnv, and caller overrides are merged in that order, so
+later and more specific values replace earlier ones."
+  (tramp-rpc--ensure-inside-emacs-env
+   (tramp-rpc--merge-environments
+    (tramp-rpc--remote-path-environment vec)
+    (tramp-rpc--tramp-remote-process-environment)
+    (tramp-rpc--emacsclient-tramp-environment vec)
+    (tramp-rpc--get-direnv-environment vec localname)
+    (tramp-rpc--caller-environment))))
 
 (defsubst tramp-rpc--port-to-string (port)
   "Normalize PORT to a string, or return nil.
@@ -1232,8 +1172,7 @@ Also clears the executable, exec-path, and login-shell caches."
         (tramp-rpc-protocol--clear-deferred-polls-for-target transport))
       (remhash key tramp-rpc--connections)
       (remhash key tramp-rpc--exec-path-cache)
-      (remhash key tramp-rpc--login-shell-cache)
-      (tramp-rpc--clear-executable-cache vec))))
+      (remhash key tramp-rpc--login-shell-cache))))
 
 (defun tramp-rpc--connection-error-response (vec event)
   "Return an RPC error response for a transport failure on VEC."
@@ -4280,13 +4219,7 @@ refresh), git commands are served from the prefetch cache when possible."
                ;; environment.  The PATH entry comes from `tramp-remote-path'
                ;; (or deprecated `tramp-rpc-remote-path'); direnv and dynamic
                ;; caller variables keep their previous roles and override it.
-               (env (tramp-rpc--ensure-inside-emacs-env
-                     (tramp-rpc--merge-environments
-                      (tramp-rpc--remote-path-environment v)
-                      (tramp-rpc--tramp-remote-process-environment)
-                      (tramp-rpc--emacsclient-tramp-environment v)
-                      (tramp-rpc--get-direnv-environment v localname)
-                      (tramp-rpc--caller-environment))))
+               (env (tramp-rpc--process-environment v localname))
                (stdin-content (when (and infile (not (eq infile t)))
                                  (with-temp-buffer
                                    (set-buffer-multibyte nil)
@@ -5520,7 +5453,6 @@ cleanup of all connections has run."
   (clrhash tramp-rpc--async-callbacks)
   (tramp-rpc-protocol--clear-deferred-polls)
   (clrhash tramp-rpc--async-callback-processes)
-  (clrhash tramp-rpc--executable-cache)
   (tramp-rpc--clear-direnv-cache)
   (tramp-rpc--clear-file-metadata-caches)
   ;; Note: recentf cleanup is handled by `tramp-recentf-cleanup-all'

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -62,6 +62,12 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
     #[derive(Deserialize)]
     struct Params {
         commands: Vec<CommandEntry>,
+        /// Environment variables applied to every command in the batch.
+        #[serde(default)]
+        env: Option<HashMap<String, String>>,
+        /// Clear the inherited server environment before applying `env`.
+        #[serde(default)]
+        clear_env: bool,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -82,13 +88,22 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
     // This budget is shared by every command in the batch, so one chatty
     // command cannot push the combined response over the frame limit.
     let remaining = Arc::new(Semaphore::new(crate::MAX_RESPONSE_OUTPUT_BYTES));
+    let env = params.env.map(Arc::new);
+    let clear_env = params.clear_env;
     let results = futures::future::join_all(params.commands.into_iter().map(|entry| {
         let remaining = Arc::clone(&remaining);
+        let env = env.clone();
         async move {
             let mut cmd = Command::new(&entry.cmd);
             cmd.args(&entry.args);
             if let Some(ref cwd) = entry.cwd {
                 cmd.current_dir(super::expand_tilde(cwd));
+            }
+            if clear_env {
+                cmd.env_clear();
+            }
+            if let Some(env) = env {
+                cmd.envs(env.iter());
             }
             cmd.stdin(if entry.stdin.is_some() {
                 Stdio::piped()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1080,6 +1080,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_commands_run_parallel_uses_batch_environment_for_lookup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temporary command directory");
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).expect("create command directory");
+        let program = bin.join("path-probe");
+        std::fs::write(&program, "#!/bin/sh\nprintf selected").expect("write command");
+        let mut permissions = std::fs::metadata(&program)
+            .expect("command metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&program, permissions).expect("make command executable");
+
+        let command = Value::Map(vec![
+            (Value::String("key".into()), Value::String("probe".into())),
+            (
+                Value::String("cmd".into()),
+                Value::String("path-probe".into()),
+            ),
+        ]);
+        let result = handlers::commands::run_parallel(Value::Map(vec![
+            (
+                Value::String("commands".into()),
+                Value::Array(vec![command]),
+            ),
+            (
+                Value::String("env".into()),
+                Value::Map(vec![(
+                    Value::String("PATH".into()),
+                    Value::String(bin.to_string_lossy().into_owned().into()),
+                )]),
+            ),
+        ]))
+        .await
+        .unwrap();
+        let entry = map_get(&result, "probe").unwrap();
+        assert_eq!(
+            map_get(entry, "stdout"),
+            Some(&Value::Binary(b"selected".to_vec()))
+        );
+        assert_eq!(map_get(entry, "exit_code").and_then(Value::as_i64), Some(0));
+    }
+
+    #[tokio::test]
     async fn test_commands_run_parallel_stdin() {
         let command = Value::Map(vec![
             (Value::String("key".into()), Value::String("cat".into())),

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -4033,6 +4033,23 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (tramp-rpc-handle-delete-file "/rpc:mock:/tmp/missing" nil)
       (should (equal invalidated "/rpc:mock:/tmp/missing")))))
 
+(ert-deftest tramp-rpc-mock-test-move-file-to-trash-fallback-bypasses-advice ()
+  "The trash fallback must not re-enter TRAMP's external operation advice."
+  :tags '(:delete)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((called nil)
+         (tramp-rpc--move-file-to-trash-function
+         (lambda (filename)
+           (setq called filename)
+           'fallback)))
+    (cl-letf (((symbol-function 'move-file-to-trash)
+               (lambda (&rest _args)
+                 (error "TRAMP external operation was re-entered"))))
+      (should (eq (tramp-rpc--fallback-move-file-to-trash
+                   "/rpc:mock:/tmp/file")
+                  'fallback))
+      (should (equal called "/rpc:mock:/tmp/file")))))
+
 (ert-deftest tramp-rpc-mock-test-move-file-to-trash-regular-file-local-trash ()
   "Test optimized `move-file-to-trash' copies a remote file to local trash."
   :tags '(:delete)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1124,6 +1124,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                   "tramp-rpc-magit" (directory &optional vec))
 (declare-function tramp-rpc-magit--git-command-entry
                   "tramp-rpc-magit" (directory args &optional vec))
+(declare-function tramp-rpc-magit--run-parallel
+                  "tramp-rpc-magit" (vec directory commands))
 (declare-function tramp-rpc-magit--process-cache-key "tramp-rpc-magit" (&rest args))
 (declare-function tramp-rpc-magit--process-cache-lookup "tramp-rpc-magit" (program args))
 (declare-function tramp-rpc-magit--process-cache-store "tramp-rpc-magit" (program args exit-code stdout))
@@ -5959,81 +5961,43 @@ discard it for being unreadable."
       (should (equal (tramp-rpc--remote-path-environment vec)
                      '(("PATH" . "/login/bin:/custom/bin")))))))
 
-(ert-deftest tramp-rpc-mock-test-find-executable-uses-configured-remote-path ()
-  "Executable lookup must preserve `tramp-remote-path' ordering."
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
-                                   :localname "/")))
-    (cl-letf (((symbol-function 'tramp-rpc--get-remote-login-shell)
-               (lambda (_vec) "/bin/zsh"))
-              ((symbol-function 'tramp-rpc--remote-path-environment)
-               (lambda (_vec)
-                 '(("PATH" . "/tool/git/bin:/usr/bin"))))
-              ((symbol-function 'tramp-rpc--decode-output)
-               (lambda (output _encoding) output))
-              ((symbol-function 'tramp-rpc--call)
-               (lambda (_vec method params)
-                 (should (equal method "process.run"))
-                 ;; Lookup must not go through the user's login shell: a
-                 ;; non-POSIX shell has no `command -v', and zsh reads
-                 ;; .zshenv even for non-interactive -c invocations.
-                 (should (equal (alist-get 'cmd params) "/bin/sh"))
-                 (should (equal (alist-get 'env params)
-                                '(("PATH" . "/tool/git/bin:/usr/bin"))))
-                 (should (equal (alist-get 'args params)
-                                ["-c" "command -v git"]))
-                 '((exit_code . 0)
-                   (stdout . "/tool/git/bin/git\n")))))
-      (should (equal (tramp-rpc--find-executable vec "git")
-                     "/tool/git/bin/git")))))
-
-(ert-deftest tramp-rpc-mock-test-find-executable-rejects-noisy-output ()
-  "Shell startup noise must not be mistaken for an executable path."
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
-                                   :localname "/")))
-    (dolist (stdout '("/etc/profile: some warning\n/tool/git/bin/git\n"
-                      "git: aliased to hub\n"
-                      "\n"))
-      (cl-letf (((symbol-function 'tramp-rpc--remote-path-environment)
-                 (lambda (_vec) '(("PATH" . "/tool/git/bin:/usr/bin"))))
-                ((symbol-function 'tramp-rpc--decode-output)
-                 (lambda (output _encoding) output))
-                ((symbol-function 'tramp-rpc--call)
-                 (lambda (_vec _method _params)
-                   `((exit_code . 0) (stdout . ,stdout)))))
-        (should-not (tramp-rpc--find-executable vec "git"))))))
-
-(ert-deftest tramp-rpc-mock-test-magit-prefetch-uses-resolved-git ()
-  "Magit prefetch must run the git found on the configured remote PATH.
-`commands.run_parallel' has no environment support, so the program name
-itself has to carry the resolution."
+(ert-deftest tramp-rpc-mock-test-magit-prefetch-uses-process-environment ()
+  "Magit prefetch must use the same effective environment as `process-file'."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-magit-loaded)
-  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
-                                   :localname "/")))
-    (cl-letf (((symbol-function 'tramp-rpc--resolve-executable)
-               (lambda (_vec program)
-                 (should (equal program "git"))
-                 "/tool/git/bin/git")))
-      ;; Full status prefetch.
-      (let ((entries (append (tramp-rpc-magit--prefetch-git-commands
-                              "/home/user/repo/" vec)
-                             nil)))
-        (should entries)
-        (let ((git-entries (seq-filter
-                            (lambda (e)
-                              (not (string-prefix-p "state_file:"
-                                                    (alist-get 'key e))))
-                            entries)))
-          (should git-entries)
-          (dolist (entry git-entries)
-            (should (equal (alist-get 'cmd entry) "/tool/git/bin/git")))))
-      ;; Incremental entries (dynamic status, file sections).
-      (should (equal (alist-get 'cmd (tramp-rpc-magit--git-command-entry
-                                      "/home/user/repo/" '("rev-parse" "HEAD")
-                                      vec))
-                     "/tool/git/bin/git")))))
+  (let* ((directory "/rpc:user@host:/home/user/repo/")
+         (vec (tramp-dissect-file-name directory))
+         (expected-env '(("PATH" . "/direnv/bin:/usr/bin")
+                         ("INSIDE_EMACS" . "test")))
+         captured)
+    ;; Commands remain relative so the batch's environment determines which
+    ;; git is run, including directory-specific direnv PATH overrides.
+    (let ((entries (append (tramp-rpc-magit--prefetch-git-commands
+                            "/home/user/repo/" vec)
+                           nil)))
+      (should entries)
+      (dolist (entry entries)
+        (unless (string-prefix-p "state_file:" (alist-get 'key entry))
+          (should (equal (alist-get 'cmd entry) "git")))))
+    (should (equal (alist-get 'cmd (tramp-rpc-magit--git-command-entry
+                                    "/home/user/repo/" '("rev-parse" "HEAD")
+                                    vec))
+                   "git"))
+    (cl-letf (((symbol-function 'tramp-rpc--process-environment)
+               (lambda (actual-vec localname)
+                 (should (equal actual-vec vec))
+                 (should (equal localname "/home/user/repo/"))
+                 expected-env))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (actual-vec method params)
+                 (should (equal actual-vec vec))
+                 (should (equal method "commands.run_parallel"))
+                 (setq captured params)
+                 '((command . ((exit_code . 0)))))))
+      (tramp-rpc-magit--run-parallel
+       vec directory
+       [( (key . "command") (cmd . "git") (args . ["status"]))])
+      (should (equal (alist-get 'env captured) expected-env)))))
 
 (ert-deftest tramp-rpc-mock-test-fetch-remote-exec-path-ignores-banner ()
   "Test login shell PATH parsing ignores startup output before the marker."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -6133,23 +6133,36 @@ itself has to carry the resolution."
                      '("PATH" . "/home/user/.cargo/bin:/usr/bin:/bin"))))))
 
 (ert-deftest tramp-rpc-mock-test-process-file-not-found-returns-127 ()
-  "Only a structured spawn ENOENT becomes process-file status 127."
+  "A structured spawn ENOENT becomes status 127 with captured stderr."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((default-directory "/rpc:user@host:/work/"))
-    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
-               (lambda (_vec) '("/usr/bin")))
-              ((symbol-function 'tramp-rpc--get-direnv-environment)
-               (lambda (&rest _) nil))
-              ((symbol-function 'tramp-rpc--caller-environment)
-               (lambda () nil))
-              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
-               (lambda (&rest _) nil))
-               ((symbol-function 'tramp-rpc--call)
-                (lambda (&rest _)
-                  (tramp-rpc--signal-rpc-error
-                   "RPC" "missing executable" tramp-rpc-protocol-error-process 2
-                   nil '((spawn_not_found . t))))))
-       (should (= (tramp-rpc-handle-process-file "missing" nil nil nil) 127)))))
+  (let ((default-directory "/rpc:user@host:/work/")
+        (stderr-file (make-temp-file "tramp-rpc-process-stderr")))
+    (unwind-protect
+        (progn
+          ;; `process-file' output files need not exist before the call.
+          (delete-file stderr-file)
+          (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+                     (lambda (_vec) '("/usr/bin")))
+                    ((symbol-function 'tramp-rpc--get-direnv-environment)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--caller-environment)
+                     (lambda () nil))
+                    ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'tramp-rpc--call)
+                     (lambda (&rest _)
+                       (tramp-rpc--signal-rpc-error
+                        "RPC" "missing executable"
+                        tramp-rpc-protocol-error-process 2
+                        nil '((spawn_not_found . t))))))
+            (should (= (tramp-rpc-handle-process-file
+                        "missing" nil (list nil stderr-file) nil)
+                       127))
+            (should (file-exists-p stderr-file))
+            (with-temp-buffer
+              (insert-file-contents stderr-file)
+              (should (string-match-p "missing executable" (buffer-string))))))
+      (ignore-errors (delete-file stderr-file)))))
 
 (ert-deftest tramp-rpc-mock-test-process-file-preserves-other-rpc-errors ()
   "A process cwd ENOENT remains a remote-file-error, not status 127."


### PR DESCRIPTION
## Summary

- prevent the optimized remote trash fallback from re-entering TRAMP advice
- preserve missing-command diagnostics in `process-file` stderr destinations
- give `commands.run_parallel` the same PATH, direnv, and caller environment as normal RPC processes
- remove the obsolete client-side executable resolver

## Stack

- Depends on #250 (`remediation/11-final-hardening`)
- Final follow-up in the remediation stack

## Tests

- 250 mock ERT tests
- 143 Rust unit tests
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- warning-as-error Lisp byte compilation
- live remote trash operation
- live isolated-server `commands.run_parallel` PATH lookup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote commands now consistently use the effective environment, including PATH, direnv settings, and relevant environment variables.
  * Parallel Git operations and other batched commands now resolve executables more reliably.
  * File operations involving trash avoid unintended handler recursion.
  * Missing-command errors now preserve diagnostic output while reporting the correct failure status.

* **Tests**
  * Added coverage for environment-aware command execution, Git prefetching, trash handling, and missing-command diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->