### PR TITLE
server: replace raw libc calls with nix and rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "notify",
  "rmp-serde",
  "rmpv",
+ "rustix",
  "serde",
  "serde_bytes",
  "tempfile",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,13 +23,16 @@ flate2 = "1.0"
 libc = "0.2"
 
 # For PTY support (term feature includes pty module)
-nix = { version = "0.31", features = ["term", "process", "signal", "fs"] }
+nix = { version = "0.31", features = ["term", "process", "signal", "fs", "user", "hostname"] }
 
 # For filesystem watching (inotify on Linux, kqueue on macOS)
 notify = "8.2"
 
 # For Git-aware recursive watch discovery.
 ignore = "0.4"
+
+# Safe syscall wrappers for renameat2/utimensat (no nix equivalents).
+rustix = { version = "1", features = ["std", "fs"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -550,7 +550,7 @@ mod tests {
     /// a passwd entry (local or NSS/LDAP).
     #[test]
     fn test_get_user_name_current_uid() {
-        let uid = unsafe { libc::getuid() };
+        let uid = nix::unistd::getuid().as_raw();
         let name = get_user_name(uid);
         assert!(
             name.is_some(),
@@ -565,7 +565,7 @@ mod tests {
     /// Verify get_group_name resolves the current process gid.
     #[test]
     fn test_get_group_name_current_gid() {
-        let gid = unsafe { libc::getgid() };
+        let gid = nix::unistd::getgid().as_raw();
         let name = get_group_name(gid);
         assert!(
             name.is_some(),
@@ -617,7 +617,7 @@ mod tests {
     /// Repeated lookups should hit the cache and return the same value.
     #[test]
     fn test_user_name_caching() {
-        let uid = unsafe { libc::getuid() };
+        let uid = nix::unistd::getuid().as_raw();
         let first = get_user_name(uid);
         let second = get_user_name(uid);
         assert_eq!(first, second, "cached lookup should match initial lookup");
@@ -626,7 +626,7 @@ mod tests {
     /// Repeated group lookups should hit the cache.
     #[test]
     fn test_group_name_caching() {
-        let gid = unsafe { libc::getgid() };
+        let gid = nix::unistd::getgid().as_raw();
         let first = get_group_name(gid);
         let second = get_group_name(gid);
         assert_eq!(first, second, "cached lookup should match initial lookup");
@@ -679,7 +679,7 @@ mod tests {
             attrs.gid
         );
 
-        let expected_uid = unsafe { libc::getuid() };
+        let expected_uid = nix::unistd::getuid().as_raw();
         assert_eq!(attrs.uid, expected_uid);
         assert_eq!(
             attrs.uname.as_deref(),

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -508,32 +508,18 @@ async fn rename_no_overwrite_fallback(src: &Path, dest: &Path) -> std::io::Resul
 
 #[cfg(target_os = "linux")]
 async fn rename_no_overwrite(src: &Path, dest: &Path) -> std::io::Result<()> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
+    use rustix::fs::{CWD, RenameFlags};
 
     let owned_src = src.to_owned();
     let owned_dest = dest.to_owned();
     let result = tokio::task::spawn_blocking(move || {
-        let src = CString::new(owned_src.as_os_str().as_bytes())?;
-        let dest = CString::new(owned_dest.as_os_str().as_bytes())?;
-        let result = unsafe {
-            libc::syscall(
-                libc::SYS_renameat2,
-                libc::AT_FDCWD,
-                src.as_ptr(),
-                libc::AT_FDCWD,
-                dest.as_ptr(),
-                libc::RENAME_NOREPLACE,
-            )
-        };
-        if result == 0 {
-            Ok(())
-        } else {
-            Err(std::io::Error::last_os_error())
-        }
+        rustix::fs::renameat_with(CWD, &owned_src, CWD, &owned_dest, RenameFlags::NOREPLACE)
     })
     .await
     .map_err(std::io::Error::other)?;
+
+    // Map rustix's Errno into a std io error so both match arms share one type.
+    let result = result.map_err(std::io::Error::from);
 
     match result {
         // Pre-3.15 kernels report ENOSYS, filesystems that do not implement
@@ -761,25 +747,13 @@ pub async fn chown(params: Value) -> HandlerResult {
     let uid = params.uid;
     let gid = params.gid;
 
-    // Use spawn_blocking for the libc syscall
+    // Use spawn_blocking for the chown syscall
     tokio::task::spawn_blocking(move || {
-        use std::os::unix::ffi::OsStrExt;
-        let path_bytes = path.as_os_str().as_bytes();
-        let mut path_cstr = path_bytes.to_vec();
-        path_cstr.push(0);
+        use nix::unistd::{Gid, Uid, chown};
 
-        let result = unsafe {
-            libc::chown(
-                path_cstr.as_ptr() as *const libc::c_char,
-                uid as libc::uid_t,
-                gid as libc::gid_t,
-            )
-        };
-
-        if result != 0 {
-            return Err(RpcError::io_error(std::io::Error::last_os_error()));
-        }
-        Ok(())
+        let owner = u32::try_from(uid).ok().map(Uid::from_raw);
+        let group = u32::try_from(gid).ok().map(Gid::from_raw);
+        chown(&path, owner, group).map_err(|error| RpcError::io_error(error.into()))
     })
     .await
     .map_err(|e| RpcError::internal_error(e.to_string()))??;
@@ -800,41 +774,24 @@ fn set_file_times_sync_path_io(
     mtime_nsec: i64,
     nofollow: bool,
 ) -> std::io::Result<()> {
-    use std::os::unix::ffi::OsStrExt;
+    use rustix::fs::{AtFlags, CWD, Timespec, Timestamps};
 
-    let path_bytes = path.as_os_str().as_bytes();
-    let mut path_cstr = path_bytes.to_vec();
-    path_cstr.push(0); // Null terminate
-
-    let times = [
-        libc::timespec {
-            tv_sec: atime as _,
-            tv_nsec: atime_nsec as _,
+    let times = Timestamps {
+        last_access: Timespec {
+            tv_sec: atime,
+            tv_nsec: atime_nsec,
         },
-        libc::timespec {
-            tv_sec: mtime as _,
-            tv_nsec: mtime_nsec as _,
+        last_modification: Timespec {
+            tv_sec: mtime,
+            tv_nsec: mtime_nsec,
         },
-    ];
-
-    let result = unsafe {
-        libc::utimensat(
-            libc::AT_FDCWD,
-            path_cstr.as_ptr() as *const libc::c_char,
-            times.as_ptr(),
-            if nofollow {
-                libc::AT_SYMLINK_NOFOLLOW
-            } else {
-                0
-            },
-        )
     };
-
-    if result != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    Ok(())
+    let flags = if nofollow {
+        AtFlags::SYMLINK_NOFOLLOW
+    } else {
+        AtFlags::empty()
+    };
+    rustix::fs::utimensat(CWD, path, &times, flags).map_err(std::io::Error::from)
 }
 
 #[cfg(test)]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -173,19 +173,84 @@ fn statvfs_blocking(path: &str) -> HandlerResult {
     })
 }
 
+/// Apple targets where nix does not expose `getgroups` (membership lives in
+/// opendirectoryd, so nix declines to wrap the raw call there).
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
+fn current_groups() -> std::io::Result<Vec<libc::gid_t>> {
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    // Group membership can change after the sizing call; retry with a larger
+    // buffer instead of relying on a fixed supplementary limit.
+    let mut count = count as usize;
+    loop {
+        let mut groups = vec![0; count];
+        let actual_count =
+            unsafe { libc::getgroups(groups.len() as libc::c_int, groups.as_mut_ptr()) };
+        if actual_count < 0 {
+            let error = std::io::Error::last_os_error();
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::EINVAL) | Some(libc::ERANGE)
+            ) {
+                count = count.saturating_mul(2).max(1);
+                continue;
+            }
+            return Err(error);
+        }
+        groups.truncate(actual_count as usize);
+        return Ok(groups);
+    }
+}
+
 /// Get groups for the current user
 fn system_groups() -> HandlerResult {
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    )))]
     use nix::unistd::{Gid, getgroups};
 
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
+    // Raw libc fallback: nix does not expose `getgroups` on Apple platforms.
+    let gids = current_groups().map_err(RpcError::io_error)?;
+
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    )))]
     // nix sizes the buffer internally and retries when group membership
     // changes between the sizing and retrieval calls.
-    let groups = getgroups().map_err(|error| RpcError::io_error(error.into()))?;
+    let gids: Vec<_> = getgroups()
+        .map_err(|error| RpcError::io_error(error.into()))?
+        .iter()
+        .map(|&gid| Gid::as_raw(gid))
+        .collect();
 
     // Convert to group info with names
-    let group_info: Vec<Value> = groups
+    let group_info: Vec<Value> = gids
         .iter()
         .map(|&gid| {
-            let gid = Gid::as_raw(gid);
             let gname = get_group_name(gid);
             msgpack_map! {
                 "gid" => gid,

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -40,6 +40,7 @@ pub type HandlerResult = Result<Value, RpcError>;
 
 /// Get system information
 fn system_info() -> HandlerResult {
+    use nix::unistd::{getgid, getuid};
     use std::env;
 
     Ok(msgpack_map! {
@@ -49,8 +50,8 @@ fn system_info() -> HandlerResult {
         "watcher" => watcher_kind(),
         "max_read_chunk_bytes" => io::MAX_FILE_READ_CHUNK_BYTES as u64,
         "hostname" => hostname(),
-        "uid" => unsafe { libc::getuid() },
-        "gid" => unsafe { libc::getgid() },
+        "uid" => getuid().as_raw(),
+        "gid" => getgid().as_raw(),
         "home" => env::var("HOME").ok().into_value(),
         "user" => env::var("USER").ok().into_value(),
         "shell" => login_shell().into_value()
@@ -75,7 +76,7 @@ fn watcher_kind() -> &'static str {
 /// Delegates to file.rs's shared getpwuid_r lookup, which retries with a
 /// growing buffer on ERANGE so large NSS records (LDAP, SSSD) still resolve.
 fn login_shell() -> Option<String> {
-    let uid = unsafe { libc::getuid() };
+    let uid = nix::unistd::getuid().as_raw();
     file::get_user_login_shell(uid)
 }
 
@@ -97,17 +98,13 @@ where
 }
 
 fn hostname() -> String {
-    let mut buf = [0u8; 256];
-    unsafe {
-        if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) == 0 {
-            let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
-            String::from_utf8_lossy(&buf[..len]).into_owned()
-        } else {
-            "unknown".to_string()
-        }
-    }
-}
+    use nix::unistd::gethostname;
 
+    gethostname()
+        .ok()
+        .and_then(|name| name.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
 /// Get environment variable
 fn system_getenv(params: Value) -> HandlerResult {
     #[derive(serde::Deserialize)]
@@ -154,28 +151,19 @@ async fn system_statvfs(params: Value) -> HandlerResult {
 }
 
 fn statvfs_blocking(path: &str) -> HandlerResult {
-    use std::ffi::CString;
+    use nix::sys::statvfs;
+
     let expanded = expand_tilde(path);
-    let path_cstr =
-        CString::new(expanded.as_str()).map_err(|_| RpcError::invalid_params("Invalid path"))?;
-
-    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
-    let result = unsafe { libc::statvfs(path_cstr.as_ptr(), &mut stat) };
-
-    if result != 0 {
-        return Err(RpcError::io_error(std::io::Error::last_os_error()));
-    }
+    // NixPath accepts raw OsStr bytes, so non-UTF-8 paths still resolve.
+    let stats = statvfs::statvfs(std::path::Path::new(&expanded))
+        .map_err(|error| RpcError::io_error(std::io::Error::from(error)))?;
 
     // Return values in bytes (multiply by block size)
-    // Allow unnecessary casts for cross-platform compatibility (types differ between Linux/macOS)
     #[allow(clippy::unnecessary_cast)]
-    let block_size = stat.f_frsize as u64;
-    #[allow(clippy::unnecessary_cast)]
-    let total = stat.f_blocks as u64 * block_size;
-    #[allow(clippy::unnecessary_cast)]
-    let free = stat.f_bfree as u64 * block_size;
-    #[allow(clippy::unnecessary_cast)]
-    let available = stat.f_bavail as u64 * block_size;
+    let block_size = stats.fragment_size() as u64;
+    let total = stats.blocks() as u64 * block_size;
+    let free = stats.blocks_free() as u64 * block_size;
+    let available = stats.blocks_available() as u64 * block_size;
 
     Ok(msgpack_map! {
         "total" => total,
@@ -185,65 +173,19 @@ fn statvfs_blocking(path: &str) -> HandlerResult {
     })
 }
 
-fn supplementary_groups_with<F>(
-    initial_count: usize,
-    mut getgroups: F,
-) -> std::io::Result<Vec<libc::gid_t>>
-where
-    F: FnMut(&mut [libc::gid_t]) -> std::io::Result<usize>,
-{
-    let mut count = initial_count;
-    loop {
-        let mut groups = vec![0; count];
-        match getgroups(&mut groups) {
-            Ok(actual_count) => {
-                if actual_count > groups.len() {
-                    count = actual_count;
-                    continue;
-                }
-                groups.truncate(actual_count);
-                return Ok(groups);
-            }
-            // Group membership can change after the sizing call.  Retry with a
-            // larger buffer instead of relying on a fixed supplementary limit.
-            Err(error)
-                if matches!(
-                    error.raw_os_error(),
-                    Some(libc::EINVAL) | Some(libc::ERANGE)
-                ) =>
-            {
-                count = count.saturating_mul(2).max(1);
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-fn supplementary_groups() -> std::io::Result<Vec<libc::gid_t>> {
-    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
-    if count < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    supplementary_groups_with(count as usize, |groups| {
-        let actual_count =
-            unsafe { libc::getgroups(groups.len() as libc::c_int, groups.as_mut_ptr()) };
-        if actual_count < 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(actual_count as usize)
-        }
-    })
-}
-
 /// Get groups for the current user
 fn system_groups() -> HandlerResult {
-    let groups = supplementary_groups().map_err(RpcError::io_error)?;
+    use nix::unistd::{Gid, getgroups};
+
+    // nix sizes the buffer internally and retries when group membership
+    // changes between the sizing and retrieval calls.
+    let groups = getgroups().map_err(|error| RpcError::io_error(error.into()))?;
 
     // Convert to group info with names
     let group_info: Vec<Value> = groups
         .iter()
         .map(|&gid| {
+            let gid = Gid::as_raw(gid);
             let gname = get_group_name(gid);
             msgpack_map! {
                 "gid" => gid,
@@ -522,41 +464,6 @@ mod tests {
         assert_eq!(expand_tilde("~root"), expected);
         assert_eq!(expand_tilde("~root/foo"), format!("{expected}/foo"));
         assert!(!expand_tilde("~nonexistent-user-xyz").starts_with('/'));
-    }
-
-    #[test]
-    fn groups_retry_after_erange() {
-        let mut calls = 0;
-        let groups = supplementary_groups_with(1, |buffer| {
-            calls += 1;
-            if calls == 1 {
-                return Err(std::io::Error::from_raw_os_error(libc::ERANGE));
-            }
-            assert!(buffer.len() >= 2);
-            buffer[..2].copy_from_slice(&[10, 20]);
-            Ok(2)
-        })
-        .expect("retry getgroups after ERANGE");
-
-        assert_eq!(groups, vec![10, 20]);
-        assert_eq!(calls, 2);
-    }
-
-    #[test]
-    fn groups_retry_after_zero_length_sizing_call() {
-        let mut calls = 0;
-        let groups = supplementary_groups_with(0, |buffer| {
-            calls += 1;
-            if buffer.is_empty() {
-                return Ok(2);
-            }
-            buffer.copy_from_slice(&[10, 20]);
-            Ok(2)
-        })
-        .expect("retry getgroups after sizing call");
-
-        assert_eq!(groups, vec![10, 20]);
-        assert_eq!(calls, 2);
     }
 
     use crate::msgpack_map;

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -1343,31 +1343,20 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn set_symlink_mtime(path: &Path, seconds: libc::time_t) {
-        let c_path = path_to_cstring(path).unwrap();
-        let times = [
-            libc::timespec {
+        use rustix::fs::{AtFlags, CWD, Timespec, Timestamps};
+
+        let times = Timestamps {
+            last_access: Timespec {
                 tv_sec: seconds,
                 tv_nsec: 0,
             },
-            libc::timespec {
+            last_modification: Timespec {
                 tv_sec: seconds,
                 tv_nsec: 0,
             },
-        ];
-        let ret = unsafe {
-            libc::utimensat(
-                libc::AT_FDCWD,
-                c_path.as_ptr(),
-                times.as_ptr(),
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
         };
-        assert_eq!(
-            ret,
-            0,
-            "utimensat failed: {}",
-            std::io::Error::last_os_error()
-        );
+        rustix::fs::utimensat(CWD, path, &times, AtFlags::SYMLINK_NOFOLLOW)
+            .expect("utimensat should succeed");
     }
 
     #[test]


### PR DESCRIPTION
The server depends on `nix` but bypassed it for many calls, keeping hand-rolled unsafe wrappers and manual buffer handling around them. This also meant reimplementing syscall sizing/retry logic that the wrapper crates already provide.

This switches `getuid`/`getgid`/`gethostname`/`statvfs`/`getgroups`/`chown` to nix, and moves `renameat2(RENAME_NOREPLACE)` and `utimensat` to rustix, preserving the existing errno fallback chain for filesystems without `RENAME_NOREPLACE`. The hand-rolled getgroups ERANGE-retry machinery goes away since nix sizes the buffer internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when renaming files without overwriting existing files.
  * Preserved file ownership, timestamps, identity, hostname, storage statistics, and group information across supported systems.
  * Improved handling of non-standard file paths and symbolic links.

* **Tests**
  * Updated filesystem tests to use safer system identity and timestamp operations.
  * Improved coverage for platform-specific filesystem behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->