### PR TITLE
Support multi-hop file names like /rpc:host|su:: and /rpc:host|docker:

### DIFF
--- a/README.org
+++ b/README.org
@@ -143,6 +143,20 @@ On first connection, the server binary is automatically obtained and deployed:
 
 The binary is cached locally in =~/.emacs.d/tramp-rpc/= and deployed to =~/.cache/emacs/tramp-rpc/= on the remote host.
 
+** Multi-hop (~|~) file names
+
+TRAMP's ad-hoc multi-hop syntax works with the ~rpc~ method:
+
+- ~/rpc:user@host|sudo:root@host:/path~ stays RPC-accelerated: the RPC
+  server on =host= is started via sudo, so file operations run with
+  root privileges at full RPC speed.
+- Chains ending in shell-based methods such as ~su~ or ~docker~, e.g.
+  ~/rpc:host|su::/path~ or ~/rpc:host|docker:container:/path~, use
+  TRAMP's regular shell-based handler, which logs in through the rpc hop
+  as if it were ~ssh~.  The RPC server and its speedup are not used for
+  these chains.  RPC-to-RPC chains remain RPC-backed at the final target;
+  intermediate rpc hops provide SSH routing.
+
 ** Deployment Commands
 
 | Command                          | Description                    |

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -75,25 +75,27 @@
   ;; Register the method
   (add-to-list 'tramp-methods
                `(,tramp-rpc-method
-                 ;; Declare that the rpc method uses the host name.
-                 ;; tramp-compute-multi-hops validates that methods without
-                 ;; "%h" in tramp-login-args use a host matching the previous
-                 ;; hop.  Since rpc IS host-directed (it SSH-connects to the
-                 ;; specified host), advertising "%h" here lets rpc appear
-                 ;; as a proxy hop in chains like /rpc:server|sudo:root@server:/path
-                 ;; without triggering the "host does not match" error.
-                 ;; The actual tramp-login-args value is never used for login
-                 ;; because rpc is a foreign (non-tramp-sh) file handler.
-                 (tramp-login-args (("%h")))
-                 ;; Match TRAMP's remote-shell convention so PTY login shells
-                 ;; can honor method/connection-local overrides.
-                 (tramp-remote-shell-login ("-l"))
-                 ;; Direct async process support: tramp-rpc uses direct SSH
-                 ;; PTY connections for async processes, which means stderr
-                 ;; is mixed with stdout (normal PTY behavior).  Setting
-                 ;; tramp-direct-async lets upstream tests know to skip
-                 ;; stderr-separation assertions for async shell-command.
-                 (tramp-direct-async t)))
+                 ;; Placeholder; replaced with ssh's parameters below.
+                 (tramp-login-args (("%h")))))
+
+  ;; Give the rpc method all ssh connection parameters so it can serve
+  ;; as a hop in tramp-sh multi-hop chains.  This matters in two ways:
+  ;; - /rpc:host|sudo:root@host:/path is claimed by the tramp-rpc
+  ;;   foreign handler (see `tramp-rpc--sudo-file-name-p'), which never
+  ;;   uses these parameters for login.
+  ;; - Chains ending in shell-based methods such as su or docker, e.g.
+  ;;   /rpc:host|su::/path or /rpc:host|docker:container:/path, are
+  ;;   handled by tramp-sh, which logs in through the rpc hop as if it
+  ;;   were ssh (issue #99).  That happens without ever loading
+  ;;   tramp-rpc.el, so the full parameter set must be installed here at
+  ;;   autoload time, not when the main file is loaded.  RPC-to-RPC
+  ;;   chains remain RPC-backed.
+  ;; This is future-proof: if ssh's parameters change in future TRAMP
+  ;; versions, rpc automatically inherits the updates.
+  ;; Suggested by Michael Albinus.
+  (when-let* ((ssh-params (alist-get "ssh" tramp-methods nil nil #'equal))
+              (rpc-entry (assoc tramp-rpc-method tramp-methods)))
+    (setcdr rpc-entry ssh-params))
 
   ;; Enable direct-async-process for the rpc method.
   ;; This tells upstream tramp that our async processes are "direct"
@@ -222,17 +224,6 @@ This is called from `tramp-multi-hop-p-hook'."
 (when (version< tramp-version "2.8.1.4")
   (error "Tramp RPC requires Tramp >= 2.8.1.4, but %s is loaded"
          tramp-version))
-
-;; Give the rpc method all ssh connection parameters so it can serve
-;; as a hop in tramp-sh multi-hop chains (e.g.
-;; /rpc:host|sudo:root@host:/path).  For single-hop rpc, the foreign
-;; handler takes over and these parameters are never used.  This is
-;; future-proof: if ssh's parameters change in future TRAMP versions,
-;; rpc automatically inherits the updates.
-;; Suggested by Michael Albinus.
-(when-let* ((ssh-params (alist-get "ssh" tramp-methods nil nil #'equal))
-            (rpc-entry (assoc tramp-rpc-method tramp-methods)))
-  (setcdr rpc-entry ssh-params))
 
 ;; Silence byte-compiler warnings for functions defined in with-eval-after-load
 (declare-function tramp-add-external-operation "tramp")

--- a/test/tramp-rpc-autoload-tests.el
+++ b/test/tramp-rpc-autoload-tests.el
@@ -44,6 +44,9 @@
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function make-tramp-file-name "tramp")
 (declare-function tramp-dissect-file-name "tramp")
+(declare-function tramp-compute-multi-hops "tramp")
+(declare-function tramp-file-name-method "tramp")
+(declare-function tramp-file-name-hop "tramp")
 (declare-function tramp-find-foreign-file-name-handler "tramp")
 (declare-function tramp-get-method-parameter "tramp")
 (declare-function loaddefs-generate "autoload")
@@ -160,7 +163,7 @@ This allows testing autoload behavior in a clean state."
   (should-not (fboundp 'tramp-rpc-file-name-p)))
 
 (ert-deftest tramp-rpc-autoload-test-method-registration ()
-  "Test that method is registered when tramp loads."
+  "Test that the method inherits ssh parameters when tramp loads."
   (tramp-rpc-autoload-test--clean-environment)
   (tramp-rpc-autoload-test--generate-autoloads)
   (load tramp-rpc-autoload-test--autoloads-file nil t)
@@ -168,8 +171,31 @@ This allows testing autoload behavior in a clean state."
   ;; (tramp-methods may not even exist yet)
   ;; Load tramp
   (require 'tramp)
-  ;; Now method should be registered
-  (should (assoc "rpc" tramp-methods)))
+  ;; Shell-based chains through an rpc hop are handled by tramp-sh without
+  ;; loading tramp-rpc.el, so the autoloaded method must be usable as ssh.
+  (should (assoc "rpc" tramp-methods))
+  (let ((rpc-vec (make-tramp-file-name :method "rpc" :host "host"))
+        (ssh-vec (make-tramp-file-name :method "ssh" :host "host")))
+    (dolist (parameter '(tramp-login-program
+                         tramp-login-args
+                         tramp-remote-shell-login))
+      (should (equal (tramp-get-method-parameter rpc-vec parameter)
+                     (tramp-get-method-parameter ssh-vec parameter))))))
+
+(ert-deftest tramp-rpc-autoload-test-shell-chain-dispatch ()
+  "Test that an rpc-to-su chain dispatches without loading tramp-rpc.el."
+  (tramp-rpc-autoload-test--clean-environment)
+  (tramp-rpc-autoload-test--generate-autoloads)
+  (load tramp-rpc-autoload-test--autoloads-file nil t)
+  (require 'tramp)
+  (let* ((vec (tramp-dissect-file-name "/rpc:host|su::/path"))
+         (chain (tramp-compute-multi-hops vec)))
+    (should (equal (tramp-file-name-method vec) "su"))
+    (should (equal (tramp-file-name-hop vec) "rpc:host|"))
+    (should (equal (mapcar #'tramp-file-name-method chain) '("rpc" "su")))
+    (should (eq (tramp-find-foreign-file-name-handler vec)
+                'tramp-sh-file-name-handler))
+    (should-not (featurep 'tramp-rpc))))
 
 (ert-deftest tramp-rpc-autoload-test-predicate-available-after-tramp ()
   "Test that predicate is available after tramp loads (no autoload needed)."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -5557,9 +5557,10 @@ hop with \"Host name does not match\"."
     (should (member "%h" (flatten-tree login-args)))))
 
 (ert-deftest tramp-rpc-mock-test-compute-multi-hops-rpc-sudo-chain ()
-  "Test that `tramp-compute-multi-hops' accepts rpc as a proxy for sudo.
-The rpc method inherits all ssh connection parameters, so
-`tramp-maybe-open-connection' can process rpc hops using SSH."
+  "Test TRAMP's low-level multi-hop expansion for an rpc-to-sudo chain.
+Normal rpc-to-sudo paths are claimed by the tramp-rpc foreign handler.
+This test hides that handler to verify that rpc's inherited ssh parameters
+also satisfy `tramp-compute-multi-hops'."
   :tags '(:multi-hop)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   ;; Manually install the proxy entry that tramp-add-hops would create


### PR DESCRIPTION
Multi-hop file names through an rpc hop, such as `/rpc:host|su::/path` or `/rpc:host|docker:container:/path`, failed with `Wrong type argument: stringp nil` (surfaced as an error by completion UIs like Vertico). These chains are handled by tramp-sh, which logs in through the rpc hop as if it were ssh — but the ssh connection parameters for the `rpc` method were only installed when `tramp-rpc.el` is fully loaded, and tramp-sh never loads it for such chains. With only the package autoloads loaded, the method entry had no `tramp-login-program`.

Copy ssh's parameters onto the `rpc` method at autoload registration time instead (ssh's parameters are already registered when the `with-eval-after-load 'tramp` block runs), and drop the now-redundant copy from the main file.

Also documents the `|` semantics in the README: `/rpc:host|sudo:root@host:` stays RPC-accelerated, while any other chain falls back to shell-based TRAMP with the rpc hop acting as ssh — so no rpc binary is involved on the final hop.

Fixes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved multi-hop TRAMP-RPC support for paths that use an RPC connection followed by `sudo`.
  - These connections retain RPC acceleration while operating with root privileges.

- **Bug Fixes**
  - Multi-hop paths using methods such as `su` or `docker` now correctly fall back to TRAMP’s shell-based handling for the final hop.

- **Documentation**
  - Added guidance explaining TRAMP-RPC behavior across different multi-hop connection methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->