### PR TITLE
Handle symlink targets consistently

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2660,8 +2660,13 @@ which would otherwise perform another remote stat."
   "Like `file-symlink-p' for TRAMP-RPC files."
   (with-parsed-tramp-file-name (expand-file-name filename) nil
     (when-let* ((stat (tramp-rpc--call-file-stat v localname t))
-                ((equal (alist-get 'type stat) "symlink")))
-      (tramp-rpc--decode-string (alist-get 'link_target stat)))))
+                ((equal (alist-get 'type stat) "symlink"))
+                (result (tramp-rpc--decode-string
+                         (alist-get 'link_target stat))))
+      ;; Quote a symlink target which looks remote.
+      (if (tramp-tramp-file-p result)
+          (file-name-quote result 'top)
+        result))))
 
 (defun tramp-rpc-handle-access-file (filename string)
   "Like `access-file' for TRAMP-RPC files."
@@ -2797,6 +2802,9 @@ ID-FORMAT specifies whether to use numeric or string IDs."
          (mode (tramp-file-mode-from-int (alist-get 'mode stat)))
          (inode (alist-get 'inode stat))
          (dev (alist-get 'dev stat)))
+    ;; Quote a symlink target which looks remote.
+    (when (and (stringp type) (tramp-tramp-file-p type))
+      (setq type (file-name-quote type 'top)))
     ;; Return in file-attributes format
     (list type nlinks
           (if (eq id-format 'string) (or uname (number-to-string uid)) uid)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -428,6 +428,34 @@ The server sends the full st_mode value including file type bits."
       ;; Link count
       (should (= (file-attribute-link-number attrs) 1)))))
 
+(ert-deftest tramp-rpc-mock-test-quote-remote-looking-symlink-targets ()
+  "Remote-looking symlink targets are quoted before they reach TRAMP."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((target "/ssh:$SENSITIVE_DATA@remote-host:")
+         (encoded-target (encode-coding-string target 'utf-8-unix))
+         (stat-result `((type . "symlink")
+                        (link_target . ,encoded-target)
+                        (mode . ,(logior #o120000 #o777))
+                        (nlinks . 1)
+                        (uid . 1000)
+                        (gid . 1000)
+                        (atime . 1700000000)
+                        (mtime . 1700000001)
+                        (ctime . 1700000002)
+                        (inode . 12345)
+                        (dev . 1)))
+         (attribute-target
+          (file-attribute-type
+           (tramp-rpc--convert-file-attributes stat-result 'integer))))
+    (cl-letf (((symbol-function 'tramp-rpc--call-file-stat)
+               (lambda (_vec _localname &optional _lstat) stat-result)))
+      (let ((symlink-target
+             (tramp-rpc-handle-file-symlink-p "/rpc:mockhost:/tmp/link")))
+        (should (file-name-quoted-p symlink-target))
+        (should (equal (file-name-unquote symlink-target) target))))
+    (should (file-name-quoted-p attribute-target))
+    (should (equal (file-name-unquote attribute-target) target))))
+
 ;;; ============================================================================
 ;;; Local Server Tests (runs actual server)
 ;;; ============================================================================


### PR DESCRIPTION
Align tramp-rpc symlink target handling with current TRAMP behavior.

Apply the same normalization consistently to `file-symlink-p` and `file-attributes` results.
