### PR TITLE
tests: support sandboxed Nix builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ rustPlatform, lib }:
+{
+  buildPackages,
+  lib,
+  rustPlatform,
+}:
 rustPlatform.buildRustPackage {
   pname = "emacs-tramp-rpc";
   version = "dev";
@@ -6,4 +10,8 @@ rustPlatform.buildRustPackage {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ./Cargo.lock;
   };
+  nativeCheckInputs = [
+    buildPackages.coreutils
+    buildPackages.python3
+  ];
 }

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -4070,10 +4070,7 @@ mod tests {
     async fn pty_read_errors_are_terminal_process_errors() {
         let _test_lock = test_process_map_lock().await;
         let start = start_pty(Value::Map(vec![
-            (
-                Value::String("cmd".into()),
-                Value::String("/bin/sleep".into()),
-            ),
+            (Value::String("cmd".into()), Value::String("sleep".into())),
             (
                 Value::String("args".into()),
                 Value::Array(vec![Value::String("30".into())]),
@@ -4338,10 +4335,7 @@ mod tests {
     async fn pty_write_completes_large_data_under_backpressure() {
         let _test_lock = test_process_map_lock().await;
         let start = start_pty(Value::Map(vec![
-            (
-                Value::String("cmd".into()),
-                Value::String("/bin/sleep".into()),
-            ),
+            (Value::String("cmd".into()), Value::String("sleep".into())),
             (
                 Value::String("args".into()),
                 Value::Array(vec![Value::String("30".into())]),


### PR DESCRIPTION
The process tests spawn Python and `sleep` at runtime, but these commands were unavailable in the Nix sandbox. This adds Python and coreutils to `nativeCheckInputs` and resolves `sleep` through `PATH` instead of relying on `/bin/sleep`.

You can test with `nix build .#tramp-rpc-server`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for process-related tests by locating the `sleep` command through the system environment.
  * Updated package checks to include required standard utilities and Python tooling.
  * Improved reliability across environments with differing system command locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->