### PR TITLE
fix: preserve process timers during RPC waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,16 @@ jobs:
             -l test/tramp-rpc-mock-tests.el \
             --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-protocol\")"
 
+      - name: Run request lifecycle tests
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(setq debug-on-error t)" \
+            -l test/tramp-rpc-mock-tests.el \
+            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-request\")"
+
   test-multi-hop:
     name: Multi-Hop Tests (${{ matrix.emacs_label }})
     runs-on: ubuntu-latest

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -66,6 +66,7 @@
 (defvar tramp-rpc-async-read-timeout-ms)
 (defvar tramp-rpc--delivering-output)
 (defvar tramp-rpc--closing-local-relay)
+(defvar tramp-rpc--process-timer-recorder)
 
 ;; ============================================================================
 ;; Process tracking state
@@ -108,6 +109,9 @@ the next read cannot discard output waiting for relay delivery."
                  (puthash process (plist-put current timer-key nil) table)
                  (apply function args)))))
       (puthash process (plist-put info timer-key timer) table)
+      (when tramp-rpc--process-timer-recorder
+        (funcall tramp-rpc--process-timer-recorder
+                 timer table process timer-key))
       timer)))
 
 (defun tramp-rpc--cancel-process-timers (table process)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -855,6 +855,9 @@ and optional :stderr-buffer.")
 (defvar tramp-rpc--async-callback-processes (make-hash-table :test 'eql)
   "Hash table mapping async request IDs to their transport process.")
 
+(defvar tramp-rpc--process-timer-recorder nil
+  "Function called for process timers created during a suspended RPC wait.")
+
 (defvar tramp-rpc--pending-responses (make-hash-table :test 'eq)
   "Hash table mapping buffers to their pending response hash tables.
 Each buffer has its own hash table mapping request IDs to response plists.")
@@ -2101,6 +2104,30 @@ and blocking SSH or the remote server."
          (max (point-min) (- (point-max) (or max-bytes 1024)))
          (point-max))))))
 
