### PR TITLE
Support flat package source discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["server"]
 [workspace.package]
 version = "0.13.1"
 edition = "2024"
+rust-version = "1.88"
 license = "GPL-3.0-or-later"
 authors = ["Arthur Heymans <arthur@aheymans.xyz>"]
 

--- a/README.org
+++ b/README.org
@@ -138,7 +138,7 @@ Access remote files using the ~rpc~ method:
 
 On first connection, the server binary is automatically obtained and deployed:
 
-1. *Release/package installs*: download from GitHub Releases first (fastest, ~850KB download), then build from source if Rust is installed and download fails.
+1. *Release/package installs*: download from GitHub Releases first (fastest, ~850KB download), then build from source if Rust 1.88 or later is installed and download fails.
 2. *Git checkout installs*: reuse a fresh source build or source-tree keyed cache.  Automatic file operations do not prompt when a binary is missing; run ~M-x tramp-rpc-deploy-install-binary~ to choose whether to download a checksum-verified release binary, build the checkout with Cargo, or skip.  A downloaded fallback remains keyed to that source tree, while strict ~build~ policy uses a separate identity.
 
 The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cache/emacs/tramp-rpc/= on the remote host.
@@ -451,7 +451,7 @@ ssh -o BatchMode=yes user@host echo success
 
 If GitHub downloads fail (corporate firewall, etc.), you can:
 
-1. Install Rust and let tramp-rpc build locally:
+1. Install Rust 1.88 or later and let tramp-rpc build locally:
    #+begin_src bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    #+end_src

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -52,12 +52,17 @@ before deriving the project root."
 
 (defun tramp-rpc-deploy--default-source-directory ()
   "Return the default tramp-rpc source directory.
-This is usually the parent of the Lisp directory.  Following source-file
+MELPA flattens Lisp files into the package root alongside the Rust sources,
+while source checkouts keep them in a Lisp subdirectory.  Following source-file
 symlinks is important for straight.el/Doom builds: the loaded .elc lives in
 straight/build..., while the adjacent .el symlink points back to
-straight/repos..., which contains Cargo.toml and the Rust server sources."
-  (when-let* ((file (tramp-rpc-deploy--load-source-file-name)))
-    (expand-file-name ".." (file-name-directory file))))
+straight/repos...."
+  (when-let* ((file (tramp-rpc-deploy--load-source-file-name))
+              (directory (file-name-directory file)))
+    (if (and (file-exists-p (expand-file-name "Cargo.toml" directory))
+             (file-directory-p (expand-file-name "server" directory)))
+        directory
+      (expand-file-name ".." directory))))
 
 (defgroup tramp-rpc-deploy nil
   "Deployment settings for TRAMP-RPC."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3,9 +3,9 @@
 ;; Copyright (C) 2026 Arthur Heymans <arthur@aheymans.xyz>
 
 ;; Author: Arthur Heymans <arthur@aheymans.xyz>
-;; URL: https://github.com/ArthurHeymans/tramp-rpc
 ;; Assisted-by: various LLMs
 ;; Version: 0.13.1
+;; URL: https://github.com/ArthurHeymans/emacs-tramp-rpc
 ;; Keywords: comm, processes, files
 ;; Package-Requires: ((emacs "30.1") (msgpack "0.1.1") (tramp "2.8.1.4"))
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tramp-rpc-server"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "RPC server for TRAMP remote file access"

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1127,6 +1127,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
                   "tramp-rpc-process" (local-process response))
 (declare-function tramp-rpc-deploy--download-file
                   "tramp-rpc-deploy" (url dest))
+(declare-function tramp-rpc-deploy--default-source-directory
+                  "tramp-rpc-deploy" ())
 (defconst tramp-rpc-mock-test--tramp-rpc-loaded t
   "The full TRAMP-RPC backend was loaded successfully.")
 
@@ -4581,6 +4583,24 @@ This matches the behavior expected by `tramp-test28-process-file'."
             (should (equal (file-name-as-directory
                             (tramp-rpc-deploy--default-source-directory))
                            (file-name-as-directory repo)))))
+      (delete-directory dir t))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-default-source-finds-flat-package ()
+  "Test default source directory finds Rust sources in a flat package."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-package" t))
+         (source (expand-file-name "tramp-rpc-deploy.el" dir)))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name "server" dir))
+          (with-temp-file (expand-file-name "Cargo.toml" dir))
+          (with-temp-file source
+            (insert ";; source\n"))
+          (let ((load-file-name source))
+            (should (equal (file-name-as-directory
+                            (tramp-rpc-deploy--default-source-directory))
+                           (file-name-as-directory dir)))))
       (delete-directory dir t))))
 
 (ert-deftest tramp-rpc-mock-test-deploy-git-install-ask-without-cargo ()


### PR DESCRIPTION
Detect Rust sources in both flat package layouts and source
checkouts, require Rust 1.88, and document the updated build
requirement. Add package metadata and deployment coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Rust 1.88 or newer is now required for building and installing from source.

* **Bug Fixes**
  * Improved deployment source detection for flat package layouts.
  * Deployment status now reports the binary ID.

* **Documentation**
  * Updated source-build and troubleshooting guidance.
  * Added documentation for multi-hop RPC workflows, including sudo, shell-based, and RPC-to-RPC chains.
  * Updated project and repository metadata for improved package identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->