### PR TITLE
ControlMaster: keep auth prompts on a PTY, forbid remote tty requests

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1592,6 +1592,17 @@ Returns non-nil on success."
          (buffer (get-buffer-create (format " *tramp-rpc-auth %s*" host)))
          (ssh-args (append
                     (list "ssh")
+                    ;; Never let this master ask for a remote
+                    ;; pseudo-terminal.  The request stays ahead of
+                    ;; user-supplied arguments on purpose: OpenSSH
+                    ;; resolves repeated options to their first value, so
+                    ;; neither `tramp-rpc-ssh-args' nor ssh_config
+                    ;; (`RequestTTY yes', `-t') can make the session-less
+                    ;; master (`-N', below, which also implies
+                    ;; RequestTTY=no) ask for a remote pseudo-terminal,
+                    ;; say on a ProxyJump hop (see #213).  The master
+                    ;; must stay a plain connection multiplexer.
+                    (list "-o" "RequestTTY=no")
                     tramp-rpc-ssh-args
                     (tramp-rpc--ssh-identity-args user port proxyjump)
                     ;; NO BatchMode - allow password prompts
@@ -1615,7 +1626,17 @@ Returns non-nil on success."
     (let (success)
       (unwind-protect
           (progn
-            ;; Start SSH with PTY for interactive password prompt.
+            ;; Start SSH with a local PTY.  OpenSSH writes password and
+            ;; passphrase prompts to, and reads the reply from, its
+            ;; controlling terminal; `tramp-process-actions' matches those
+            ;; prompts in the process buffer and answers via stdin, which
+            ;; with a PTY is that same terminal.  A controlling terminal is
+            ;; therefore required for authentication: a pipe leaves ssh
+            ;; without one (it will not fall back to reading stdin), and a
+            ;; separate stderr buffer would hide the prompts from the
+            ;; regexp actions (see the review of #213).  Only the local
+            ;; side gets a terminal; the `RequestTTY=no' above keeps any
+            ;; remote tty request out of the ControlMaster itself.
             (let ((process-connection-type t))
               (setq process (apply #'start-process process-name buffer ssh-args)))
             (set-process-query-on-exit-flag process nil)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -6565,6 +6565,66 @@ retry must still happen in that case."
           (should (= establish-calls 2)))
       (delete-directory controlmaster-dir t))))
 
+(ert-deftest tramp-rpc-mock-test-establish-controlmaster-argv-and-connection-type ()
+"The establish command must keep a local PTY but never ask for a remote tty.
+OpenSSH prompts on the controlling terminal, so the establish process needs
+`process-connection-type' t; the ControlMaster itself must run without a
+session terminal (`-N' plus a leading explicit RequestTTY=no) so user SSH
+options can not reintroduce one (see #213)."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((controlmaster-dir (make-temp-file "tramp-rpc-controlmaster" t))
+        ssh-args program connection-type process-buffer)
+    (unwind-protect
+        (progn
+          (let ((vec (tramp-dissect-file-name "/rpc:mock:/"))
+                (tramp-rpc-controlmaster-path
+                 (expand-file-name "%C" controlmaster-dir))
+                ;; Adversarial: user-supplied args must not win over the
+                ;; trailing no-terminal request.
+                (tramp-rpc-ssh-args '("-o" "RequestTTY=yes")))
+            (cl-letf (((symbol-function 'start-process)
+                       (lambda (name buffer prog &rest args)
+                         (setq program prog
+                               ssh-args args
+                               process-buffer buffer
+                               ;; Establish must have bound t locally around
+                               ;; the process start; with a pipe there is no
+                               ;; terminal for ssh to prompt on.
+                               connection-type process-connection-type)
+                         ;; Run a real, harmless child so the process
+                         ;; bookkeeping in the caller works.
+                         (make-process :name name
+                                       :buffer " *tramp-rpc-establish-argv-mock*"
+                                       :command (list "sleep" "60")
+                                       :noquery t)))
+                      ((symbol-function 'tramp-process-actions) #'ignore)
+                      ((symbol-function 'sleep-for) #'ignore))
+              ;; Poison the outer value; establish must locally bind t
+              ;; around the process start, and a regression to a pipe
+              ;; would capture this sentinel and fail the check below.
+              (let ((process-connection-type :pipe-regression-sentinel))
+                (should (tramp-rpc--establish-controlmaster vec)))))
+          ;; The local PTY is what carries password prompts to and from ssh.
+          (should (eq connection-type t))
+          ;; The session-less master must never request a remote terminal.
+          ;; OpenSSH applies the first value of a repeated option, so the
+          ;; enforce request must precede the user-supplied one.
+          (should (< (seq-position ssh-args "RequestTTY=no")
+                     (seq-position ssh-args "RequestTTY=yes")))
+          (should (member "ControlMaster=yes" ssh-args))
+          (should (member "-N" ssh-args)))
+      ;; Resource cleanup runs even when an assertion in the body fails.
+      ;; Delete the mock master process before killing its buffers, so
+      ;; `kill-buffer' is not asked about a running process.
+      (dolist (proc (process-list))
+        (when (string-prefix-p "*tramp-rpc-auth" (process-name proc))
+          (ignore-errors (delete-process proc))))
+      (when (buffer-live-p process-buffer)
+        (kill-buffer process-buffer))
+      (when (buffer-live-p (get-buffer " *tramp-rpc-establish-argv-mock*"))
+        (kill-buffer " *tramp-rpc-establish-argv-mock*"))
+      (ignore-errors (delete-directory controlmaster-dir t)))))
+
 (ert-deftest tramp-rpc-mock-test-controlmaster-action-tolerates-late-socket ()
   "A dead establish process still succeeds when its socket appears late.
 With ControlPersist the ssh parent exits as soon as the master forks to the


### PR DESCRIPTION
PR #213 fixes a flaky first connection over ProxyJump, but its review raises two concerns:

1. The ControlMaster ssh switch from PTY to pipe changes auth semantics: OpenSSH reads password and passphrase prompts from its controlling tty (never from stdin, and only via `$SSH_ASKPASS` when there is no tty at all), so the pipe variant cannot answer prompts. A split-off stderr buffer would in addition hide the prompt text from the `tramp-process-actions` regexps.
2. The once-only socket re-check after process death is racy; a short polling grace period was requested.

This PR resolves the review:

- **Grace poll (2)** is already on master: 055942f polls for the socket after the ControlPersist fork and additionally retries dead establish attempts.
- **Auth semantics (1)**: follow the review's preferred option and keep the local PTY, with comments explaining why (prompts are read from the controlling tty; `tramp-process-actions` matches the prompt in the buffer and answers on stdin, which with a PTY is the same device). Only the local side gets a terminal.
- **No remote tty ever**: `-o RequestTTY=no` is emitted *ahead* of `tramp-rpc-ssh-args`, because OpenSSH resolves repeated options to their first value — so a user-supplied `-o RequestTTY=yes` (or a `-t`, or an ssh_config `RequestTTY yes`) can never make the session-less (`-N`) master ask for a remote pseudo-terminal, the scenario #213 was about. `-N` itself already implies `RequestTTY=no` and serves as a backstop.
- A mock test pins the establish command line (`-N`, `ControlMaster=yes`, leading `RequestTTY=no` that must precede user args) and the local PTY connection type.

Closes #213
