### PR TITLE
Fix signal-process for arbitrary remote PIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-libc-wrappers"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd97be0a7cf7b87085442067b6caa72b2f9b0ddd4a4df537d7225cd40498937"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +639,7 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "rustix",
+ "rustix-libc-wrappers",
  "serde",
  "serde_bytes",
  "tempfile",

--- a/README.org
+++ b/README.org
@@ -254,6 +254,7 @@ The dispatcher exposes these public methods:
 | Process | ~process.status~ | Return managed process status. |
 | Process | ~process.close_stdin~ | Close managed process stdin. |
 | Process | ~process.kill~ | Signal a managed process. |
+| Process | ~process.signal~ | Signal a positive OS PID permitted by the server's credentials. |
 | Process | ~process.list~ | List managed processes. |
 | PTY | ~process.start_pty~ | Start a pseudo-terminal process. |
 | PTY | ~process.read_pty~ | Read pseudo-terminal output. |

--- a/doc/TECHNICAL_COMPARISON.org
+++ b/doc/TECHNICAL_COMPARISON.org
@@ -187,6 +187,7 @@ TRAMP-RPC exposes these method categories:
 | process.read      | pid, timeout_ms?             | {stdout, stderr, exited}   |
 | process.write     | pid, data                    | {written}                  |
 | process.kill      | pid, signal?                 | boolean                    |
