### PR TITLE
Allow configuring synchronous RPC timeouts

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -547,6 +547,19 @@ Used to skip cache invalidation in `tramp-rpc-handle-process-file'.")
   "TRAMP backend using RPC."
   :group 'tramp)
 
+(defcustom tramp-rpc-call-timeout 30
+  "Maximum seconds to wait for a synchronous RPC call to complete.
+The value must be a positive number."
+  :type 'number
+  :group 'tramp-rpc)
+
+(defun tramp-rpc--configured-call-timeout ()
+  "Return the validated synchronous RPC call timeout."
+  (unless (and (numberp tramp-rpc-call-timeout)
+               (> tramp-rpc-call-timeout 0))
+    (user-error "`tramp-rpc-call-timeout' must be a positive number"))
+  tramp-rpc-call-timeout)
+
 (defcustom tramp-rpc-use-controlmaster t
   "Whether to use SSH ControlMaster for connection sharing.
 When enabled, multiple connections to the same host share a single
@@ -1900,7 +1913,8 @@ Returns the request ID."
   "Call METHOD with PARAMS on the RPC server for VEC.
 CONNECTION, when non-nil, is the captured connection generation to use.
 Returns the result or signals an error."
-  (tramp-rpc--call-with-timeout vec method params 30 0.1 connection))
+  (tramp-rpc--call-with-timeout
+   vec method params (tramp-rpc--configured-call-timeout) 0.1 connection))
 
 (defun tramp-rpc--call-fast (vec method params)
   "Call METHOD with PARAMS with shorter timeout for low-latency ops.
@@ -2071,7 +2085,8 @@ Returns:
   (t                          ; file.exists result
    ((type . \"file\") ...)    ; file.stat result
    (:error -32001 :message \"...\"))  ; or error plist"
-  (let* ((conn (tramp-rpc--ensure-connection vec))
+  (let* ((timeout (tramp-rpc--configured-call-timeout))
+         (conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
          (id-and-request (let ((tramp-rpc-protocol--message-target process))
@@ -2090,7 +2105,7 @@ Returns:
       ;; Wait for response with matching ID using wall-clock deadline
     (with-current-buffer buffer
       (let ((start-time (float-time))
-            (deadline (+ (float-time) 30))
+            (deadline (+ (float-time) timeout))
             response)
         ;; A transport sentinel may have injected an error before the loop.
         (setq response (tramp-rpc--find-response-by-id expected-id process))
@@ -2186,12 +2201,14 @@ Returns a list of request IDs in the same order."
 (defun tramp-rpc--receive-responses (vec ids &optional timeout connection)
   "Receive responses for request IDS from the RPC server for VEC.
 Returns an alist mapping each ID to its response plist.
-TIMEOUT is the maximum time to wait in seconds (default 30).
-CONNECTION, when non-nil, is the captured connection generation to use."
-  (let* ((conn (or connection (tramp-rpc--ensure-connection vec)))
+TIMEOUT is the maximum time to wait in seconds.
+When nil, `tramp-rpc-call-timeout' is used.  CONNECTION, when non-nil, is the
+captured connection generation to use."
+  (let* ((timeout (or timeout (tramp-rpc--configured-call-timeout)))
+         (conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
-         (deadline (+ (float-time) (or timeout 30)))
+         (deadline (+ (float-time) timeout))
          (remaining-ids (copy-sequence ids))
          (responses (make-hash-table :test 'eql)))
     (tramp-rpc--debug "RECV-PIPE waiting for %d responses: %S" (length ids) ids)
@@ -2265,9 +2282,11 @@ Each result is either the actual result or an error plist.
 Unlike `tramp-rpc--call-batch', this sends each request as a separate
 RPC call, allowing the server to process them concurrently.
 This is more efficient when the server has async support."
-  (let* ((connection (tramp-rpc--ensure-connection vec))
+  (let* ((timeout (tramp-rpc--configured-call-timeout))
+         (connection (tramp-rpc--ensure-connection vec))
          (ids (tramp-rpc--send-requests vec requests connection))
-         (responses (tramp-rpc--receive-responses vec ids nil connection)))
+         (responses (tramp-rpc--receive-responses
+                     vec ids timeout connection)))
     ;; Process responses in order and extract results
     (mapcar (lambda (id-response)
               (let ((response (cdr id-response)))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1090,6 +1090,47 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (should-error (tramp-rpc--apply-directory-count entries count)
                     :type 'wrong-type-argument))))
 
+(ert-deftest tramp-rpc-mock-test-call-uses-configured-timeout ()
+  "Synchronous RPC calls honor `tramp-rpc-call-timeout'."
+  (let ((tramp-rpc-call-timeout 75))
+    (cl-letf (((symbol-function 'tramp-rpc--call-with-timeout)
+               (lambda (_vec _method _params timeout poll-interval
+                             &optional _connection)
+                 (should (= timeout 75))
+                 (should (= poll-interval 0.1))
+                 'result)))
+      (should (eq (tramp-rpc--call 'vec "test" nil) 'result)))))
+
+(ert-deftest tramp-rpc-mock-test-call-rejects-invalid-configured-timeout ()
+  "Synchronous RPC calls reject invalid configured timeouts before sending."
+  (dolist (timeout '(0 -1 invalid))
+    (let ((tramp-rpc-call-timeout timeout))
+      (cl-letf (((symbol-function 'tramp-rpc--call-with-timeout)
+                 (lambda (&rest _)
+                   (ert-fail "RPC call started with an invalid timeout"))))
+        (should-error (tramp-rpc--call 'vec "test" nil)
+                      :type 'user-error)))))
+
+(ert-deftest tramp-rpc-mock-test-pipelined-call-uses-configured-timeout ()
+  "Pipelined RPC calls pass `tramp-rpc-call-timeout' to their receiver."
+  (let ((tramp-rpc-call-timeout 75)
+        (connection '(:process test-process :buffer test-buffer)))
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+               (lambda (_vec) connection))
+              ((symbol-function 'tramp-rpc--send-requests)
+               (lambda (_vec _requests passed-connection)
+                 (should (eq passed-connection connection))
+                 '(1)))
+              ((symbol-function 'tramp-rpc--receive-responses)
+               (lambda (_vec ids timeout passed-connection)
+                 (should (equal ids '(1)))
+                 (should (= timeout 75))
+                 (should (eq passed-connection connection))
+                 (list (cons 1 '(:id 1 :result result))))))
+      (should (equal '(result)
+                     (tramp-rpc--call-pipelined
+                      'vec '(("test" . nil))))))))
+
 (ert-deftest tramp-rpc-mock-test-pipelined-timeout-signals-error ()
   "A live connection with no response reaches the pipeline timeout branch."
   (let* ((buffer (generate-new-buffer " *tramp-rpc-pipeline-test*"))

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -98,6 +98,32 @@
         (should-not (process-get process :tramp-rpc-pending-ids))
         (should-not (gethash buffer tramp-rpc--pending-responses))))))
 
+(ert-deftest tramp-rpc-mock-test-request-batch-uses-configured-timeout ()
+  "Batch RPC calls wait for the configured synchronous timeout."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc-call-timeout 75)
+          (tramp-rpc--connections (make-hash-table :test 'equal))
+          (clock-calls 0))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec) (list :process process :buffer buffer)))
+                ((symbol-function 'tramp-rpc-protocol-encode-batch-request-with-id)
+                 (lambda (&rest _) '(103 . "batch")))
+                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
+                ((symbol-function 'float-time)
+                 (lambda (&rest _)
+                   (setq clock-calls (1+ clock-calls))
+                   (if (<= clock-calls 2) 0 50)))
+                ((symbol-function 'accept-process-output)
+                 (lambda (&rest _)
+                   (puthash 103 '(:id 103 :result batch)
+                            (tramp-rpc--get-pending-responses buffer))
+                   t))
+                ((symbol-function 'tramp-rpc-protocol-decode-batch-response)
+                 (lambda (_response) 'batch-result)))
+        (should (eq 'batch-result
+                    (tramp-rpc--call-batch vec '(("test" . nil)))))))))
+
 (ert-deftest tramp-rpc-mock-test-request-pipeline-death-keeps-receive-on-old-generation ()
   "A pipeline receives its injected error from the generation that sent it."
   (tramp-rpc-mock-test-request--with-connection (process buffer)


### PR DESCRIPTION
Synchronous RPC calls currently time out after a hard-coded 30 seconds, which can interrupt long-running operations such as Magit command prefetches.

Add `tramp-rpc-call-timeout` so users can increase the response timeout when needed, while keeping the existing 30-second default.

Fixes #265.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for synchronous remote procedure calls, defaulting to 30 seconds.

* **Bug Fixes**
  * Improved consistency when applying RPC timeout and polling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->