### PR TITLE
Fix remote process signaling and Windows relay startup

### DIFF
--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -37,6 +37,7 @@
 ;; Functions from tramp.el
 (declare-function tramp-add-external-operation "tramp")
 (declare-function tramp-remove-external-operation "tramp")
+(declare-function tramp-dissect-file-name "tramp" (name &optional nodefault))
 
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process"
@@ -53,6 +54,7 @@
 (declare-function tramp-rpc--debug "tramp-rpc")
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc--managed-file-name-p "tramp-rpc")
 
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
 (defvar tramp-rpc--delivering-output)
@@ -242,25 +244,45 @@ PROCESS is the process being handled."
        ;; Not a tramp-rpc process
        (t (tramp-run-real-handler #'process-send-eof (and process (list process))))))))
 
-(defun tramp-rpc-handle-signal-process (process sigcode &optional _remote)
+(defun tramp-rpc-handle-signal-process (process sigcode &optional remote)
   "Handler for `signal-process' of TRAMP-RPC processes.
 It will be added to `signal-process-functions'.
-PROCESS is the process being handled.
-SIGCODE identifies the signal to send."
-  (when-let* ((pid (and (processp process)
-			(process-get process :tramp-rpc-pid)))
-	      (vec (process-get process :tramp-rpc-vec)))
-    (condition-case err
-        (progn
-          ;; Use PTY kill for PTY processes, regular kill for pipe processes
-          (if (process-get process :tramp-rpc-pty)
-              (tramp-rpc--call vec "process.kill_pty"
-                               `((pid . ,pid) (signal . ,sigcode)))
-            (tramp-rpc--kill-remote-process vec pid sigcode))
-          0) ; Return 0 for success
-      (error
-       (message "tramp-rpc: Error signaling process: %s" err)
-       -1))))
+PROCESS is the process object or remote PID being handled.
+SIGCODE identifies the signal to send.  REMOTE identifies the host when
+PROCESS is a PID."
+  (when (stringp process)
+    (setq process
+          (or (get-process process)
+              (and (string-match-p (rx bol (+ digit) eol) process)
+                   (string-to-number process)))))
+  (let (pid vec rpc-process)
+    (cond
+     ((processp process)
+      (setq pid (process-get process :tramp-rpc-pid)
+            vec (process-get process :tramp-rpc-vec)
+            rpc-process process))
+     ((and (numberp process)
+           (stringp remote)
+           (tramp-rpc--managed-file-name-p remote))
+      (setq pid process
+            vec (tramp-dissect-file-name remote))))
+    (when (and pid vec)
+      (let ((connection (and rpc-process
+                             (process-get rpc-process :tramp-rpc-connection))))
+        (condition-case err
+            (progn
+              ;; Use PTY kill for PTY processes, regular kill for pipe processes.
+              (if (and rpc-process
+                       (process-get rpc-process :tramp-rpc-pty))
+                  (tramp-rpc--call vec "process.kill_pty"
+                                   `((pid . ,pid) (signal . ,sigcode))
+                                   connection)
+                (tramp-rpc--kill-remote-process
+                 vec pid sigcode connection))
+              0) ; Return 0 for success.
+          (error
+           (message "tramp-rpc: Error signaling process: %s" err)
+           -1))))))
 
 ;; ============================================================================
 ;; Process metadata handlers

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -178,7 +178,10 @@ Return raw unibyte bytes suitable for MessagePack bin payloads."
 If relay construction fails, delete any relay already created and call CLEANUP
 before propagating the original error.
 Return (STDOUT-PROCESS . STDERR-PROCESS)."
-  (let (stdout-process stderr-process complete)
+  (let ((default-directory (default-toplevel-value 'temporary-file-directory))
+        (exec-path (default-toplevel-value 'exec-path))
+        (process-environment (default-toplevel-value 'process-environment))
+        stdout-process stderr-process complete)
     (unwind-protect
         (prog1
             (progn

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -934,8 +934,82 @@ fn signal_pty_process_group(pid: u32, signal: i32, action: &str) -> Result<(), R
     }
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SignalCode {
+    Number(i32),
+    Name(String),
+}
+
+impl SignalCode {
+    fn resolve(self) -> Result<i32, RpcError> {
+        match self {
+            Self::Number(signal) => {
+                validate_signal(signal)?;
+                Ok(signal)
+            }
+            Self::Name(name) => {
+                let name = name.to_ascii_uppercase();
+                let name = if name.starts_with("SIG") {
+                    name
+                } else {
+                    format!("SIG{name}")
+                };
+                let canonical_name = match name.as_str() {
+                    "SIGCLD" => "SIGCHLD",
+                    "SIGIOT" => "SIGABRT",
+                    "SIGPOLL" => "SIGIO",
+                    "SIGUNUSED" => "SIGSYS",
+                    _ => name.as_str(),
+                };
+                if canonical_name.starts_with("SIGRTMIN") || canonical_name.starts_with("SIGRTMAX")
+                {
+                    parse_realtime_signal(canonical_name)
+                        .ok_or_else(|| RpcError::invalid_params(format!("Invalid signal: {name}")))
+                } else {
+                    canonical_name
+                        .parse::<Signal>()
+                        .map(|signal| signal as i32)
+                        .map_err(|_| RpcError::invalid_params(format!("Invalid signal: {name}")))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn realtime_signal_bounds() -> Option<(i32, i32)> {
+    Some((libc::SIGRTMIN(), libc::SIGRTMAX()))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn realtime_signal_bounds() -> Option<(i32, i32)> {
+    None
+}
+
+fn parse_realtime_signal(name: &str) -> Option<i32> {
+    let (minimum, maximum) = realtime_signal_bounds()?;
+    let (base, suffix, minimum_based) = if let Some(suffix) = name.strip_prefix("SIGRTMIN") {
+        (minimum, suffix, true)
+    } else {
+        (maximum, name.strip_prefix("SIGRTMAX")?, false)
+    };
+    let offset = if suffix.is_empty() {
+        0
+    } else {
+        let expected_operator = if minimum_based { '+' } else { '-' };
+        suffix
+            .starts_with(expected_operator)
+            .then(|| suffix.parse::<i32>().ok())??
+    };
+    let signal = base.checked_add(offset)?;
+    (minimum..=maximum).contains(&signal).then_some(signal)
+}
+
 fn validate_signal(signal: i32) -> Result<(), RpcError> {
-    if signal == 0 || Signal::try_from(signal).is_ok() {
+    let realtime = realtime_signal_bounds()
+        .is_some_and(|(minimum, maximum)| (minimum..=maximum).contains(&signal));
+    if signal == 0 || Signal::try_from(signal).is_ok() || realtime {
         Ok(())
     } else {
         Err(RpcError::invalid_params(format!(
@@ -1123,15 +1197,15 @@ pub async fn kill(params: Value) -> HandlerResult {
         pid: u32,
         /// Signal to send (default: SIGTERM)
         #[serde(default = "default_signal")]
-        signal: i32,
+        signal: SignalCode,
     }
 
-    fn default_signal() -> i32 {
-        libc::SIGTERM
+    fn default_signal() -> SignalCode {
+        SignalCode::Number(libc::SIGTERM)
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
-    validate_signal(params.signal)?;
+    let signal = params.signal.resolve()?;
     // Signaling an unknown pid is an error; internal cleanup paths call
     // terminate_pipe_process directly and tolerate vanished entries.
     if !get_process_map().lock().await.contains_key(&params.pid) {
@@ -1140,7 +1214,7 @@ pub async fn kill(params: Value) -> HandlerResult {
             params.pid
         )));
     }
-    terminate_pipe_process(params.pid, params.signal, false).await?;
+    terminate_pipe_process(params.pid, signal, false).await?;
     Ok(Value::Boolean(true))
 }
 
@@ -2189,15 +2263,15 @@ pub async fn kill_pty(params: Value) -> HandlerResult {
     struct Params {
         pid: u32,
         #[serde(default = "default_pty_signal")]
-        signal: i32,
+        signal: SignalCode,
     }
 
-    fn default_pty_signal() -> i32 {
-        libc::SIGTERM
+    fn default_pty_signal() -> SignalCode {
+        SignalCode::Number(libc::SIGTERM)
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
-    validate_signal(params.signal)?;
+    let signal = params.signal.resolve()?;
     // Signaling an unknown pid is an error; close_pty stays idempotent by
     // calling terminate_pty_process directly.
     if !get_pty_process_map().lock().await.contains_key(&params.pid) {
@@ -2212,10 +2286,10 @@ pub async fn kill_pty(params: Value) -> HandlerResult {
     // Explicit SIGKILL also opts out of output draining.
     terminate_pty_process(
         params.pid,
-        params.signal,
+        signal,
         false,
-        params.signal == libc::SIGKILL,
-        params.signal == libc::SIGKILL,
+        signal == libc::SIGKILL,
+        signal == libc::SIGKILL,
     )
     .await?;
     Ok(Value::Boolean(true))
@@ -2331,6 +2405,67 @@ pub async fn cleanup_managed_processes() -> Result<(), RpcError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signal_code_accepts_emacs_signal_names() {
+        assert_eq!(
+            SignalCode::Name("SIGINT".into()).resolve().unwrap(),
+            libc::SIGINT
+        );
+        assert_eq!(
+            SignalCode::Name("term".into()).resolve().unwrap(),
+            libc::SIGTERM
+        );
+        assert_eq!(
+            SignalCode::Name("SIGCLD".into()).resolve().unwrap(),
+            libc::SIGCHLD
+        );
+        assert_eq!(
+            SignalCode::Name("SIGIOT".into()).resolve().unwrap(),
+            libc::SIGABRT
+        );
+        assert_eq!(
+            SignalCode::Name("poll".into()).resolve().unwrap(),
+            libc::SIGIO
+        );
+        assert_eq!(
+            SignalCode::Name("SIGUNUSED".into()).resolve().unwrap(),
+            libc::SIGSYS
+        );
+        assert_eq!(SignalCode::Number(0).resolve().unwrap(), 0);
+        assert_eq!(
+            SignalCode::Name("not-a-signal".into())
+                .resolve()
+                .expect_err("invalid signal name")
+                .code,
+            RpcError::INVALID_PARAMS
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn signal_code_accepts_emacs_realtime_signal_names() {
+        let minimum = libc::SIGRTMIN();
+        let maximum = libc::SIGRTMAX();
+        assert_eq!(
+            SignalCode::Name("SIGRTMIN".into()).resolve().unwrap(),
+            minimum
+        );
+        assert_eq!(
+            SignalCode::Name("rtmin+1".into()).resolve().unwrap(),
+            minimum + 1
+        );
+        assert_eq!(
+            SignalCode::Name("SIGRTMAX-1".into()).resolve().unwrap(),
+            maximum - 1
+        );
+        assert_eq!(SignalCode::Number(maximum).resolve().unwrap(), maximum);
+        assert!(SignalCode::Name("SIGRTMIN-1".into()).resolve().is_err());
+        assert!(SignalCode::Name("SIGRTMAX+1".into()).resolve().is_err());
+        assert!(SignalCode::Name("SIGRTMIN+999".into()).resolve().is_err());
+        assert!(SignalCode::Name("SIGRTMIN1".into()).resolve().is_err());
+        assert!(SignalCode::Name("SIGRTMAX1".into()).resolve().is_err());
+    }
 
     #[test]
     fn process_group_signal_reports_eperm_instead_of_treating_cleanup_as_success() {
@@ -3273,17 +3408,14 @@ mod tests {
             (Value::String("pid".into()), Value::Integer(pipe_pid.into())),
             (
                 Value::String("signal".into()),
-                Value::Integer((libc::SIGKILL as i64).into()),
+                Value::String("SIGKILL".into()),
             ),
         ]))
         .await
-        .expect("cleanup pipe");
+        .expect("cleanup pipe with named signal");
         kill_pty(Value::Map(vec![
             (Value::String("pid".into()), Value::Integer(pty_pid.into())),
-            (
-                Value::String("signal".into()),
-                Value::Integer((libc::SIGKILL as i64).into()),
-            ),
+            (Value::String("signal".into()), Value::String("KILL".into())),
         ]))
         .await
         .expect("cleanup PTY");

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1125,6 +1125,8 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (require 'tramp-rpc)
 (declare-function tramp-rpc--pty-handle-async-response
                   "tramp-rpc-process" (local-process response))
+(declare-function tramp-rpc-handle-signal-process
+                  "tramp-rpc-advice" (process sigcode &optional remote))
 (declare-function tramp-rpc-deploy--download-file
                   "tramp-rpc-deploy" (url dest))
 (defconst tramp-rpc-mock-test--tramp-rpc-loaded t
@@ -6545,6 +6547,51 @@ discard it for being unreadable."
        (setq body-env tramp-remote-process-environment)))
     (should (equal body-env
                    '("TERM=dumb" "PYTHONUNBUFFERED=1" "EXISTING=yes")))))
+
+(ert-deftest tramp-rpc-mock-test-signal-process-routes-remote-pid ()
+  "Remote PID signals use RPC and relays retain their owning connection."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:user@host:/"))
+        (old-connection 'old-connection)
+        (replacement-connection 'replacement-connection)
+        process captured)
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--get-connection)
+                   (lambda (_vec) replacement-connection))
+                  ((symbol-function 'tramp-rpc--kill-remote-process)
+                   (lambda (vec pid signal &optional connection)
+                     (setq captured (list 'pipe vec pid signal connection))))
+                  ((symbol-function 'tramp-rpc--call)
+                   (lambda (vec method params &optional connection)
+                     (setq captured (list 'pty vec method params connection)))))
+          (should (= 0 (tramp-rpc-handle-signal-process
+                        12345 'SIGINT "/rpc:user@host:/")))
+          (should (equal (list (car captured) (nth 2 captured)
+                               (nth 3 captured) (nth 4 captured))
+                         '(pipe 12345 SIGINT nil)))
+          (should (string= (tramp-file-name-method (nth 1 captured)) "rpc"))
+          (should-not (tramp-rpc-handle-signal-process
+                       12345 2 "/ssh:user@host:/"))
+
+          (setq process (start-process "tramp-rpc-signal-owner" nil "cat"))
+          (process-put process :tramp-rpc-vec vec)
+          (process-put process :tramp-rpc-pid 54321)
+          (process-put process :tramp-rpc-connection old-connection)
+          (should (= 0 (tramp-rpc-handle-signal-process process 15)))
+          (should (equal (list (car captured) (nth 2 captured)
+                               (nth 3 captured) (nth 4 captured))
+                         `(pipe 54321 15 ,old-connection)))
+
+          (process-put process :tramp-rpc-pty t)
+          (should (= 0 (tramp-rpc-handle-signal-process process 'SIGINT)))
+          (should (equal (list (car captured) (nth 2 captured)
+                               (alist-get 'pid (nth 3 captured))
+                               (alist-get 'signal (nth 3 captured))
+                               (nth 4 captured))
+                         `(pty "process.kill_pty" 54321 SIGINT
+                               ,old-connection))))
+      (when (processp process)
+        (ignore-errors (delete-process process))))))
 
 (ert-deftest tramp-rpc-mock-test-process-file-passes-path-and-unresolved-command ()
   "Test `process-file' searches commands with `tramp-remote-path' PATH."

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -84,6 +84,8 @@
 
 (declare-function tramp-rpc--decode-output "tramp-rpc" (data))
 (declare-function tramp-rpc--handle-async-read-response "tramp-rpc-process")
+(declare-function tramp-rpc--start-cat-relays
+                  "tramp-rpc-process" (name buffer stderr-buffer cleanup))
 (declare-function tramp-rpc--pty-handle-async-response
                   "tramp-rpc-process" (local-process response))
 
@@ -1874,6 +1876,28 @@ This matches the upstream `tramp-test28-process-file' test."
     ;; Cons pair with nil encoding: nil replaced with default
     (should (equal (list 'utf-8-unix default-enc)
                    (tramp-rpc--coding-args '(utf-8-unix . nil))))))
+
+(ert-deftest tramp-rpc-test13a-cat-relay-uses-local-process-context ()
+  "Local relay creation must not inherit a remote process context."
+  (let ((original-start-process (symbol-function 'start-process))
+        (local-directory (default-toplevel-value 'temporary-file-directory))
+        (local-exec-path (default-toplevel-value 'exec-path))
+        (local-environment (default-toplevel-value 'process-environment))
+        (default-directory "/rpc:mock:/tmp/")
+        (exec-path '("/remote/bin"))
+        (process-environment '("REMOTE=1"))
+        captured process)
+    (unwind-protect
+        (cl-letf (((symbol-function 'start-process)
+                   (lambda (&rest args)
+                     (setq captured
+                           (list default-directory exec-path process-environment))
+                     (setq process (apply original-start-process args)))))
+          (tramp-rpc--start-cat-relays "tramp-rpc-local-relay" nil nil #'ignore)
+          (should (equal captured
+                         (list local-directory local-exec-path local-environment))))
+      (when (processp process)
+        (ignore-errors (delete-process process))))))
 
 (ert-deftest tramp-rpc-test13b-cat-relay-construction-cleans-partial-state ()
   "A failed stderr relay removes the stdout relay and remote child."


### PR DESCRIPTION
Remote PID signaling fell through to TRAMP's generic handler, which could hang and invalidate the RPC connection. Local relay creation could also inherit remote process lookup paths, preventing `cat.exe` from being found on Windows.

Route numeric PIDs with RPC remote paths through the RPC signal handler, and let the server resolve symbolic signal names such as `SIGINT`. Create local relay processes with Emacs's local process context so executable lookup remains local.

Closes #286
Closes #201


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal handling now supports process names, numeric PIDs, standard signal names, legacy aliases, and realtime signals.
  * Signals for managed remote processes and PTY relays are routed through the appropriate connection.

* **Bug Fixes**
  * Local relay processes now start with the correct local environment.
  * Invalid signal names and out-of-range values are rejected safely.

* **Tests**
  * Added coverage for remote PID signaling, PTY routing, signal-name resolution, realtime signals, and relay environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->