### PR TITLE
fix: retry sudo authentication after rejected password (#274)

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -387,6 +387,7 @@ is VEC itself."
   (tramp-file-name-port (tramp-rpc--ssh-detail-vec vec)))
 
 (declare-function tramp-read-passwd "tramp")
+(declare-function tramp-clear-passwd "tramp" (vec))
 
 (defun tramp-rpc--sudo-auth-vec (vec)
   "Return the unprivileged rpc vector used to validate sudo for VEC."
@@ -454,6 +455,12 @@ shape before passing the value to `sudo -S'."
                     (if ssh-user (concat ssh-user "@") "") host))))
       (when (process-live-p process)
         (delete-process process)))))
+
+(defun tramp-rpc--clear-sudo-password (vec)
+  "Clear the cached sudo password for VEC.
+Called when a sudo-via-RPC server start fails so the next attempt prompts
+for a fresh password instead of silently reusing a rejected one."
+  (tramp-clear-passwd vec))
 
 (defun tramp-rpc--proxy-hop-string (vec)
   "Return VEC's hop string with its sudo rpc hop removed.
@@ -1710,11 +1717,23 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
 
     ;; Wait for server to be ready by sending a ping, and seed the
     ;; connection-local system.info cache for later uid/gid/home/shell lookups.
-    (let ((response (tramp-rpc--cache-system-info
-                     vec (tramp-rpc--call vec "system.info" nil))))
-      (unless response
-        (tramp-rpc--remove-connection vec)
-        (signal 'remote-file-error (list "Failed to connect to RPC server on" host))))
+    ;; `tramp-rpc--call' signals on the usual failed-start paths (a closed
+    ;; transport or timeout), so clear a supplied sudo password in the error
+    ;; handler as well as for an unexpected empty response.
+    (condition-case err
+        (let ((response (tramp-rpc--cache-system-info
+                         vec (tramp-rpc--call vec "system.info" nil))))
+          (unless response
+            (signal 'remote-file-error
+                    (list "Failed to connect to RPC server on" host))))
+      (remote-file-error
+       (tramp-rpc--remove-connection vec)
+       ;; A sudo start that fails to respond likely had its password rejected
+       ;; by sudo.  Clear the cached password so the next attempt prompts again
+       ;; instead of silently reusing the rejected password.
+       (when sudo-password
+         (tramp-rpc--clear-sudo-password vec))
+       (signal (car err) (cdr err))))
 
     ;; Set connection-local variables in the connection buffer.
     ;; Every TRAMP backend must call this after establishing the connection
@@ -1819,6 +1838,13 @@ accidentally routing file operations through tramp-sh."
          ;; leaving it alive can cause vc/diff-hl sentinels to route
          ;; file operations through tramp-sh instead of tramp-rpc.
          (tramp-rpc--cleanup-bootstrap-connection vec)
+         ;; The first start may have failed because sudo rejected the password.
+         ;; `tramp-rpc--start-server-process' cleared the cached password, so
+         ;; re-read it here to give the retry a fresh prompt.
+         (when sudo-ssh-user
+           (setq sudo-password
+                 (when (tramp-rpc--sudo-password-required-p vec)
+                   (tramp-rpc--sudo-read-password vec sudo-ssh-user))))
          (tramp-rpc--start-server-process vec binary-path sudo-password)))))))
 
 (defun tramp-rpc--disconnect (vec)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -5566,6 +5566,30 @@ as a hop in multi-hop chains."
     ;; gateway != server, so no sudo elevation
     (should-not (tramp-rpc--detect-sudo-elevation vec))))
 
+(ert-deftest tramp-rpc-mock-test-clear-sudo-password ()
+  "Clearing the sudo password cache removes the cached password.
+A rejected sudo password must not be reused on the next attempt, otherwise
+`tramp-revert-buffer-with-sudo' fails again without prompting (issue #274)."
+  :tags '(:multi-hop :sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name
+               "/rpc:alice@server|sudo:root@server:/etc/shadow"))
+         (sudo-ssh-user (tramp-rpc--detect-sudo-elevation vec))
+         (host (tramp-file-name-host vec))
+         (port (tramp-rpc--port-to-string (tramp-rpc--ssh-detail-port vec)))
+         (pw-spec (list :max 1 :user sudo-ssh-user :host host :port port
+                        :method "sudo"
+                        :require (cons :secret (and sudo-ssh-user '(:user)))
+                        :create (and sudo-ssh-user t)))
+         (key (auth-source-format-cache-entry pw-spec)))
+    ;; Simulate the pw-spec that `tramp-read-passwd' stores on the vec, then
+    ;; cache a (wrong) password the way `password-read' would.
+    (tramp-set-connection-property vec " pw-spec" pw-spec)
+    (password-cache-add key "wrongpass")
+    (should (password-in-cache-p key))
+    (tramp-rpc--clear-sudo-password vec)
+    (should-not (password-in-cache-p key))))
+
 (ert-deftest tramp-rpc-mock-test-sudo-file-name-predicate ()
   "Test the sudo+rpc handler predicate."
   :tags '(:multi-hop :sudo)
@@ -5907,6 +5931,42 @@ as a hop in multi-hop chains."
             (should-not (member "" command))
             (should (equal sent "secret\n")))
         (when (processp proc)
+          (delete-process proc))
+        (tramp-rpc--remove-connection vec)))))
+
+(ert-deftest tramp-rpc-mock-test-start-server-sudo-failure-clears-password ()
+  "A failed sudo server probe forgets its password before a retry."
+  :tags '(:sudo)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name
+              "/rpc:alice@server|sudo:root@server:/root/"))
+        (orig-make-process (symbol-function 'make-process))
+        cleared proc)
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest _)
+                 (setq proc (funcall orig-make-process
+                                     :name "tramp-rpc-mock-cat"
+                                     :buffer nil
+                                     :command '("cat")
+                                     :connection-type 'pipe
+                                     :noquery t))))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method _params)
+                 (should (equal method "system.info"))
+                 ;; This is the normal rejected-password failure: sudo exits,
+                 ;; and the RPC probe reports a closed transport.
+                 (signal 'remote-file-error '("RPC transport disconnected"))))
+              ((symbol-function 'tramp-rpc--clear-sudo-password)
+               (lambda (actual-vec)
+                 (setq cleared actual-vec))))
+      (unwind-protect
+          (progn
+            (should-error
+             (tramp-rpc--start-server-process
+              vec "/tmp/tramp-rpc-server" "wrong-password")
+             :type 'remote-file-error)
+            (should (eq cleared vec)))
+        (when (process-live-p proc)
           (delete-process proc))
         (tramp-rpc--remove-connection vec)))))
 


### PR DESCRIPTION
Clear the cached sudo password when the RPC server probe fails, then
request a fresh password before retrying after deployment.

Add mock coverage for cache clearing and transport failures during an
elevated server start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sudo authentication handling when remote RPC startup fails.
  * Clears rejected cached sudo passwords before retrying, allowing users to enter a fresh password when required.

* **Tests**
  * Added regression coverage for clearing cached sudo credentials and retrying failed sudo RPC server probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->