+| process.signal    | OS pid permitted by server credentials, signal | boolean         |
 | process.close_stdin | pid                        | boolean                    |
 | process.list      | (none)                       | [{pid, cmd, running}]      |
 | process.start_pty | cmd, args, cwd, rows, cols   | {pid, tty_name}            |

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -271,14 +271,20 @@ PROCESS is a PID."
                              (process-get rpc-process :tramp-rpc-connection))))
         (condition-case err
             (progn
-              ;; Use PTY kill for PTY processes, regular kill for pipe processes.
-              (if (and rpc-process
-                       (process-get rpc-process :tramp-rpc-pty))
-                  (tramp-rpc--call vec "process.kill_pty"
-                                   `((pid . ,pid) (signal . ,sigcode))
-                                   connection)
+              (cond
+               ;; A numeric PID names an arbitrary remote OS process, not an
+               ;; entry in the RPC server's managed-process registry.
+               ((not rpc-process)
+                (tramp-rpc--call vec "process.signal"
+                                 `((pid . ,pid) (signal . ,sigcode))))
+               ;; Use PTY kill for PTY processes, regular kill for pipes.
+               ((process-get rpc-process :tramp-rpc-pty)
+                (tramp-rpc--call vec "process.kill_pty"
+                                 `((pid . ,pid) (signal . ,sigcode))
+                                 connection))
+               (t
                 (tramp-rpc--kill-remote-process
-                 vec pid sigcode connection))
+                 vec pid sigcode connection)))
               0) ; Return 0 for success.
           (error
            (message "tramp-rpc: Error signaling process: %s" err)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,8 +32,12 @@ notify = "8.2"
 # For Git-aware recursive watch discovery.
 ignore = "0.4"
 
-# Safe syscall wrappers for renameat2/utimensat (no nix equivalents).
-rustix = { version = "1", features = ["std", "fs"] }
+# Safe syscall wrappers.
+rustix = { version = "1", features = ["std", "fs", "process"] }
+
+# Linux real-time signal bounds are provided by libc at runtime.
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+rustix-libc-wrappers = { version = "0.1", features = ["process"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -454,6 +454,7 @@ async fn route(method: String, params: Value) -> HandlerResult {
         "process.status" => process::status(params).await,
         "process.close_stdin" => process::close_stdin(params).await,
         "process.kill" => process::kill(params).await,
+        "process.signal" => process::signal_pid(params).await,
         "process.list" => process::list(params).await,
 
         // PTY (pseudo-terminal) process operations

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -8,6 +8,9 @@ use nix::sys::termios::{LocalFlags, OutputFlags, SetArg, tcgetattr, tcsetattr};
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, tcgetpgrp};
 use rmpv::Value;
+use rustix::process::{Pid as RustixPid, Signal as RustixSignal};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use rustix_libc_wrappers::process::SignalExt;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::ErrorKind;
@@ -908,13 +911,29 @@ fn signal_process_group(pid: u32, signal: i32) -> std::io::Result<()> {
     }
 }
 
-#[cfg(target_os = "macos")]
+fn rustix_signal(signal: i32) -> Option<RustixSignal> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        RustixSignal::from_raw(signal)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        RustixSignal::from_named_raw(signal)
+    }
+}
+
 fn signal_process(pid: u32, signal: i32) -> std::io::Result<()> {
-    let result = unsafe { libc::kill(pid as libc::pid_t, signal) };
-    if result == 0 {
-        Ok(())
+    let pid = i32::try_from(pid)
+        .ok()
+        .and_then(RustixPid::from_raw)
+        .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidInput, "PID is out of range"))?;
+    if signal == 0 {
+        rustix::process::test_kill_process(pid).map_err(std::io::Error::from)
     } else {
-        Err(std::io::Error::last_os_error())
+        let signal = rustix_signal(signal).ok_or_else(|| {
+            std::io::Error::new(ErrorKind::InvalidInput, "Signal is out of range")
+        })?;
+        rustix::process::kill_process(pid, signal).map_err(std::io::Error::from)
     }
 }
 
@@ -1215,6 +1234,24 @@ pub async fn kill(params: Value) -> HandlerResult {
         )));
     }
     terminate_pipe_process(params.pid, signal, false).await?;
+    Ok(Value::Boolean(true))
+}
+
+/// Signal an arbitrary operating-system process by PID.
+pub async fn signal_pid(params: Value) -> HandlerResult {
+    #[derive(Deserialize)]
+    struct Params {
+        pid: u32,
+        signal: SignalCode,
+    }
+
+    let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
+    if params.pid == 0 {
+        return Err(RpcError::invalid_params("PID must be greater than zero"));
+    }
+    let signal = params.signal.resolve()?;
+    signal_process(params.pid, signal)
+        .map_err(|error| RpcError::process_error(format!("Failed to signal process: {error}")))?;
     Ok(Value::Boolean(true))
 }
 
@@ -2484,6 +2521,69 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn signal_pid_signals_unmanaged_os_process() {
+        let mut child = StdCommand::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("start unmanaged child");
+        let pid = child.id();
+
+        let signal_result = signal_pid(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("signal".into()),
+                Value::String("SIGKILL".into()),
+            ),
+        ]))
+        .await;
+        if let Err(error) = signal_result {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("failed to signal unmanaged process: {error:?}");
+        }
+
+        let status = match tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Some(status) = child.try_wait()? {
+                    return Ok::<_, std::io::Error>(status);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        {
+            Ok(Ok(status)) => status,
+            Ok(Err(error)) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("failed to query unmanaged child: {error}");
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("timed out waiting for unmanaged child to exit");
+            }
+        };
+        assert_eq!(status.signal(), Some(libc::SIGKILL));
+
+        let zero_pid = signal_pid(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(0.into())),
+            (Value::String("signal".into()), Value::Integer(0.into())),
+        ]))
+        .await
+        .expect_err("PID zero must not signal the server process group");
+        assert_eq!(zero_pid.code, RpcError::INVALID_PARAMS);
+
+        let oversized_pid = signal_pid(Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(u32::MAX.into())),
+            (Value::String("signal".into()), Value::Integer(0.into())),
+        ]))
+        .await
+        .expect_err("oversized PID must not become a negative kill target");
+        assert_eq!(oversized_pid.code, RpcError::PROCESS_ERROR);
     }
 
     #[tokio::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -149,12 +149,14 @@ impl Default for Admissions {
 }
 
 fn task_class(method: &str) -> TaskClass {
-    // These operations only signal/close an already managed process.  Keep
-    // them available while long-running general requests consume their slots.
+    // These operations only signal or close a process.  Keep them available
+    // while long-running general requests consume their slots.
     match method {
-        "process.kill" | "process.close_stdin" | "process.kill_pty" | "process.close_pty" => {
-            TaskClass::Control
-        }
+        "process.kill"
+        | "process.signal"
+        | "process.close_stdin"
+        | "process.kill_pty"
+        | "process.close_pty" => TaskClass::Control,
         // PTY writes can remain blocked until the remote program reads input.
         // Isolate them so they cannot consume every general request permit;
         // lifecycle operations retain their separately reserved control slots.
@@ -779,6 +781,7 @@ mod tests {
             .expect("reserve every general permit");
 
         assert_eq!(task_class("process.write_pty"), TaskClass::PtyWrite);
+        assert_eq!(task_class("process.signal"), TaskClass::Control);
         assert!(admissions.try_acquire(TaskClass::PtyWrite).is_some());
         assert!(admissions.try_acquire(TaskClass::Control).is_some());
     }

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -6584,12 +6584,14 @@ discard it for being unreadable."
                      (setq captured (list 'pipe vec pid signal connection))))
                   ((symbol-function 'tramp-rpc--call)
                    (lambda (vec method params &optional connection)
-                     (setq captured (list 'pty vec method params connection)))))
+                     (setq captured (list 'rpc vec method params connection)))))
           (should (= 0 (tramp-rpc-handle-signal-process
                         12345 'SIGINT "/rpc:user@host:/")))
           (should (equal (list (car captured) (nth 2 captured)
-                               (nth 3 captured) (nth 4 captured))
-                         '(pipe 12345 SIGINT nil)))
+                               (alist-get 'pid (nth 3 captured))
+                               (alist-get 'signal (nth 3 captured))
+                               (nth 4 captured))
+                         '(rpc "process.signal" 12345 SIGINT nil)))
           (should (string= (tramp-file-name-method (nth 1 captured)) "rpc"))
           (should-not (tramp-rpc-handle-signal-process
                        12345 2 "/ssh:user@host:/"))
@@ -6609,7 +6611,7 @@ discard it for being unreadable."
                                (alist-get 'pid (nth 3 captured))
                                (alist-get 'signal (nth 3 captured))
                                (nth 4 captured))
-                         `(pty "process.kill_pty" 54321 SIGINT
+                         `(rpc "process.kill_pty" 54321 SIGINT
                                ,old-connection))))
       (when (processp process)
         (ignore-errors (delete-process process))))))


### PR DESCRIPTION
Numeric PIDs passed to `signal-process` with a remote RPC file name were treated as RPC-managed process handles. This prevented the original connection hang, but signaling arbitrary remote processes still failed because their OS PIDs were absent from the managed-process registry.

Add a dedicated `process.signal` RPC method for positive OS PIDs while preserving the existing managed pipe and PTY process behavior. The server validates PID and signal values, keeps signaling available through reserved control admission, and documents that normal server credential checks apply.

Addresses the follow-up report in #286.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for signaling remote operating-system processes by process ID.
  * Signals are permitted according to server credentials and support standard process lifecycle operations.

* **Bug Fixes**
  * Improved validation for process IDs and signal values, including rejection of invalid or oversized IDs.
  * Preserved specialized handling for managed terminal and pipe processes.

* **Documentation**
  * Documented the new `process.signal` RPC method and added it to the process-operations comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->