### PR TITLE
Expand tilde paths in the high-level handlers

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2894,11 +2894,7 @@ that `locate-dominating-stop-dir-regexp' is expected to match."
 (defun tramp-rpc-handle-dir-locals--all-files (directory &optional base-el-only)
   "Like `dir-locals--all-files' for TRAMP-RPC files.
 Return readable dir-locals files in DIRECTORY in increasing priority order."
-  (with-parsed-tramp-file-name
-      (if (file-name-absolute-p directory)
-          directory
-        (file-name-concat default-directory directory))
-      nil
+  (with-parsed-tramp-file-name (expand-file-name directory) nil
     ;; Unquote file names (e.g. /: prefix) before sending to server.
     (let* ((quoted-localname localname)
            (localdir (directory-file-name (file-name-unquote localname)))
@@ -2921,11 +2917,7 @@ For string/list NAME, uses a high-level RPC call.  Predicate NAME falls back
 to the built-in implementation."
   (if (functionp name)
       (tramp-run-real-handler #'locate-dominating-file (list file name))
-    (with-parsed-tramp-file-name
-        (if (file-name-absolute-p file)
-            file
-          (file-name-concat default-directory file))
-        nil
+    (with-parsed-tramp-file-name (expand-file-name file) nil
       ;; Unquote file names (e.g. /: prefix) before sending to server.
       (let* ((quoted-localname localname)
              (localname (file-name-unquote localname))
@@ -2951,11 +2943,7 @@ to the built-in implementation."
 
 (defun tramp-rpc--dir-locals-cache-update (file cache)
   "Call RPC helper for `dir-locals-find-file' update using FILE and CACHE."
-  (with-parsed-tramp-file-name
-      (if (file-name-absolute-p file)
-          file
-        (file-name-concat default-directory file))
-      nil
+  (with-parsed-tramp-file-name (expand-file-name file) nil
     ;; Unquote file names (e.g. /: prefix) before sending to server.
     (let* ((localname (file-name-unquote localname))
            (file-connection (file-remote-p file))
@@ -2991,9 +2979,7 @@ This is a lexical path check: the directories can be remote or not yet exist."
 
 (defun tramp-rpc-handle-dir-locals-find-file (file)
   "Like `dir-locals-find-file' for TRAMP-RPC files."
-  (let* ((file (if (file-name-absolute-p file)
-                   file
-                 (file-name-concat default-directory file)))
+  (let* ((file (expand-file-name file))
          (file-connection (file-remote-p file))
          (cache-update (tramp-rpc--dir-locals-cache-update file dir-locals-directory-cache))
          (locals-dir-update (alist-get 'locals cache-update))

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -365,7 +365,7 @@ pub async fn highlevel_test_files_in_dir(params: Value) -> HandlerResult {
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
-        let dir = canonical_or_original(Path::new(&params.directory));
+        let dir = canonical_or_original(Path::new(&super::expand_tilde(&params.directory)));
         if !dir.is_dir() {
             return Ok(Value::Array(vec![]));
         }
@@ -396,7 +396,7 @@ pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerRes
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
-        let path = PathBuf::from(&params.file);
+        let path = PathBuf::from(super::expand_tilde(&params.file));
         // Preserve lexical path shape instead of canonicalizing symlinks.
         // TRAMP clients rely on this to compute repo-relative paths correctly.
         let Some(existing_start) = find_existing_start(&path) else {
@@ -433,7 +433,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
     tokio::task::spawn_blocking(move || {
-        let file_path = PathBuf::from(&params.file);
+        let file_path = PathBuf::from(super::expand_tilde(&params.file));
         // Keep lexical (non-canonical) path shape to match locate-dominating behavior.
         let lexical_file = file_path.clone();
         let file_value = lexical_file.to_string_lossy().to_string().into_value();

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -808,6 +808,36 @@ Returns the result or signals an error."
             (should (string-match-p "/highlevel-root/\\.git\\'" first)))))
     (tramp-rpc-mock-test--stop-server)))
 
+(ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-expands-tilde ()
+  "Test high-level locate-dominating-file RPC expands a leading tilde.
+A tilde is a shell convention rather than a directory, so walking it
+literally finds nothing."
+  :tags '(:server)
+  (skip-unless tramp-rpc-mock-test--msgpack-available)
+  (skip-unless (tramp-rpc-mock-test--find-server))
+  (let ((home (make-temp-file "tramp-rpc-home" t))
+        ;; Overriding HOME below also changes how Emacs expands a tilde, so
+        ;; resolve `default-directory' while the real one is still in effect;
+        ;; the server is started with it as its working directory.
+        (default-directory (expand-file-name default-directory)))
+    (unwind-protect
+        (let ((process-environment (cons (concat "HOME=" home) process-environment)))
+          (tramp-rpc-mock-test--start-server)
+          (let ((deep (expand-file-name "project/a/b" home)))
+            (make-directory deep t)
+            (make-directory (expand-file-name "project/.git" home) t)
+            (with-temp-file (expand-file-name "file.txt" deep) (insert "x"))
+            (let* ((result (tramp-rpc-mock-test--rpc-call
+                            "highlevel.locate_dominating_file_multi"
+                            `((file . ,(encode-coding-string
+                                        "~/project/a/b/file.txt" 'utf-8))
+                              (names . [".git"]))))
+                   (first (car result)))
+              (should (stringp first))
+              (should (string= first (expand-file-name "project/.git" home))))))
+      (tramp-rpc-mock-test--stop-server)
+      (delete-directory home t))))
+
 (ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-preserves-symlink-path ()
   "Test locate-dominating-file keeps lexical symlink path."
   :tags '(:server)
@@ -6083,6 +6113,28 @@ operations and re-quoted on the way back."
              (result (tramp-rpc-handle-locate-dominating-file "foo" ".git")))
         (should (equal captured-file "/tmp/tramp-rpc-root/subdir/foo"))
         (should (equal result "/rpc:host:/:/tmp/tramp-rpc-root/"))))))
+
+(ert-deftest tramp-rpc-mock-test-locate-dominating-file-expands-tilde ()
+  "Ensure the locate-dominating handler expands a tilde before the RPC call.
+`find-file' abbreviates the remote home directory, so buffer paths reach
+this handler in tilde form.  Expanding here also keeps the search path and
+the returned directory in the one form
+`tramp-rpc--locate-dominating-before-stop-p' compares."
+  :tags '(:dir-locals)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let (captured-file)
+    (cl-letf (((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (string= method "highlevel.locate_dominating_file_multi"))
+                 (setq captured-file
+                       (decode-coding-string (alist-get 'file params) 'utf-8 t))
+                 (list (encode-coding-string "/home/user/project/.git" 'utf-8 t))))
+              ((symbol-function 'tramp-get-home-directory)
+               (lambda (&rest _) "/home/user")))
+      (let ((result (tramp-rpc-handle-locate-dominating-file
+                     "/rpc:host:~/project/src/" ".git")))
+        (should (equal captured-file "/home/user/project/src/"))
+        (should (equal result "/rpc:host:/home/user/project/"))))))
 
 (ert-deftest tramp-rpc-mock-test-locate-dominating-file-respects-stop-regexp ()
   "Ensure locate-dominating handler filters results above stop regexp."


### PR DESCRIPTION

`find-file` abbreviates the remote home directory, so most buffers under a
remote `$HOME` end up with a tilde `default-directory`. The three high-level
handlers walked such a path literally and found nothing. Visibly that broke VC —
`vc-git-root` is `locate-dominating-file`, so `vc-root-diff` built the fileset
`(Git (nil))` and reported `Wrong type argument: stringp, nil` instead of a
diff. The dir-locals handlers failed silently, never finding `.dir-locals.el`.

Expand on both sides, each for its own reason. The server expands at ingress, as
`ancestors_scan` and the file and process handlers already do, so a tilde in any
parameter is tolerated. The client normalizes the name, as the other file name
handlers already do, because the result goes back to Emacs and is compared:
`tramp-rpc--locate-dominating-before-stop-p` matches the search path against the
dominating directory by string equality, so expanding only on the server would
trade an empty result for a rejected one.

`expand-file-name` subsumes the hand-rolled absolute-or-concat branch it
replaces, resolving a relative name against `default-directory` exactly as
before.

Fixes #276.

Tests: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --release`
(144), `./test/run-tests.sh --mock` (275), and Lisp byte compilation with
`byte-compile-error-on-warn`. There is one new test per side, and both fail
without the change. Also verified against a live remote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paths beginning with `~` when locating files and directories on remote systems.
  * Directory-local configuration lookup now consistently expands paths before processing, improving results for home-directory-based paths.
  * Preserved existing path canonicalization, ancestor search, and caching behavior.

* **Tests**
  * Added regression coverage for remote home-directory expansion in file and directory lookup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->