### PR TITLE
Unblock building on FreeBSD

### DIFF
--- a/README.org
+++ b/README.org
@@ -415,6 +415,7 @@ Run ~M-x tramp-rpc-deploy-status~ to see:
 - Whether Rust/cargo is available
 - Cached binaries
 - Download URLs
+- The binary ID (in case you are manually installing the binary on the remote out of band)
 
 ** diff-hl issues in dired
 

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -20,7 +20,7 @@ use crate::protocol::path_or_bytes;
 /// Extract time and mode fields from libc::stat in a cross-platform way
 /// Returns (atime, mtime, ctime, mode)
 /// - On Linux: st_mode is u32; time fields are i32 on 32-bit, i64 on 64-bit
-/// - On macOS: st_mode is u16, time fields are i64
+/// - On macOS and FreeBSD: st_mode is u16, time fields are i64
 #[inline]
 fn stat_time_to_i64<T: Into<i64>>(time: T) -> i64 {
     time.into()
@@ -28,9 +28,9 @@ fn stat_time_to_i64<T: Into<i64>>(time: T) -> i64 {
 
 #[inline]
 fn extract_stat_fields(stat_buf: &libc::stat) -> (i64, i64, i64, u32) {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     let mode = stat_buf.st_mode as u32;
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
     let mode = stat_buf.st_mode;
 
     (


### PR DESCRIPTION
This unblocks building the server on FreeBSD. There may be more subtle issues, but this is working quite well for me so far!

This also contains a minor README edit to let you know where to find the binary ID. This probably warrants some more extensive documentation depending on how you're feeling about the possible directions for source builds (I started a discussion in #277), but I spent like half an hour figuring out what the right path was after getting the server build working 😂 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file metadata handling on FreeBSD by applying the correct permissions and mode conversion, aligning behavior with macOS.
  - Updated related platform documentation to accurately reflect FreeBSD support.

- **Documentation**
  - Added a troubleshooting checklist item explaining how to identify the binary ID needed for manual, out-of-band remote binary installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->