### PR TITLE
fix(deploy): parse LF-only HTTP responses when downloading binaries

### DIFF
--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -604,7 +604,7 @@ Returns t on success, nil on failure."
                     (if (looking-at "HTTP/[0-9.]+ \\([0-9]+\\)")
                         (signal 'remote-file-error (list "HTTP error" (match-string 1)))
                       (signal 'remote-file-error (list "Invalid HTTP response"))))
-                  (unless (re-search-forward "^\\r?\\n" nil t)
+                  (unless (re-search-forward "\r?\n\r?\n" nil t)
                     (signal 'remote-file-error (list "Malformed HTTP response")))
                   (let ((coding-system-for-write 'binary))
                     (write-region (point) (point-max) dest nil 'silent))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -4689,6 +4689,42 @@ Each entry is (HOST ALLOW-PROMPT FORCE-OBTAIN AUTO-DEPLOY)."
       (format "%s  %s\n%s  other.tar.gz\n" digest asset digest) asset)
      :type 'remote-file-error)))
 
+(ert-deftest tramp-rpc-mock-test-deploy-download-parses-lf-only-response ()
+  "Test `tramp-rpc-deploy--download-file' parses LF-only HTTP responses.
+
+GitHub's release-assets server (release-assets.githubusercontent.com)
+returns headers terminated by bare LF (no CRLF).  The header/body
+separator must be located without relying on a `^'-anchored regexp,
+which fails to match an empty line in Emacs.  Regression test for
+issue #268 (0.13 fails to download prebuilt binary)."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((body "310a9545a07d9848d1125fda930ddba9f219def7bec9d94ab5965d072a8caa0c  server.tar.gz\n")
+         (dest (make-temp-file "tramp-rpc-download"))
+         (resp-buf (generate-new-buffer " *tramp-rpc-mock-http*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'url-retrieve-synchronously)
+                   (lambda (&rest _args)
+                     (with-current-buffer resp-buf
+                       (erase-buffer)
+                       (set-buffer-multibyte nil)
+                       ;; LF-only headers, exactly as GitHub's release
+                       ;; assets server emits them.
+                       (insert "HTTP/1.1 200 OK\n"
+                               "Content-Length: 123\n"
+                               "Content-Type: application/octet-stream\n"
+                               "\n"
+                               body))
+                     resp-buf)))
+          (should (tramp-rpc-deploy--download-file
+                   "https://example.invalid/server.tar.gz.sha256" dest))
+          (should (equal (with-temp-buffer
+                           (insert-file-contents-literally dest)
+                           (buffer-string))
+                         body)))
+      (delete-file dest)
+      (when (buffer-live-p resp-buf) (kill-buffer resp-buf)))))
+
 (ert-deftest tramp-rpc-mock-test-deploy-download-requires-checksum ()
   "Test release artifacts are rejected when checksum retrieval fails."
   :tags '(:deploy)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1066,6 +1066,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (require 'tramp-rpc)
 (declare-function tramp-rpc--pty-handle-async-response
                   "tramp-rpc-process" (local-process response))
+(declare-function tramp-rpc-deploy--download-file
+                  "tramp-rpc-deploy" (url dest))
 (defconst tramp-rpc-mock-test--tramp-rpc-loaded t
   "The full TRAMP-RPC backend was loaded successfully.")
 


### PR DESCRIPTION
## Summary

Fixes #268 — "0.13 fails to download prebuilt binary".

GitHub's release-assets server (`release-assets.githubusercontent.com`) terminates response headers with **bare LF**, not CRLF. The header/body separator search in `tramp-rpc-deploy--download-file` used a `^`-anchored regexp:

```elisp
(unless (re-search-forward "^\\r?\\n" nil t)
  (signal 'remote-file-error (list "Malformed HTTP response")))
```

A `^`-anchored `\n` **never matches an empty line in Emacs** (verified: `^\\n` → nil, while `\n\n` and `^$` both match). So every prebuilt-binary download was rejected as a "Malformed HTTP response", forcing a source build that then failed.

This regressed in **0.13.0**: the 0.12 code used the same regexp but ignored its return value, so the failed search was silent and the body was still written correctly. The 0.13 hardening turned that silent no-op into a hard error.

## Fix

Replace the anchored search with an unanchored one that actually matches the blank line:

```elisp
(unless (re-search-forward "\r?\n\r?\n" nil t)
  (signal 'remote-file-error (list "Malformed HTTP response")))
```

Verified against the real `v0.13.0` release URL: the patched function downloads the checksum correctly, and the checksum matches the actual binary.

## Test

Added `tramp-rpc-mock-test-deploy-download-parses-lf-only-response`, which feeds a realistic LF-only HTTP response through `tramp-rpc-deploy--download-file` (mocking `url-retrieve-synchronously`). Confirmed it:
- **fails** on the buggy `^\\r?\\n` regexp ("Malformed HTTP response")
- **passes** with the fix

The existing mock tests stub out `tramp-rpc-deploy--download-file` entirely, so the real HTTP header-parsing path was never exercised — this test covers it.

## Test plan

- `./test/run-tests.sh --mock` (CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment file downloads to correctly process HTTP responses using either LF or CRLF header line endings.
  - Ensures downloaded files are written successfully when servers use LF-only separators.
  - Improves compatibility with a wider range of HTTP servers and response formats.

- **Tests**
  - Added regression coverage for LF-only HTTP responses, checksum handling, and successful file retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->