+(defmacro tramp-rpc--with-suspended-timers-preserving-process-timers (&rest body)
+  "Run BODY with external timers suspended, preserving new process timers.
+Reactivation assumes no enclosing `with-tramp-suspended-timers' is still
+in effect when BODY exits, because the restored timers would land in that
+outer binding of `timer-list' and be discarded again.  The RPC wait loops
+satisfy this: they accept output with JUST-THIS-ONE, so no other
+connection's filter, and therefore no nested wait, can run inside BODY."
+  (declare (indent 0) (debug t))
+  (let ((recorded (make-symbol "recorded-process-timers")))
+    `(let (,recorded)
+       (unwind-protect
+           (let ((tramp-rpc--process-timer-recorder
+                  (lambda (&rest timer-state)
+                    (push timer-state ,recorded))))
+             (with-tramp-suspended-timers
+               ,@body))
+         (dolist (timer-state ,recorded)
+           (pcase-let ((`(,timer ,table ,process ,timer-key) timer-state))
+             (when (and (timerp timer)
+                        (not (memq timer timer-list))
+                        (when-let* ((info (gethash process table)))
+                          (eq timer (plist-get info timer-key))))
+               (timer-activate timer))))))))
+
 (defun tramp-rpc--call-with-timeout (vec method params total-timeout poll-interval
                                           &optional connection)
   "Call METHOD with PARAMS on the RPC server for VEC.
@@ -2158,12 +2185,14 @@ Returns the result or signals an error."
             ;; - JUST-THIS-ONE=t to only accept from this process (Bug#12145)
             ;; - with-local-quit to allow C-g, returns t on success
             ;; - Propagate quit if user pressed C-g
-            ;; - with-tramp-suspended-timers to prevent deferred process
-            ;;   sentinels (scheduled via run-at-time 0) from firing
-            ;;   inside accept-process-output and blocking this call.
-            ;;   The sentinels will run when control returns to the
-            ;;   command loop.  (Mirrors tramp-accept-process-output.)
-            (if (with-tramp-suspended-timers
+            ;; - suspended timers to prevent deferred process sentinels
+            ;;   (scheduled via run-at-time 0) from firing inside
+            ;;   accept-process-output and blocking this call.  The
+            ;;   sentinels will run when control returns to the command
+            ;;   loop.  (Mirrors tramp-accept-process-output.)  The
+            ;;   wrapper additionally keeps process timers this wait
+            ;;   scheduled, which the plain suspension would discard.
+            (if (tramp-rpc--with-suspended-timers-preserving-process-timers
                   (with-local-quit
                     (tramp-rpc--drain-connection-stderr conn)
                     (accept-process-output process poll-interval nil t)
@@ -2263,7 +2292,7 @@ Returns:
                 ;; Check if other thread already got our response
                 (setq response (tramp-rpc--find-response-by-id expected-id process)))
             ;; Process is accessible
-            (if (with-tramp-suspended-timers
+            (if (tramp-rpc--with-suspended-timers-preserving-process-timers
                   (with-local-quit
                     (tramp-rpc--drain-connection-stderr conn)
                     (accept-process-output process 0.1 nil t)
@@ -2382,7 +2411,7 @@ captured connection generation to use."
                     (puthash id response responses)
                     (setq remaining-ids (delete id remaining-ids))))))
           ;; Process is accessible
-          (if (with-tramp-suspended-timers
+          (if (tramp-rpc--with-suspended-timers-preserving-process-timers
                 (with-local-quit
                   (tramp-rpc--drain-connection-stderr conn)
                   (accept-process-output process 0.1 nil t)

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -6,6 +6,8 @@
 
 (declare-function tramp-rpc--invalidate-timed-out-connection "tramp-rpc"
                   (process vec event))
+(declare-function tramp-rpc-mock-test--wait-for "tramp-rpc-mock-tests"
+                  (predicate description &optional process))
 
 (defun tramp-rpc-mock-test-request--connection ()
   "Return a live process and its buffer for request lifecycle tests."
@@ -209,6 +211,113 @@
       (should-not (gethash 201 tramp-rpc--async-callbacks))
       (should (equal '(:id 202 :result second)
                      (gethash 202 (tramp-rpc--get-pending-responses buffer)))))))
+
+(defun tramp-rpc-mock-test-request--assert-poll-survives-wait
+    (vec connection-process deliver wait)
+  "Assert a relay poll scheduled inside a synchronous RPC wait stays live.
+CONNECTION-PROCESS is the transport the waiter listens on.  DELIVER runs
+inside the first `accept-process-output\=' and must buffer the response the
+waiter expects.  WAIT performs the synchronous call; its value is returned."
+  (let* ((relay (make-pipe-process
+                 :name "tramp-rpc-mock-test-request-relay"
+                 :noquery t))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (original-accept-process-output
+          (symbol-function 'accept-process-output))
+         (next-reads 0)
+         response-delivered
+         result)
+    (unwind-protect
+        (progn
+          (puthash relay
+                   (list :vec vec :pid 42
+                         :connection-process connection-process
+                         :delivery-timer nil :poll-timer nil)
+                   tramp-rpc--async-processes)
+          (cl-letf (((symbol-function 'tramp-rpc--call-async)
+                     (lambda (&rest _) (cl-incf next-reads)))
+                    ((symbol-function 'accept-process-output)
+                     (lambda (&rest args)
+                       (if response-delivered
+                           (apply original-accept-process-output args)
+                         (setq response-delivered t)
+                         (tramp-rpc--handle-async-read-response
+                          relay
+                          '(:result ((stdout . nil)
+                                     (stderr . nil)
+                                     (exited . nil))))
+                         (funcall deliver)
+                         t))))
+            (setq result (funcall wait))
+            (tramp-rpc-mock-test--wait-for
+             (lambda () (= next-reads 1))
+             "next async process read" relay))
+          (should (= next-reads 1))
+          result)
+      (when (process-live-p relay)
+        (delete-process relay)))))
+
+(ert-deftest tramp-rpc-mock-test-request-wait-preserves-async-process-poll ()
+  "An async process response received during a sync wait schedules its next poll."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec)
+                   (list :process process :buffer buffer :vec vec)))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(301 . "request")))
+                ((symbol-function 'process-send-string)
+                 (lambda (&rest _) nil)))
+        (should (eq 'done
+                    (tramp-rpc-mock-test-request--assert-poll-survives-wait
+                     vec process
+                     (lambda ()
+                       (puthash 301 '(:id 301 :result done)
+                                (tramp-rpc--get-pending-responses buffer)))
+                     (lambda ()
+                       (tramp-rpc--call-with-timeout
+                        vec "test" nil 1 0.01)))))))))
+
+(ert-deftest tramp-rpc-mock-test-request-batch-wait-preserves-async-process-poll ()
+  "An async process response received during a batch wait schedules its next poll."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                 (lambda (_vec)
+                   (list :process process :buffer buffer :vec vec)))
+                ((symbol-function 'tramp-rpc-protocol-encode-batch-request-with-id)
+                 (lambda (&rest _) '(302 . "batch")))
+                ((symbol-function 'process-send-string)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'tramp-rpc-protocol-decode-batch-response)
+                 (lambda (_response) 'batch-result)))
+        (should (eq 'batch-result
+                    (tramp-rpc-mock-test-request--assert-poll-survives-wait
+                     vec process
+                     (lambda ()
+                       (puthash 302 '(:id 302 :result batch)
+                                (tramp-rpc--get-pending-responses buffer)))
+                     (lambda ()
+                       (tramp-rpc--call-batch vec '(("test" . nil)))))))))))
+
+(ert-deftest tramp-rpc-mock-test-request-receive-preserves-async-process-poll ()
+  "An async process response received during a pipelined wait schedules its next poll."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (tramp-rpc--track-pending-request process 303)
+      (should (equal '((303 . (:id 303 :result pipelined)))
+                     (tramp-rpc-mock-test-request--assert-poll-survives-wait
+                      vec process
+                      (lambda ()
+                        (puthash 303 '(:id 303 :result pipelined)
+                                 (tramp-rpc--get-pending-responses buffer)))
+                      (lambda ()
+                        (tramp-rpc--receive-responses
+                         vec '(303) 1
+                         (list :process process :buffer buffer :vec vec)))))))))
 
 (ert-deftest tramp-rpc-mock-test-request-batch-timeout-cleans-id ()
   "A batch timeout releases its request ID and response table."


### PR DESCRIPTION
## Problem

`with-tramp-suspended-timers` let-binds `timer-list` and `timer-idle-list` to nil for the duration of its body. The RPC wait loops call `accept-process-output` inside that binding, so the connection filter runs there too.

When the filter dispatches an async process response, `tramp-rpc--handle-async-read-response` schedules the next read with `tramp-rpc--schedule-process-timer`. That timer lands in the temporary `timer-list` binding and is discarded when the macro exits. The relay process stays live with no active read, so its output stops arriving until something else pokes it.

## Fix

`tramp-rpc--with-suspended-timers-preserving-process-timers` records the process timers created inside the suspended extent and reactivates them afterwards. It reactivates a timer only when all three hold:

- the timer is not already in `timer-list`, so the macro is a no-op when `tramp-dont-suspend-timers` is set;
- the process still has a tracking entry;
- that entry still points at this timer, so timers that fired, were cancelled, or were replaced during the wait are skipped.

All three wait loops share the transport that carries relay responses, so the fix covers each of them: `tramp-rpc--call-with-timeout`, `tramp-rpc--call-batch`, and `tramp-rpc--receive-responses`. The batch path matters in practice because the magit prefetch drives it.

The ControlMaster wait in `tramp-rpc--action-controlmaster-established` is left alone. It waits on a raw SSH process that carries no relay traffic.

## Tests

`tramp-rpc-mock-test-request--assert-poll-survives-wait` delivers an async relay response inside the first `accept-process-output` of a wait, then asserts the next read is actually scheduled. Three tests use it, one per wait loop.

All three fail on master with `Timed out waiting for next async process read` and pass with the fix.

## CI coverage

No CI selector matched `tramp-rpc-mock-test-request`, so the whole request lifecycle suite ran only locally and this regression guard would not have run in CI. A second commit adds a step to the protocol job, which already installs the needed packages and runs on both Emacs versions.

## Verification

- `emacs -Q --batch -l test/tramp-rpc-mock-tests.el --eval '(ert-run-tests-batch-and-exit "^tramp-rpc-mock-test-request")'` gives 16 of 16, both with and without `debug-on-error t`.
- `./test/run-tests.sh --mock` after `cargo build --release` gives 281 tests, 273 as expected, 0 skipped, 8 failures. The same 8 fail on a clean master checkout on macOS: two deploy tests compare `/var/folders/...` against a resolved `/private/var/folders/...`, and six `move-file-to-trash` tests assume `system-move-file-to-trash` is unbound, which is false on macOS. Both causes are absent on the Linux CI runners.
- Byte-compiling `lisp/*.el` with `byte-compile-error-on-warn` set to t exits 0 with no warnings.

No Rust code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of synchronous, batch, and pipelined RPC requests.
  * Preserved asynchronous relay polling during RPC waits, helping ensure responses are delivered without interrupting scheduled processing.

* **Tests**
  * Added coverage for request lifecycle handling across single, batch, and pipelined requests.
  * CI now runs the expanded RPC request tests automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
