### PR TITLE
test: harden run-tests.sh quoting and shellcheck directive

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -26,6 +26,7 @@ TRAMP_TEST_SOURCE_ENV_SET="${TRAMP_TEST_SOURCE+x}"
 TRAMP_RPC_TEST_HOST_ENV="${TRAMP_RPC_TEST_HOST-}"
 TRAMP_RPC_TEST_HOST_ENV_SET="${TRAMP_RPC_TEST_HOST+x}"
 if [[ -f "$PROJECT_DIR/.config.local" ]]; then
+    # shellcheck source=/dev/null
     source "$PROJECT_DIR/.config.local"
 fi
 if [[ -n "$TRAMP_SOURCE_ENV_SET" ]]; then TRAMP_SOURCE="$TRAMP_SOURCE_ENV"; fi
@@ -34,8 +35,8 @@ if [[ -n "$TRAMP_RPC_TEST_HOST_ENV_SET" ]]; then TRAMP_RPC_TEST_HOST="$TRAMP_RPC
 
 expand_home() {
     case "$1" in
-        "~") printf '%s' "$HOME" ;;
-        "~/"*) printf '%s/%s' "$HOME" "${1#\~/}" ;;
+        \~) printf '%s' "$HOME" ;;
+        \~/*) printf '%s/%s' "$HOME" "${1#\~/}" ;;
         *) printf '%s' "$1" ;;
     esac
 }


### PR DESCRIPTION
run-tests.sh sources .config.local without a shellcheck directive, so running shellcheck on the script fails on a file that only exists on developer machines. The tilde patterns in expand_home also use quoted pattern characters, which bash accepts but is fragile and trips stricter parsers.

Add a shellcheck source directive for the optional local config and escape the tilde patterns instead of quoting them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed expansion of home-directory shortcuts such as `~` and `~/...` in test execution.
* **Chores**
  * Added shell-check guidance for sourcing local configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->