### PR TITLE
Prevent bootstrap shells from corrupting RPC startup

### DIFF
--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1893,14 +1893,22 @@ Kills the process if still alive and removes the connection entry."
       (tramp-rpc--remove-connection vec))))
 
 (defun tramp-rpc--cleanup-bootstrap-connection (vec)
-  "Close the scpx/scp bootstrap connection for VEC if it exists.
-The bootstrap connection is only needed during deploy and should be
-closed afterward to prevent other packages (vc, diff-hl) from
-accidentally routing file operations through tramp-sh."
+  "Remove the scpx/scp bootstrap connection for VEC if it has state.
+The bootstrap connection is only needed during deployment.  Leaving its
+TRAMP cache entries behind lets background packages keep using tramp-sh for
+the same host while tramp-rpc is active.  In particular, a tramp-sh liveness
+probe can then interleave with RPC startup and corrupt the protocol stream."
   (let* ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
          (proc (tramp-get-connection-process bootstrap-vec)))
-    (when (and proc (process-live-p proc))
-      (delete-process proc))))
+    (when (or (process-live-p proc)
+              (tramp-connection-property-p bootstrap-vec "process-buffer")
+              (tramp-connection-property-p bootstrap-vec " process-buffer")
+              (tramp-connection-property-p bootstrap-vec " connected"))
+      ;; Preserve authentication and unrelated asynchronous processes while
+      ;; removing the bootstrap shell, buffers, timers, and cached connection
+      ;; properties.
+      (tramp-cleanup-connection
+       bootstrap-vec 'keep-debug 'keep-password 'keep-processes))))
 
 (defun tramp-rpc--connect (vec)
   "Establish an RPC connection to VEC."
@@ -1943,7 +1951,9 @@ accidentally routing file operations through tramp-sh."
       ;; Never-deploy mode: use the configured path directly, no fallback.
       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
         (condition-case err
-            (tramp-rpc--start-server-process vec binary-path sudo-password)
+            (progn
+              (tramp-rpc--cleanup-bootstrap-connection vec)
+              (tramp-rpc--start-server-process vec binary-path sudo-password))
           (remote-file-error
            (tramp-rpc--cleanup-failed-connection vec)
            (signal 'remote-file-error
@@ -1959,24 +1969,32 @@ accidentally routing file operations through tramp-sh."
     ;; version bump), SSH exits immediately, we catch the error, deploy
     ;; via scpx, and retry.
     (condition-case err
-        (tramp-rpc--start-server-process
-         vec (tramp-rpc-deploy-expected-binary-localname) sudo-password)
+        (progn
+          ;; Remove bootstrap state left by an earlier deployment before the
+          ;; startup probe begins exchanging MessagePack frames.
+          (tramp-rpc--cleanup-bootstrap-connection vec)
+          (tramp-rpc--start-server-process
+           vec (tramp-rpc-deploy-expected-binary-localname) sudo-password))
       ((tramp-rpc-server-unavailable tramp-rpc-sudo-auth-rejected)
        ;; Binary missing or sudo rejected the password.  Clean up and deploy.
        (tramp-rpc--cleanup-failed-connection vec)
-       (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
-         ;; Close the bootstrap connection - it's no longer needed and
-         ;; leaving it alive can cause vc/diff-hl sentinels to route
-         ;; file operations through tramp-sh instead of tramp-rpc.
-         (tramp-rpc--cleanup-bootstrap-connection vec)
-         ;; Re-prompt only when sudo explicitly rejected the supplied password.
-         ;; Missing-binary fallback keeps using the still-valid credential.
-         (when (and sudo-ssh-user
-                    (eq (car err) 'tramp-rpc-sudo-auth-rejected))
-           (setq sudo-password
-                 (when (tramp-rpc--sudo-password-required-p vec)
-                   (tramp-rpc--sudo-read-password vec sudo-ssh-user))))
-         (tramp-rpc--start-server-process vec binary-path sudo-password)))))))
+       ;; Deployment uses a bootstrap TRAMP connection.  Remove all of its
+       ;; state before retrying RPC startup, and also when deployment or the
+       ;; retry itself fails.
+       (unwind-protect
+           (let ((binary-path (tramp-rpc-deploy-ensure-binary vec)))
+             (tramp-rpc--cleanup-bootstrap-connection vec)
+             ;; Re-prompt only when sudo explicitly rejected the supplied
+             ;; password.  Missing-binary fallback keeps using the still-valid
+             ;; credential.
+             (when (and sudo-ssh-user
+                        (eq (car err) 'tramp-rpc-sudo-auth-rejected))
+               (setq sudo-password
+                     (when (tramp-rpc--sudo-password-required-p vec)
+                       (tramp-rpc--sudo-read-password vec sudo-ssh-user))))
+             (tramp-rpc--start-server-process
+              vec binary-path sudo-password))
+         (tramp-rpc--cleanup-bootstrap-connection vec)))))))
 
 (defun tramp-rpc--disconnect (vec)
   "Disconnect the RPC connection to VEC explicitly."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -6245,6 +6245,92 @@ A rejected sudo password must not be reused on the next attempt, otherwise
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-clears-cached-state ()
+  "Bootstrap cleanup should remove live and cached TRAMP connection state."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:bootstrap-host:/")))
+    (dolist (state '(live-process process-buffer legacy-process-buffer connected))
+      (let ((proc (when (eq state 'live-process)
+                    (make-process :name "tramp-rpc-bootstrap-cleanup-test"
+                                  :command '("cat")
+                                  :connection-type 'pipe
+                                  :noquery t)))
+            cleanup-args)
+        (unwind-protect
+            (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+                       (lambda (_vec) vec))
+                      ((symbol-function 'tramp-get-connection-process)
+                       (lambda (_vec) proc))
+                      ((symbol-function 'tramp-connection-property-p)
+                       (lambda (_vec property)
+                         (pcase state
+                           ('process-buffer (equal property "process-buffer"))
+                           ('legacy-process-buffer
+                            (equal property " process-buffer"))
+                           ('connected (equal property " connected")))))
+                      ((symbol-function 'tramp-cleanup-connection)
+                       (lambda (&rest args) (setq cleanup-args args))))
+              (tramp-rpc--cleanup-bootstrap-connection vec)
+              (should (equal cleanup-args
+                             (list vec 'keep-debug 'keep-password
+                                   'keep-processes))))
+          (when (process-live-p proc)
+            (delete-process proc)))))))
+
+(ert-deftest tramp-rpc-mock-test-cleanup-bootstrap-ignores-empty-state ()
+  "Bootstrap cleanup should do nothing when TRAMP has no bootstrap state."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:bootstrap-host:/"))
+        cleanup-called)
+    (cl-letf (((symbol-function 'tramp-rpc-deploy--bootstrap-vec)
+               (lambda (_vec) vec))
+              ((symbol-function 'tramp-get-connection-process)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-connection-property-p)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-cleanup-connection)
+               (lambda (&rest _) (setq cleanup-called t))))
+      (tramp-rpc--cleanup-bootstrap-connection vec)
+      (should-not cleanup-called))))
+
+(ert-deftest tramp-rpc-mock-test-connect-cleans-bootstrap-around-deployment ()
+  "RPC startup should not overlap with stale or newly-created bootstrap state."
+  :tags '(:connection-cleanup)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((vec (tramp-dissect-file-name "/rpc:bootstrap-host:/"))
+        (tramp-rpc-use-controlmaster nil)
+        (tramp-rpc-deploy-never-deploy nil)
+        events)
+    (cl-letf (((symbol-function 'tramp-rpc--ensure-controlmaster-directory)
+               #'ignore)
+              ((symbol-function 'tramp-rpc--detect-sudo-elevation)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc-deploy-expected-binary-localname)
+               (lambda () "/expected/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc-deploy-ensure-binary)
+               (lambda (_vec)
+                 (push 'deploy events)
+                 "/deployed/tramp-rpc-server"))
+              ((symbol-function 'tramp-rpc--cleanup-bootstrap-connection)
+               (lambda (_vec) (push 'cleanup-bootstrap events)))
+              ((symbol-function 'tramp-rpc--cleanup-failed-connection)
+               (lambda (_vec) (push 'cleanup-failed events)))
+              ((symbol-function 'tramp-rpc--start-server-process)
+               (lambda (_vec binary-path &optional _sudo-password)
+                 (if (equal binary-path "/expected/tramp-rpc-server")
+                     (progn
+                       (push 'start-expected events)
+                       (signal 'tramp-rpc-server-unavailable
+                               '("mock missing binary")))
+                   (push 'start-deployed events)
+                   'connection))))
+      (should (eq (tramp-rpc--connect vec) 'connection))
+      (should (equal (nreverse events)
+                     '(cleanup-bootstrap start-expected cleanup-failed deploy
+                       cleanup-bootstrap start-deployed cleanup-bootstrap))))))
+
 (ert-deftest tramp-rpc-mock-test-start-server-sudo-password-uses-stdin ()
   "When sudo needs a password, start the elevated RPC server with sudo -S."
   :tags '(:sudo)


### PR DESCRIPTION
Bootstrap TRAMP connections can leave cached tramp-sh state behind after deployment. Background liveness checks may then overlap RPC startup and inject shell output into the MessagePack stream.

Remove the complete bootstrap connection state before RPC startup and on every post-deployment exit path, while preserving authentication and unrelated asynchronous processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRAMP RPC connection cleanup during startup, deployment, retries, and failures.
  * Prevented stale bootstrap shells, buffers, timers, and cached connection state from interfering with subsequent connections.
  * Preserved authentication details, debugging information, and unrelated asynchronous processes during cleanup.
  * Improved recovery when deployment or RPC server startup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->