### PR TITLE
Restore container completion through rpc hops

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1064,12 +1064,29 @@ server side."
           path))))
 
 (defun tramp-rpc--remote-path-environment (vec)
-  "Return a PATH environment entry for VEC.
+  "Return the configured PATH environment entry for VEC.
 Uses `tramp-remote-path' by default.  A non-nil deprecated
 `tramp-rpc-remote-path' overrides it for compatibility."
   (let ((remote-path (tramp-rpc--cached-remote-path vec)))
     (when remote-path
       `(("PATH" . ,(mapconcat #'identity remote-path ":"))))))
+
+(defun tramp-rpc--cached-login-path (vec)
+  "Return the login shell PATH directories for VEC, caching the result."
+  (with-tramp-connection-property vec "tramp-rpc-login-path"
+    (or (tramp-rpc--fetch-remote-exec-path vec) '())))
+
+(defun tramp-rpc--process-path-environment (vec)
+  "Return the PATH entry used for shell child processes on VEC.
+Configured `tramp-remote-path' entries keep precedence.  Append missing
+entries from the remote login shell PATH so shell commands behave like
+`tramp-sh', whose persistent login shell retains its own PATH."
+  (let ((path (copy-sequence (tramp-rpc--cached-remote-path vec))))
+    (dolist (entry (tramp-rpc--cached-login-path vec))
+      (unless (member entry path)
+        (setq path (append path (list entry)))))
+    (when path
+      `(("PATH" . ,(mapconcat #'identity path ":"))))))
 
 (defvar tramp-remote-process-environment)
 
@@ -1128,14 +1145,18 @@ by `with-environment-variables') are returned as an alist of
         (push (cons (match-string 1 elt) (match-string 2 elt)) env)))
     (nreverse env)))
 
-(defun tramp-rpc--process-environment (vec localname)
+(defun tramp-rpc--process-environment (vec localname &optional login-path)
   "Return the effective child environment for LOCALNAME on VEC.
-The configured remote PATH is the baseline.  Dynamic TRAMP environment,
+The configured remote PATH is the baseline.  When LOGIN-PATH is non-nil,
+append entries from the remote login shell PATH; this matches `tramp-sh' for
+commands run through `shell-file-name'.  Dynamic TRAMP environment,
 EMACSCLIENT_TRAMP, direnv, and caller overrides are merged in that order, so
 later and more specific values replace earlier ones."
   (tramp-rpc--ensure-inside-emacs-env
    (tramp-rpc--merge-environments
-    (tramp-rpc--remote-path-environment vec)
+    (if login-path
+        (tramp-rpc--process-path-environment vec)
+      (tramp-rpc--remote-path-environment vec))
     (tramp-rpc--tramp-remote-process-environment)
     (tramp-rpc--emacsclient-tramp-environment vec)
     (tramp-rpc--get-direnv-environment vec localname)
@@ -1205,6 +1226,7 @@ Also clears the executable, variable `exec-path', and login-shell caches."
       (when-let* ((transport (plist-get current :process)))
         (tramp-rpc-protocol--clear-deferred-polls-for-target transport))
       (remhash key tramp-rpc--connections)
+      (tramp-flush-connection-property vec "tramp-rpc-login-path")
       (remhash key tramp-rpc--exec-path-cache)
       (remhash key tramp-rpc--login-shell-cache))))
 
@@ -4618,9 +4640,12 @@ ARGS contains the original function arguments."
         ;; below, matching `tramp-remote-path' order.
         (let* (;; Like TRAMP's process handlers, pass only the remote-relevant
                ;; environment.  The PATH entry comes from `tramp-remote-path'
-               ;; (or deprecated `tramp-rpc-remote-path'); direnv and dynamic
-               ;; caller variables keep their previous roles and override it.
-               (env (tramp-rpc--process-environment v localname))
+               ;; (or deprecated `tramp-rpc-remote-path').  Shell commands also
+               ;; retain login-shell entries, matching tramp-sh; direnv and
+               ;; dynamic caller variables keep their previous roles and
+               ;; override it.
+               (env (tramp-rpc--process-environment
+                     v localname (equal program shell-file-name)))
                (stdin-content (when (and infile (not (eq infile t)))
                                  (with-temp-buffer
                                    (set-buffer-multibyte nil)

--- a/test/tramp-rpc-autoload-tests.el
+++ b/test/tramp-rpc-autoload-tests.el
@@ -79,6 +79,13 @@
 (defvar tramp-rpc-autoload-test--autoloads-generated nil
   "Non-nil if autoloads have been generated for this test session.")
 
+(defun tramp-rpc-autoload-test--remove-generated-autoloads ()
+  "Remove the generated source-tree autoload file used by these tests."
+  (when (file-exists-p tramp-rpc-autoload-test--autoloads-file)
+    (delete-file tramp-rpc-autoload-test--autoloads-file)))
+
+(add-hook 'kill-emacs-hook #'tramp-rpc-autoload-test--remove-generated-autoloads)
+
 (defun tramp-rpc-autoload-test--generate-autoloads ()
   "Generate autoloads file for testing.
 Only generates once per test session to avoid file disappearing issues."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -7054,6 +7054,56 @@ discard it for being unreadable."
       (should (equal (tramp-rpc--remote-path-environment vec)
                      '(("PATH" . "/login/bin:/custom/bin")))))))
 
+(ert-deftest tramp-rpc-mock-test-login-path-cache-survives-connection-start ()
+  "Login PATH caching must keep one stable TRAMP connection-property key."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (make-tramp-file-name :method "rpc" :host "host" :user "user"
+                                   :localname "/"))
+        (fetches 0))
+    (unwind-protect
+        (progn
+          (tramp-flush-connection-property vec "tramp-rpc-login-path")
+          (cl-letf (((symbol-function 'tramp-rpc--fetch-remote-exec-path)
+                     (lambda (_vec)
+                       (cl-incf fetches)
+                       '("/home/user/.local/bin" "/usr/bin"))))
+            (should (equal (tramp-rpc--cached-login-path vec)
+                           '("/home/user/.local/bin" "/usr/bin")))
+            (should (equal (tramp-rpc--cached-login-path vec)
+                           '("/home/user/.local/bin" "/usr/bin")))
+            (should (= fetches 1))))
+      (tramp-flush-connection-property vec "tramp-rpc-login-path"))))
+
+(ert-deftest tramp-rpc-mock-test-shell-process-appends-login-path ()
+  "Shell commands must retain login PATH entries like `tramp-sh'."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/")
+        (shell-file-name "/bin/bash")
+        captured-params)
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (_vec) '("/usr/bin" "/bin")))
+              ((symbol-function 'tramp-rpc--cached-login-path)
+               (lambda (_vec) '("/home/user/.local/bin" "/usr/bin")))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--decode-output)
+               (lambda (output) output))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (should (equal method "process.run"))
+                 (setq captured-params params)
+                 '((exit_code . 0) (stdout . "") (stderr . "")))))
+      (should (= (tramp-rpc-handle-process-file
+                  shell-file-name nil nil nil "-c" "docker ps")
+                 0))
+      (should (equal (alist-get 'cmd captured-params) "/bin/bash"))
+      (should (equal (assoc "PATH" (alist-get 'env captured-params))
+                     '("PATH" . "/usr/bin:/bin:/home/user/.local/bin"))))))
+
 (ert-deftest tramp-rpc-mock-test-magit-prefetch-uses-process-environment ()
   "Magit prefetch must use the same effective environment as `process-file'."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)


### PR DESCRIPTION
TRAMP's container completion runs `docker ps` through the previous hop. Unlike `tramp-sh`, tramp-rpc replaced the login shell's PATH with only the configured remote path, so containers disappeared from completion even though `/rpc:host|docker:container:` remained usable.

Preserve configured PATH precedence while appending login-shell entries for shell commands. This makes container completion through an rpc hop behave like the equivalent ssh hop.

Autoload tests now also remove their generated source-tree autoload file on exit, preventing stale test artifacts from masking the current definitions.

Fixes #35.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote shell commands now include missing entries from the remote login shell’s PATH while preserving configured remote PATH entries.
  * Login-shell PATH information is cached per connection for consistent command execution.

* **Tests**
  * Added regression coverage for combined PATH handling and caching.
  * Improved test cleanup by removing generated files when tests exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->