### PR TITLE
Address MELPA review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,17 +143,22 @@ jobs:
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" \
               --eval "(package-install 'package-lint)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
 
       - name: Byte-compile
         run: |
+          rm -f lisp/*.elc
           emacs -Q --batch \
             --eval "(require 'package)" \
             --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
             --eval "(package-initialize)" \
-            --eval "(setq byte-compile-error-on-warn t)" \
+            --eval "(setq byte-compile-error-on-warn t byte-compile-warnings t load-prefer-newer t)" \
             --eval "(push \"$(pwd)/lisp\" load-path)" \
             -f batch-byte-compile lisp/*.el
 
@@ -164,7 +169,7 @@ jobs:
             --eval "(package-initialize)" \
             --eval "(require 'package-lint)" \
             --eval "(setq package-lint-main-file \"lisp/tramp-rpc.el\")" \
-            --eval "(advice-add 'package-lint--check-eval-after-load :override (lambda () nil))" \
+            --eval "(setq package-lint-batch-fail-on-warnings t)" \
             -f package-lint-batch-and-exit \
             lisp/tramp-rpc.el \
             lisp/tramp-rpc-advice.el \
@@ -175,18 +180,25 @@ jobs:
 
       - name: Check documentation strings
         run: |
-          for file in \
+          emacs -Q --batch \
+            --eval "(require 'checkdoc)" \
+            --eval "(setq checkdoc-autofix-flag 'never)" \
+            --eval "(setq checkdoc-create-error-function (lambda (text start _end &optional _unfixable) (error \"%s:%d: checkdoc: %s\" buffer-file-name (line-number-at-pos start) text)))" \
+            --eval "(dolist (file command-line-args-left) (checkdoc-file file))" \
             lisp/tramp-rpc.el \
             lisp/tramp-rpc-advice.el \
             lisp/tramp-rpc-deploy.el \
             lisp/tramp-rpc-magit.el \
             lisp/tramp-rpc-process.el \
-            lisp/tramp-rpc-protocol.el; do
-            emacs -Q --batch \
-              --eval "(require 'checkdoc)" \
-              --eval "(setq checkdoc-autofix-flag 'never)" \
-              --eval "(checkdoc-file \"$file\")"
-          done
+            lisp/tramp-rpc-protocol.el
+
+      - name: Check function declarations
+        run: |
+          emacs -Q --batch \
+            --eval "(require 'package)" \
+            --eval "(package-initialize)" \
+            --eval "(require 'check-declare)" \
+            --eval "(kill-emacs (if (check-declare-directory \"lisp\") 1 0))"
 
   test-autoload:
     name: Autoload Tests (${{ matrix.emacs_label }})
@@ -221,6 +233,10 @@ jobs:
               --eval "(setq package-install-upgrade-built-in t)" \
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
@@ -261,6 +277,10 @@ jobs:
               --eval "(setq package-install-upgrade-built-in t)" \
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
@@ -323,6 +343,10 @@ jobs:
               --eval "(setq package-install-upgrade-built-in t)" \
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
@@ -381,6 +405,10 @@ jobs:
               --eval "(setq package-install-upgrade-built-in t)" \
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
@@ -464,6 +492,10 @@ jobs:
               --eval "(setq package-install-upgrade-built-in t)" \
               --eval "(package-install 'tramp)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done
@@ -562,6 +594,10 @@ jobs:
               --eval "(package-initialize)" \
               --eval "(package-refresh-contents)" \
               --eval "(package-install 'msgpack)" && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after $attempt attempts" >&2
+              exit 1
+            fi
             echo "Attempt $attempt failed, retrying in 10s..."
             sleep 10
           done

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -1,0 +1,32 @@
+name: melpazoid
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install melpazoid
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y emacs
+          git clone --depth 1 https://github.com/riscy/melpazoid.git ~/melpazoid
+      - name: Run MELPA package checks
+        env:
+          LOCAL_REPO: ${{ github.workspace }}
+          RECIPE: >-
+            (tramp-rpc :fetcher github
+             :repo "ArthurHeymans/emacs-tramp-rpc"
+             :files (:defaults "Cargo.toml" "Cargo.lock" "server" ".cargo"))
+          WARN_IS_ERROR: true
+          EXIST_OK: false
+        run: make -C ~/melpazoid

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -51,6 +51,8 @@
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
 (declare-function tramp-rpc--managed-file-name-p "tramp-rpc")
+(declare-function tramp-rpc--add-external-operation "tramp-rpc")
+(declare-function tramp-rpc--remove-external-operation "tramp-rpc")
 
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
 (defvar tramp-rpc--delivering-output)
@@ -576,38 +578,38 @@ exited (remote side finished), delete it so the refresh can proceed."
                            'process-coding-system)
     (advice-add 'process-coding-system :around
                 #'tramp-rpc--process-coding-system-advice))
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'process-send-string
      #'tramp-rpc-handle-process-send-string 'tramp-rpc 'process)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
      'process-send-region
      #'tramp-rpc-handle-process-send-region 'tramp-rpc 'process)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'process-send-eof
      #'tramp-rpc-handle-process-send-eof 'tramp-rpc 'process)
   ;; This must be before `tramp-signal-process'.  Since tramp.el is
   ;; required, this is guaranteed.
   (add-hook 'signal-process-functions #'tramp-rpc-handle-signal-process)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'process-status
      #'tramp-rpc-handle-process-status 'tramp-rpc 'process)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
      'process-exit-status
      #'tramp-rpc-handle-process-exit-status 'tramp-rpc 'process)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
      'process-command
      #'tramp-rpc-handle-process-command 'tramp-rpc 'process)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'process-tty-name
      #'tramp-rpc-handle-process-tty-name 'tramp-rpc 'process)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'vc-call-backend
      #'tramp-rpc-handle-vc-call-backend 'tramp-rpc
      #'tramp-rpc--vc-call-backend-file-name-for-operation)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
      'vc-exec-after
      #'tramp-rpc-handle-vc-exec-after 'tramp-rpc 'default-directory)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
    'vc-dir-refresh
    #'tramp-rpc-handle-vc-dir-refresh 'tramp-rpc
    #'tramp-rpc--vc-dir-refresh-file-name-for-operation))
@@ -617,7 +619,7 @@ exited (remote side finished), delete it so the refresh can proceed."
   (when (featurep 'python)
       (if (tramp-rpc--python-tramp-file-name-external-operation-p)
           (condition-case err
-              (tramp-add-external-operation
+              (tramp-rpc--add-external-operation
                'python-shell--tramp-with-environment
                #'tramp-rpc-handle-python-shell--tramp-with-environment
                'tramp-rpc 'tramp-file-name)
@@ -634,11 +636,11 @@ exited (remote side finished), delete it so the refresh can proceed."
            :around
            #'tramp-rpc-handle-python-shell--tramp-with-environment-compat))))
   (when (featurep 'eglot)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
        'eglot--cmd
        #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory))
   (when (featurep 'magit-process)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
        'magit-start-process
        #'tramp-rpc-handle-magit-start-process 'tramp-rpc 'default-directory)))
 
@@ -648,25 +650,25 @@ exited (remote side finished), delete it so the refresh can proceed."
                  #'tramp-rpc--set-process-coding-system-advice)
   (advice-remove 'process-coding-system
                  #'tramp-rpc--process-coding-system-advice)
-  (tramp-remove-external-operation 'process-send-string 'tramp-rpc)
-  (tramp-remove-external-operation 'process-send-region 'tramp-rpc)
-  (tramp-remove-external-operation 'process-send-eof 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-send-string 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-send-region 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-send-eof 'tramp-rpc)
   (remove-hook 'signal-process-functions #'tramp-rpc-handle-signal-process)
-  (tramp-remove-external-operation 'process-status 'tramp-rpc)
-  (tramp-remove-external-operation 'process-exit-status 'tramp-rpc)
-  (tramp-remove-external-operation 'process-command 'tramp-rpc)
-  (tramp-remove-external-operation 'process-tty-name 'tramp-rpc)
-  (tramp-remove-external-operation 'vc-call-backend 'tramp-rpc)
-  (tramp-remove-external-operation 'vc-exec-after 'tramp-rpc)
-  (tramp-remove-external-operation
+  (tramp-rpc--remove-external-operation 'process-status 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-exit-status 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-command 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'process-tty-name 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'vc-call-backend 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'vc-exec-after 'tramp-rpc)
+  (tramp-rpc--remove-external-operation
    'python-shell--tramp-with-environment 'tramp-rpc)
   (when (fboundp 'python-shell--tramp-with-environment)
     (advice-remove
      'python-shell--tramp-with-environment
      #'tramp-rpc-handle-python-shell--tramp-with-environment-compat))
-  (tramp-remove-external-operation 'eglot--cmd 'tramp-rpc)
-  (tramp-remove-external-operation 'magit-start-process 'tramp-rpc)
-  (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc))
+  (tramp-rpc--remove-external-operation 'eglot--cmd 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'magit-start-process 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'vc-dir-refresh 'tramp-rpc))
 
 
 ;; ============================================================================

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -33,11 +33,7 @@
 
 (require 'tramp)
 (require 'msgpack)
-
-;; Functions from tramp.el
-(declare-function tramp-add-external-operation "tramp")
-(declare-function tramp-remove-external-operation "tramp")
-(declare-function tramp-dissect-file-name "tramp" (name &optional nodefault))
+(require 'seq)
 
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process"
@@ -580,21 +576,19 @@ exited (remote side finished), delete it so the refresh can proceed."
                            'process-coding-system)
     (advice-add 'process-coding-system :around
                 #'tramp-rpc--process-coding-system-advice))
-  (with-eval-after-load 'tramp-rpc
-    (tramp-add-external-operation
+  (tramp-add-external-operation
      'process-send-string
      #'tramp-rpc-handle-process-send-string 'tramp-rpc 'process)
     (tramp-add-external-operation
      'process-send-region
      #'tramp-rpc-handle-process-send-region 'tramp-rpc 'process)
-    (tramp-add-external-operation
+  (tramp-add-external-operation
      'process-send-eof
-     #'tramp-rpc-handle-process-send-eof 'tramp-rpc 'process))
+     #'tramp-rpc-handle-process-send-eof 'tramp-rpc 'process)
   ;; This must be before `tramp-signal-process'.  Since tramp.el is
   ;; required, this is guaranteed.
   (add-hook 'signal-process-functions #'tramp-rpc-handle-signal-process)
-  (with-eval-after-load 'tramp-rpc
-    (tramp-add-external-operation
+  (tramp-add-external-operation
      'process-status
      #'tramp-rpc-handle-process-status 'tramp-rpc 'process)
     (tramp-add-external-operation
@@ -603,23 +597,24 @@ exited (remote side finished), delete it so the refresh can proceed."
     (tramp-add-external-operation
      'process-command
      #'tramp-rpc-handle-process-command 'tramp-rpc 'process)
-    (tramp-add-external-operation
+  (tramp-add-external-operation
      'process-tty-name
-     #'tramp-rpc-handle-process-tty-name 'tramp-rpc 'process))
-  (with-eval-after-load 'tramp-rpc
-    (tramp-add-external-operation
+     #'tramp-rpc-handle-process-tty-name 'tramp-rpc 'process)
+  (tramp-add-external-operation
      'vc-call-backend
      #'tramp-rpc-handle-vc-call-backend 'tramp-rpc
      #'tramp-rpc--vc-call-backend-file-name-for-operation)
-    (tramp-add-external-operation
+  (tramp-add-external-operation
      'vc-exec-after
-     #'tramp-rpc-handle-vc-exec-after 'tramp-rpc 'default-directory))
-  ;; If python/eglot/magit-process is already loaded while `tramp-rpc'
-  ;; is being required, defer registration until `tramp-rpc' is
-  ;; provided; otherwise `tramp-add-external-operation' calls
-  ;; `(require 'tramp-rpc)' recursively.
-  (with-eval-after-load 'python
-    (with-eval-after-load 'tramp-rpc
+     #'tramp-rpc-handle-vc-exec-after 'tramp-rpc 'default-directory)
+  (tramp-add-external-operation
+   'vc-dir-refresh
+   #'tramp-rpc-handle-vc-dir-refresh 'tramp-rpc
+   #'tramp-rpc--vc-dir-refresh-file-name-for-operation))
+
+(defun tramp-rpc-advice-install-optional-handlers ()
+  "Install handlers for loaded optional integration packages."
+  (when (featurep 'python)
       (if (tramp-rpc--python-tramp-file-name-external-operation-p)
           (condition-case err
               (tramp-add-external-operation
@@ -637,22 +632,15 @@ exited (remote side finished), delete it so the refresh can proceed."
           (advice-add
            'python-shell--tramp-with-environment
            :around
-           #'tramp-rpc-handle-python-shell--tramp-with-environment-compat)))))
-  (with-eval-after-load 'eglot
-    (with-eval-after-load 'tramp-rpc
-      (tramp-add-external-operation
+           #'tramp-rpc-handle-python-shell--tramp-with-environment-compat))))
+  (when (featurep 'eglot)
+    (tramp-add-external-operation
        'eglot--cmd
-       #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory)))
-  (with-eval-after-load 'magit-process
-    (with-eval-after-load 'tramp-rpc
-      (tramp-add-external-operation
+       #'tramp-rpc-handle-eglot--cmd 'tramp-rpc 'default-directory))
+  (when (featurep 'magit-process)
+    (tramp-add-external-operation
        'magit-start-process
        #'tramp-rpc-handle-magit-start-process 'tramp-rpc 'default-directory)))
-  (with-eval-after-load 'tramp-rpc
-    (tramp-add-external-operation
-     'vc-dir-refresh
-     #'tramp-rpc-handle-vc-dir-refresh 'tramp-rpc
-     #'tramp-rpc--vc-dir-refresh-file-name-for-operation)))
 
 (defun tramp-rpc-handler-remove ()
   "Remove all process handler installed by tramp-rpc."
@@ -680,15 +668,6 @@ exited (remote side finished), delete it so the refresh can proceed."
   (tramp-remove-external-operation 'magit-start-process 'tramp-rpc)
   (tramp-remove-external-operation 'vc-dir-refresh 'tramp-rpc))
 
-(defcustom tramp-rpc-install-handler-on-load t
-  "Whether to install process handler when tramp-rpc-advice is loaded.
-Set to nil before loading to prevent automatic handler installation."
-  :type 'boolean
-  :group 'tramp-rpc)
-
-;; Install handler when loaded (if enabled)
-(when tramp-rpc-install-handler-on-load
-  (tramp-rpc-handler-install))
 
 ;; ============================================================================
 ;; Unload support
@@ -701,24 +680,6 @@ Removes handler."
   (tramp-rpc-handler-remove)
   ;; Return nil to allow normal unload to proceed
   nil)
-
-(add-hook 'tramp-rpc-unload-hook
-	  (lambda ()
-	    (when (featurep 'tramp-rpc-advice)
-	      ;; When Emacs is configured --with-native-compilation,
-	      ;; `load-history' contains `--anonymous-lambda' defun
-	      ;; entries for tramp-rpc-advice.el.  This raises an
-	      ;; `cl--assertion-failed' error when unloading.  Emacs
-	      ;; bug#80446.
-	      (dolist (entry load-history)
-		(when (string-match-p
-		       (rx "tramp-rpc-advice" (| ".el" ".elc") eos) (car entry))
-		  (setcdr entry
-			  (seq-remove
-			   (lambda (item)
-			     (equal item '(defun . --anonymous-lambda)))
-			   (cdr entry)))))
-	      (unload-feature 'tramp-rpc-advice 'force))))
 
 (provide 'tramp-rpc-advice)
 ;;; tramp-rpc-advice.el ends here

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -559,7 +559,7 @@ exited (remote side finished), delete it so the refresh can proceed."
                (or (process-get proc :tramp-rpc-exited)
                    (not (process-live-p proc))))
       (remhash proc tramp-rpc--async-processes)
-      (ignore-errors (delete-process proc))))
+      (delete-process proc)))
   (tramp-run-real-handler 'vc-dir-refresh nil))
 
 ;; ============================================================================

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -27,12 +27,8 @@
 
 (require 'cl-lib)
 (require 'tramp)
+(require 'tramp-sh)
 (require 'url)
-
-;; Silence byte-compiler warnings for functions defined in tramp-sh
-(declare-function tramp-send-command "tramp-sh")
-(declare-function tramp-send-command-and-check "tramp-sh")
-(declare-function tramp-send-command-and-read "tramp-sh")
 
 ;; Functions from tramp-rpc.el.  `tramp-rpc-deploy' is loaded by
 ;; tramp-rpc.el after these helpers have been defined.
@@ -1593,11 +1589,6 @@ This helps troubleshoot deployment issues."
 ;; ============================================================================
 ;; Unload support
 ;; ============================================================================
-
-(add-hook 'tramp-rpc-unload-hook
-	  (lambda ()
-	    (when (featurep 'tramp-rpc-deploy)
-	      (unload-feature 'tramp-rpc-deploy 'force))))
 
 (provide 'tramp-rpc-deploy)
 ;;; tramp-rpc-deploy.el ends here

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -278,7 +278,7 @@ Messages are logged to *tramp-rpc-deploy* buffer."
   "Log a debug message if `tramp-rpc-deploy-debug' is non-nil.
 FORMAT-STRING and ARGS are passed to `format'."
   (when tramp-rpc-deploy-debug
-    (let* ((line (concat (format-time-string "[%Y-%m-%d %H:%M:%S] ")
+    (let* ((line (concat (format-time-string "[%F %T] ")
                          (apply #'format format-string args)
                          "\n"))
            (log-file (or (getenv "TRAMP_RPC_DEPLOY_DEBUG_LOG")
@@ -1076,9 +1076,9 @@ Tries sha256sum first, then shasum -a 256 for macOS compatibility."
     ;; would reject every automatic deployment.
     (tramp-send-command
      vec
-     (format (concat "umask 077 && parent=$(cd %s && pwd -P) && "
-                     "directory=$(mktemp -d \"$parent/.tramp-rpc-transfer.XXXXXX\") && "
-                     "printf '%%s\\n%%s\\n' \"$parent\" \"$directory\"")
+     (format "umask 077 && parent=$(cd %s && pwd -P) && \
+directory=$(mktemp -d \"$parent/.tramp-rpc-transfer.XXXXXX\") && \
+printf '%%s\\n%%s\\n' \"$parent\" \"$directory\""
              (tramp-shell-quote-argument parent)))
     (with-current-buffer (tramp-get-connection-buffer vec)
       (goto-char (point-min))
@@ -1192,14 +1192,12 @@ to inline encoding (base64 through the shell), which can be fragile."
                              (dest (tramp-shell-quote-argument remote-local))
                              (digest (tramp-shell-quote-argument local-checksum)))
                          (format
-                          (concat "test -f %s && ! test -L %s && chmod +x %s && "
-                                  "test -f %s && ! test -L %s && "
-                                  "(test ! -e %s && ! test -L %s || "
-                                  "test -f %s && ! test -L %s) && "
-                                  "actual=$({ sha256sum %s 2>/dev/null || "
-                                  "shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1) && "
-                                  "test \"$actual\" = %s && mv -f %s %s && "
-                                  "test -f %s && ! test -L %s && test -x %s")
+                          "test -f %s && ! test -L %s && chmod +x %s && \
+test -f %s && ! test -L %s && \
+(test ! -e %s && ! test -L %s || test -f %s && ! test -L %s) && \
+actual=$({ sha256sum %s 2>/dev/null || shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1) && \
+test \"$actual\" = %s && mv -f %s %s && \
+test -f %s && ! test -L %s && test -x %s"
                           tmp tmp tmp tmp tmp dest dest dest dest tmp tmp digest tmp dest
                           dest dest dest)))
                     (signal 'remote-file-error

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -8,6 +8,11 @@
 
 ;; This file is part of tramp-rpc.
 
+;; tramp-rpc is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
 ;;; Commentary:
 
 ;; This file handles deployment of the tramp-rpc-server binary to
@@ -34,9 +39,9 @@
 (declare-function tramp-rpc--proxy-hop-string "tramp-rpc")
 (declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Customization
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--load-source-file-name ()
   "Return the Elisp source file corresponding to `load-file-name'.
@@ -293,9 +298,9 @@ FORMAT-STRING and ARGS are passed to `format'."
               (write-region line nil log-file 'append 'silent))
           (error nil))))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Architecture detection and path helpers
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--normalize-hops (hop-string)
   "Convert \"rpc:\" method references in HOP-STRING to \"ssh:\" for bootstrap.
@@ -562,9 +567,9 @@ outputs whose mtime predates the source files."
                    tramp-rpc-deploy-binary-name
                    (tramp-rpc-deploy--binary-id)))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Download from GitHub Releases
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--release-asset-name (arch)
   "Return the release asset filename for ARCH."
@@ -787,9 +792,9 @@ release artifact into the cache."
       ;; Never leave downloaded archives or unpromoted extraction behind.
       (ignore-errors (delete-directory temp-dir t)))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Build from source
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--cargo-available-p ()
   "Check if cargo (Rust) is available."
@@ -845,9 +850,9 @@ Returns the path to the binary on success, nil on failure."
 	   'remote-file-error
 	   (list (format "Build failed (exit %d):\n%s" exit-code (buffer-string)))))))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Main logic: ensure local binary exists
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--ask-git-install-action (arch)
   "Ask how to obtain a git-checkout server binary for ARCH.
@@ -1014,9 +1019,9 @@ Returns the path to the local binary."
        (format "Binary should be placed at:\n   %s"
                (tramp-rpc-deploy--local-cache-path arch))))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Remote deployment
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy--remote-binary-exists-p (vec)
   "Check if a regular non-symlink executable binary exists on remote VEC."
@@ -1218,9 +1223,9 @@ to inline encoding (base64 through the shell), which can be fragile."
 
     remote-path))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Public API
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc-deploy-expected-binary-localname ()
   "Return the expected remote binary localname without network access.

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -475,7 +475,7 @@ preserve timestamps."
        t))
 
 (defun tramp-rpc-deploy--source-directory-warning ()
-  "Return a warning string when source-build auto-detection looks suspicious."
+  "Return a warning string for suspicious source-build auto-detection."
   (when (and (memq tramp-rpc-deploy-git-build-policy '(auto build))
              tramp-rpc-deploy-source-directory
              (not (tramp-rpc-deploy--source-has-server-p)))

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -664,7 +664,9 @@ Returns t if checksum matches, nil otherwise."
           (rename-file temp-path path t)
           (setq temp-path nil))
       (when temp-path
-        (ignore-errors (delete-file temp-path))))))
+        (condition-case nil
+            (delete-file temp-path)
+          (file-missing nil))))))
 
 (defun tramp-rpc-deploy--write-cache-provenance (cache-path kind digest)
   "Atomically record KIND and SHA256 DIGEST for CACHE-PATH."
@@ -678,8 +680,11 @@ Returns t if checksum matches, nil otherwise."
 
 (defun tramp-rpc-deploy--invalidate-cache (cache-path)
   "Remove CACHE-PATH and its provenance after failed source-cache validation."
-  (ignore-errors (delete-file cache-path))
-  (ignore-errors (delete-file (tramp-rpc-deploy--cache-provenance-path cache-path))))
+  (dolist (path (list cache-path
+                      (tramp-rpc-deploy--cache-provenance-path cache-path)))
+    (condition-case nil
+        (delete-file path)
+      (file-missing nil))))
 
 (defun tramp-rpc-deploy--promote-cached-binary (source cache-path kind)
   "Atomically promote SOURCE to CACHE-PATH with KIND and a recorded digest.
@@ -694,13 +699,17 @@ never one authorized by stale provenance."
           (set-file-modes temp-path #o755)
           (let ((digest (tramp-rpc-deploy--compute-checksum temp-path)))
             ;; Remove stale authority before changing the cache binary.
-            (ignore-errors (delete-file provenance-path))
+            (condition-case nil
+                (delete-file provenance-path)
+              (file-missing nil))
             (rename-file temp-path cache-path t)
             (setq temp-path nil)
             (tramp-rpc-deploy--write-cache-provenance cache-path kind digest)
             cache-path))
       (when temp-path
-        (ignore-errors (delete-file temp-path))))))
+        (condition-case nil
+            (delete-file temp-path)
+          (file-missing nil))))))
 
 (defun tramp-rpc-deploy--cached-binary-trusted-p (cache-path)
   "Return non-nil when CACHE-PATH matches a recorded provenance digest."
@@ -786,7 +795,9 @@ release artifact into the cache."
             (message "Downloaded and verified tramp-rpc-server for %s" arch)
             cache-path))
       ;; Never leave downloaded archives or unpromoted extraction behind.
-      (ignore-errors (delete-directory temp-dir t)))))
+      (condition-case nil
+          (delete-directory temp-dir t)
+        (file-missing nil)))))
 
 ;; ============================================================================
 ;;; Build from source
@@ -1202,9 +1213,14 @@ to inline encoding (base64 through the shell), which can be fragile."
                  (message "Transfer error: %s" err-msg))
                (setq retries (1+ retries))))
           (when staging-directory
-            (ignore-errors
-              (tramp-rpc-deploy--remove-remote-staging-directory
-               vec staging-directory))))))
+            (condition-case cleanup-error
+                (tramp-rpc-deploy--remove-remote-staging-directory
+                 vec staging-directory)
+              ((file-error remote-file-error)
+               (tramp-rpc-deploy--log
+                "Failed to remove remote staging directory %s: %s"
+                staging-directory
+                (error-message-string cleanup-error))))))))
 
     (unless success
       (signal

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -29,6 +29,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'eieio)
 (require 'tramp)
 (require 'tramp-cache)
 
@@ -227,14 +228,12 @@ must still report symlink type for lstat."
                 (remhash (cons candidate t) tramp-rpc--file-stat-cache))
               (flush-tramp-properties (candidate)
                 (when (tramp-tramp-file-p candidate)
-                  (ignore-errors
-                    (with-parsed-tramp-file-name candidate nil
-                      (tramp-flush-file-properties v localname)))))
+                  (with-parsed-tramp-file-name candidate nil
+                    (tramp-flush-file-properties v localname))))
               (flush-tramp-directory-properties (candidate)
                 (when (tramp-tramp-file-p candidate)
-                  (ignore-errors
-                    (with-parsed-tramp-file-name candidate nil
-                      (tramp-flush-directory-properties v localname)))))
+                  (with-parsed-tramp-file-name candidate nil
+                    (tramp-flush-directory-properties v localname))))
               (spellings (path)
                 (delete-dups
                  (list path
@@ -261,10 +260,9 @@ must still report symlink type for lstat."
     (tramp-rpc--invalidate-cache-for-path expanded-file)
     (cl-labels ((flush-tramp-properties (candidate)
                   (when (tramp-tramp-file-p candidate)
-                    (ignore-errors
-                      (with-parsed-tramp-file-name candidate nil
-                        (tramp-flush-file-properties v localname)
-                        (tramp-flush-directory-properties v localname)))))
+                    (with-parsed-tramp-file-name candidate nil
+                      (tramp-flush-file-properties v localname)
+                      (tramp-flush-directory-properties v localname))))
                 (drop-string-prefix (cache)
                   (let (keys)
                     (maphash (lambda (key _value)
@@ -308,9 +306,8 @@ must still report symlink type for lstat."
 (defun tramp-rpc--clear-current-tramp-file-properties ()
   "Clear TRAMP file properties for the current remote connection."
   (when (file-remote-p default-directory)
-    (ignore-errors
-      (with-parsed-tramp-file-name default-directory nil
-        (tramp-flush-directory-properties v "/")))))
+    (with-parsed-tramp-file-name default-directory nil
+      (tramp-flush-directory-properties v "/"))))
 
 (defun tramp-rpc--clear-file-metadata-caches ()
   "Clear cached file metadata."
@@ -331,7 +328,7 @@ must still report symlink type for lstat."
 Entries are keyed by expanded TRAMP filenames; this removes those
 matching the remote prefix of VEC."
   (tramp-rpc-magit--clear-ancestor-caches-for-connection vec)
-  (ignore-errors (tramp-flush-directory-properties vec "/"))
+  (tramp-flush-directory-properties vec "/")
   (let ((prefix (tramp-make-tramp-file-name vec "/")))
     ;; Match the prefix up to the colon-slash that starts the localname.
     ;; e.g. "/rpc:user@host:/" -- any key starting with this belongs to VEC.
@@ -1663,7 +1660,10 @@ Returns t, nil, or \\='not-cached if not in cache."
 
 (defun tramp-rpc-magit--section-slot (section slot)
   "Return SECTION's SLOT value, or nil if unavailable."
-  (ignore-errors (eieio-oref section slot)))
+  (when (and (eieio-object-p section)
+             (slot-exists-p section slot)
+             (slot-boundp section slot))
+    (slot-value section slot)))
 
 (defun tramp-rpc-magit--maybe-prefetch-for-section (section)
   "Ensure batched data exists before expanding lazy Magit SECTION."

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -53,6 +53,8 @@
 (declare-function tramp-rpc--file-notify-dispatch "tramp-rpc")
 (declare-function tramp-rpc--file-notify-dispatch-rescan "tramp-rpc")
 (declare-function tramp-rpc--watch-entry-canonical-directory "tramp-rpc")
+(declare-function tramp-rpc--add-external-operation "tramp-rpc")
+(declare-function tramp-rpc--remove-external-operation "tramp-rpc")
 
 ;; Functions from magit-section.el.
 (autoload 'magit-section-show "magit-section")
@@ -1762,10 +1764,10 @@ magit-status on remote repositories."
   (when (fboundp 'magit-section-show)
     (advice-add 'magit-section-show :around #'tramp-rpc-magit--section-show-advice))
 
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
    'magit-status-setup-buffer
    #'tramp-rpc-handle-magit-status-setup-buffer 'tramp-rpc)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
    'magit-status-refresh-buffer
    #'tramp-rpc-handle-magit-status-refresh-buffer 'tramp-rpc)
   (setq tramp-rpc-magit--magit-enabled t)
@@ -1776,8 +1778,8 @@ magit-status on remote repositories."
   "Disable tramp-rpc magit optimizations."
   (interactive)
   (advice-remove 'magit-section-show #'tramp-rpc-magit--section-show-advice)
-  (tramp-remove-external-operation 'magit-status-setup-buffer 'tramp-rpc)
-  (tramp-remove-external-operation 'magit-status-refresh-buffer 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'magit-status-setup-buffer 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'magit-status-refresh-buffer 'tramp-rpc)
   (tramp-rpc-magit--clear-cache)
   (setq tramp-rpc-magit--magit-enabled nil)
   (message "tramp-rpc magit optimizations disabled"))
@@ -1842,10 +1844,10 @@ PROJECT-ROOT is the project root directory."
 This ensures fd is not used for remote directories where it may not
 be available, and uses alien indexing for better performance."
   (interactive)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
    'projectile-dir-files
    #'tramp-rpc-handle-projectile-dir-files 'tramp-rpc)
-  (tramp-add-external-operation
+  (tramp-rpc--add-external-operation
    'projectile-project-files
    #'tramp-rpc-handle-projectile-project-files 'tramp-rpc)
   (setq tramp-rpc-magit--projectile-enabled t)
@@ -1855,8 +1857,8 @@ be available, and uses alien indexing for better performance."
 (defun tramp-rpc-projectile-disable ()
   "Disable tramp-rpc projectile optimizations."
   (interactive)
-  (tramp-remove-external-operation 'projectile-dir-files 'tramp-rpc)
-  (tramp-remove-external-operation 'projectile-project-files 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'projectile-dir-files 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'projectile-project-files 'tramp-rpc)
   (setq tramp-rpc-magit--projectile-enabled nil)
   (message "tramp-rpc projectile optimizations disabled"))
 

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -510,7 +510,7 @@ DIRECTORY itself returns the empty string.  Descendants can contain slashes."
                     (tramp-rpc--file-notify-dispatch action path path1 cookie)))))))))))
 
 (defun tramp-rpc-watch-directory (directory &optional recursive)
-  "Start watching DIRECTORY for filesystem changes.
+  "Start watching DIRECTORY for filesystem change events.
 When RECURSIVE is non-nil, watch subdirectories too."
   (interactive "DDirectory to watch: ")
   (with-parsed-tramp-file-name directory nil
@@ -558,7 +558,7 @@ When RECURSIVE is non-nil, watch subdirectories too."
     (tramp-rpc--debug "Watching: %s (recursive=%s)" localname recursive)))
 
 (defun tramp-rpc-unwatch-directory (directory)
-  "Stop watching DIRECTORY for filesystem changes."
+  "Stop watching DIRECTORY for filesystem change events."
   (interactive "DDirectory to unwatch: ")
   (with-parsed-tramp-file-name directory nil
     (let* ((watch-key (format "%s:%s" (tramp-rpc--connection-key-string v)
@@ -1620,7 +1620,7 @@ Returns t, nil, or \\='not-cached if not in cache."
 ;; ============================================================================
 
 (defun tramp-rpc-magit--clear-status-cache ()
-  "Clear all status caches (git state that changes frequently)."
+  "Clear all frequently changing Git status caches."
   (clrhash tramp-rpc-magit--process-caches))
 
 (defun tramp-rpc-magit--clear-status-cache-for-connection (vec)

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -30,11 +30,7 @@
 
 (require 'cl-lib)
 (require 'tramp)
-
-;; Functions from tramp.el
-(declare-function tramp-add-external-operation "tramp")
-(declare-function tramp-remove-external-operation "tramp")
-(declare-function tramp-message "tramp-message")
+(require 'tramp-cache)
 
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
@@ -57,19 +53,21 @@
 (declare-function tramp-rpc--file-notify-dispatch-rescan "tramp-rpc")
 (declare-function tramp-rpc--watch-entry-canonical-directory "tramp-rpc")
 
-;; Functions from tramp-cache.el.
-(declare-function tramp-flush-file-properties "tramp-cache")
-(declare-function tramp-flush-directory-properties "tramp-cache")
-
 ;; Functions from magit-section.el.
-(declare-function magit-section-show "magit-section")
+(autoload 'magit-section-show "magit-section")
 
 ;; Silence byte-compiler warnings for external functions
-(declare-function projectile-dir-files-alien "projectile")
-(declare-function projectile-time-seconds "projectile")
+(autoload 'projectile-dir-files-alien "projectile")
+(autoload 'projectile-time-seconds "projectile")
 
 ;; Variables from magit-diff.el.
 (defvar magit-diff-adjust-tab-width)
+
+(defvar tramp-rpc-magit--magit-enabled nil
+  "Non-nil when Magit integrations are installed.")
+
+(defvar tramp-rpc-magit--projectile-enabled nil
+  "Non-nil when Projectile integrations are installed.")
 
 ;; ============================================================================
 ;; Cache infrastructure
@@ -1763,15 +1761,14 @@ magit-status on remote repositories."
   (advice-remove 'magit-section-show #'tramp-rpc-magit--section-show-advice)
   (when (fboundp 'magit-section-show)
     (advice-add 'magit-section-show :around #'tramp-rpc-magit--section-show-advice))
-  (with-eval-after-load 'magit-section
-    (advice-remove 'magit-section-show #'tramp-rpc-magit--section-show-advice)
-    (advice-add 'magit-section-show :around #'tramp-rpc-magit--section-show-advice))
+
   (tramp-add-external-operation
    'magit-status-setup-buffer
    #'tramp-rpc-handle-magit-status-setup-buffer 'tramp-rpc)
   (tramp-add-external-operation
    'magit-status-refresh-buffer
    #'tramp-rpc-handle-magit-status-refresh-buffer 'tramp-rpc)
+  (setq tramp-rpc-magit--magit-enabled t)
   (message "tramp-rpc magit optimizations enabled"))
 
 ;;;###autoload
@@ -1782,6 +1779,7 @@ magit-status on remote repositories."
   (tramp-remove-external-operation 'magit-status-setup-buffer 'tramp-rpc)
   (tramp-remove-external-operation 'magit-status-refresh-buffer 'tramp-rpc)
   (tramp-rpc-magit--clear-cache)
+  (setq tramp-rpc-magit--magit-enabled nil)
   (message "tramp-rpc magit optimizations disabled"))
 
 ;;;###autoload
@@ -1798,11 +1796,6 @@ magit-status on remote repositories."
   (setq tramp-rpc-magit--debug nil)
   (message "tramp-rpc magit debug disabled"))
 
-;; Fix #m4: Auto-enable behind defcustom gate
-(with-eval-after-load 'magit
-  (with-eval-after-load 'tramp-rpc
-    (when tramp-rpc-magit-optimize
-      (tramp-rpc-magit-enable))))
 
 ;; ============================================================================
 ;; Projectile optimizations
@@ -1855,6 +1848,7 @@ be available, and uses alien indexing for better performance."
   (tramp-add-external-operation
    'projectile-project-files
    #'tramp-rpc-handle-projectile-project-files 'tramp-rpc)
+  (setq tramp-rpc-magit--projectile-enabled t)
   (message "tramp-rpc projectile optimizations enabled"))
 
 ;;;###autoload
@@ -1863,11 +1857,16 @@ be available, and uses alien indexing for better performance."
   (interactive)
   (tramp-remove-external-operation 'projectile-dir-files 'tramp-rpc)
   (tramp-remove-external-operation 'projectile-project-files 'tramp-rpc)
+  (setq tramp-rpc-magit--projectile-enabled nil)
   (message "tramp-rpc projectile optimizations disabled"))
 
-;; Auto-enable when projectile is loaded
-(with-eval-after-load 'projectile
-  (with-eval-after-load 'tramp-rpc
+(defun tramp-rpc-magit-install-optional-handlers ()
+  "Install handlers for loaded Magit and Projectile packages."
+  (when (and (featurep 'magit) tramp-rpc-magit-optimize
+             (not tramp-rpc-magit--magit-enabled))
+    (tramp-rpc-magit-enable))
+  (when (and (featurep 'projectile)
+             (not tramp-rpc-magit--projectile-enabled))
     (tramp-rpc-projectile-enable)))
 
 ;; ============================================================================
@@ -1882,11 +1881,6 @@ Removes handlers."
   (tramp-rpc-projectile-disable)
   ;; Return nil to allow normal unload to proceed
   nil)
-
-(add-hook 'tramp-rpc-unload-hook
-	  (lambda ()
-	    (when (featurep 'tramp-rpc-magit)
-	      (unload-feature 'tramp-rpc-magit 'force))))
 
 (provide 'tramp-rpc-magit)
 ;;; tramp-rpc-magit.el ends here

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -1396,7 +1396,7 @@ EVENT is the process event string."
 ;; ============================================================================
 
 (defun tramp-rpc--adjust-pty-window-size (process _windows)
-  "Adjust PTY window size when Emacs window size changes.
+  "Adjust PTY window size after an Emacs window resize.
 PROCESS is the local relay process, WINDOWS is the list of windows.
 Returns nil to tell Emacs not to call `set-process-window-size' on
 the local relay process (we handle resizing via RPC to the remote)."

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -71,6 +71,18 @@
 ;; Process tracking state
 ;; ============================================================================
 
+(defmacro tramp-rpc--best-effort (&rest body)
+  "Run BODY for teardown and log failures instead of hiding them.
+Best-effort cleanup must not replace an active transport or process error, but
+unexpected failures remain visible in TRAMP-RPC debug output."
+  (declare (indent 0) (debug t))
+  `(condition-case err
+       (progn ,@body)
+     (error
+      (tramp-rpc--debug "best-effort cleanup failed in %S: %s"
+                        ',(car body) (error-message-string err))
+      nil)))
+
 (defvar tramp-rpc--async-processes (make-hash-table :test 'eq)
   "Hash table mapping local relay processes to their remote process info.
 Value is a plist with :vec, :pid, :connection-process, :delivery-timer,
@@ -199,8 +211,8 @@ Return (STDOUT-PROCESS . STDERR-PROCESS)."
       (unless complete
         (dolist (process (list stderr-process stdout-process))
           (when (process-live-p process)
-            (ignore-errors (delete-process process))))
-        (ignore-errors (funcall cleanup))))))
+            (tramp-rpc--best-effort (delete-process process))))
+        (tramp-rpc--best-effort (funcall cleanup))))))
 
 (defun tramp-rpc--configure-relay-coding (process coding)
   "Configure PROCESS's binary relay and remember public CODING.
@@ -545,12 +557,12 @@ EVENT is the process event string."
                   (and (processp connection)
                        (process-get connection :tramp-rpc-transport-dead)))
         (when (and vec pid)
-          (ignore-errors
+          (tramp-rpc--best-effort
             (tramp-rpc--kill-remote-process
              vec pid 9 (process-get proc :tramp-rpc-connection)))))
       (when-let* ((stderr-process (plist-get info :stderr-process)))
         (when (process-live-p stderr-process)
-          (ignore-errors (delete-process stderr-process))))
+          (tramp-rpc--best-effort (delete-process stderr-process))))
       (let ((remote-exit (process-get proc :tramp-rpc-exit-code)))
         (tramp-rpc--call-user-sentinel-once
          proc user-sentinel
@@ -658,7 +670,7 @@ EXIT-CODE is the process exit status."
       ;; Send EOF to the stderr cat relay so it exits cleanly.
       (when-let* ((stderr-process (plist-get info :stderr-process)))
         (when (process-live-p stderr-process)
-          (ignore-errors (process-send-eof stderr-process))))
+          (tramp-rpc--best-effort (process-send-eof stderr-process))))
       ;; Send EOF to the LOCAL cat relay (not the remote process).
       ;; Bind `tramp-rpc--closing-local-relay' so the `process-send-eof'
       ;; handler calls the original function instead of routing to the
@@ -668,7 +680,7 @@ EXIT-CODE is the process exit status."
       ;; `tramp-rpc--install-process-cleanup' then deletes the process.
       (when (process-live-p local-process)
         (let ((tramp-rpc--closing-local-relay t))
-          (ignore-errors (process-send-eof local-process))))
+          (tramp-rpc--best-effort (process-send-eof local-process))))
       ;; Now mark as exited so process-status handler returns 'exit.
       (process-put local-process :tramp-rpc-exited t))))
 
@@ -692,7 +704,7 @@ update is still running."
                   (when (processp proc)
                     (remhash proc tramp-rpc--async-processes)
                     (unless (process-live-p proc)
-                      (ignore-errors
+                      (tramp-rpc--best-effort
                         (delete-process proc))))))))
     (cond
      ((process-live-p process)
@@ -778,9 +790,14 @@ VEC is the TRAMP connection vector."
              (not (member "--command" args))
              (not (member "--login" args))
              (not (cl-intersection login-args args :test #'string=))
-             (equal base (ignore-errors
-                           (file-name-nondirectory
-                            (tramp-rpc--get-remote-login-shell vec)))))
+             (equal base
+                    (condition-case err
+                        (file-name-nondirectory
+                         (tramp-rpc--get-remote-login-shell vec))
+                      ((file-error remote-file-error)
+                       (tramp-rpc--debug "login shell probe failed: %s"
+                                         (error-message-string err))
+                       nil))))
         ;; bash refuses `bash -l --noediting -i' but accepts `bash --noediting -i -l'.
         (append command login-args)
       command)))
@@ -883,7 +900,7 @@ Resolves program path and loads direnv environment from working directory."
                     (tramp-rpc--start-cat-relays
                      (or name "tramp-rpc-async") buffer stderr-buffer
                      (lambda ()
-                       (ignore-errors
+                       (tramp-rpc--best-effort
                          (tramp-rpc--kill-remote-process
                           v remote-pid 9 connection)))))
                    (local-process (car relays))
@@ -1182,7 +1199,7 @@ DIRENV-ENV is an optional alist of environment variables for the process."
           (tramp-rpc--start-cat-relays
            (or name "tramp-rpc-pty") actual-buffer nil
            (lambda ()
-             (ignore-errors
+             (tramp-rpc--best-effort
                (tramp-rpc--call vec "process.close_pty"
                                 `((pid . ,remote-pid)) connection)))))
          (local-process (car relays)))
@@ -1328,7 +1345,7 @@ EXIT-CODE is the process exit status."
     (when-let* ((vec (process-get local-process :tramp-rpc-vec))
                (pid (process-get local-process :tramp-rpc-pid))
                (connection (process-get local-process :tramp-rpc-connection)))
-      (ignore-errors
+      (tramp-rpc--best-effort
         (tramp-rpc--call vec "process.close_pty" `((pid . ,pid)) connection)))
     ;; A terminal server response without a status is abnormal.  In
     ;; particular, do not translate a killed remote PTY into local success.
@@ -1341,7 +1358,7 @@ EXIT-CODE is the process exit status."
     ;; deleting it here discards the final output returned with EXITED.
     (when (process-live-p local-process)
       (let ((tramp-rpc--closing-local-relay t))
-        (ignore-errors (process-send-eof local-process))))))
+        (tramp-rpc--best-effort (process-send-eof local-process))))))
 
 (defun tramp-rpc--pty-sentinel (process event)
   "Sentinel for PTY relay PROCESS, preserving its user sentinel once.
@@ -1357,7 +1374,7 @@ EVENT is the process event string."
                                     :tramp-rpc-transport-dead)))
         (when-let* ((vec (plist-get info :vec))
                     (pid (plist-get info :pid)))
-          (ignore-errors
+          (tramp-rpc--best-effort
             (tramp-rpc--call vec "process.kill_pty"
                              `((pid . ,pid) (signal . 9))
                              (process-get process :tramp-rpc-connection)))))
@@ -1386,12 +1403,16 @@ the local relay process (we handle resizing via RPC to the remote)."
     (when-let* ((vec (process-get process :tramp-rpc-vec))
                (pid (process-get process :tramp-rpc-pid)))
       (let ((size (tramp-rpc--get-terminal-size (process-buffer process))))
-        ;; Resize the remote PTY
-        (ignore-errors
-          (tramp-rpc--call-fast vec "process.resize_pty"
-                                `((pid . ,pid)
-                                  (cols . ,(car size))
-                                  (rows . ,(cdr size))))))))
+        ;; Resize the remote PTY.  A transport race is expected when the
+        ;; process exits while Emacs is dispatching a window change.
+        (condition-case err
+            (tramp-rpc--call-fast vec "process.resize_pty"
+                                  `((pid . ,pid)
+                                    (cols . ,(car size))
+                                    (rows . ,(cdr size))))
+          ((file-error remote-file-error)
+           (tramp-rpc--debug "PTY resize failed: %s"
+                             (error-message-string err)))))))
   ;; Return nil - we handle resizing ourselves, Emacs shouldn't try to
   ;; set-process-window-size on our local relay process
   nil)
@@ -1420,12 +1441,16 @@ Returns the final (width . height) cons, or nil if resize was not handled."
                   (setq width (car adjusted)
                         height (cdr adjusted))))
               (when (and (> width 0) (> height 0))
-                ;; Resize remote PTY
-                (ignore-errors
-                  (tramp-rpc--call-fast vec "process.resize_pty"
-                                        `((pid . ,pid)
-                                          (cols . ,width)
-                                          (rows . ,height))))
+                ;; Resize remote PTY.  Ignore only the expected transport race
+                ;; when the process exits during a display update.
+                (condition-case err
+                    (tramp-rpc--call-fast vec "process.resize_pty"
+                                          `((pid . ,pid)
+                                            (cols . ,width)
+                                            (rows . ,height)))
+                  ((file-error remote-file-error)
+                   (tramp-rpc--debug "terminal resize failed: %s"
+                                     (error-message-string err))))
                 ;; Let terminal-specific code update display
                 (when display-updater
                   (funcall display-updater width height))
@@ -1517,7 +1542,7 @@ callbacks that mutate the process registry."
          (push (cons (plist-get info :vec) (plist-get info :pid)) targets)))
      tramp-rpc--pty-processes)
     (dolist (target targets)
-      (ignore-errors
+      (tramp-rpc--best-effort
         (tramp-rpc--call (car target) "process.kill_pty"
                          `((pid . ,(cdr target)) (signal . 9)) connection)))))
 
@@ -1577,7 +1602,7 @@ generation has been detached from global connection lookup."
          (push (cons (plist-get info :vec) (plist-get info :pid)) targets)))
      tramp-rpc--async-processes)
     (dolist (target targets)
-      (ignore-errors
+      (tramp-rpc--best-effort
         (tramp-rpc--call (car target) "process.kill"
                          `((pid . ,(cdr target)) (signal . 9)) connection)))))
 
@@ -1601,7 +1626,7 @@ transport is live."
        (tramp-rpc--cancel-process-timers tramp-rpc--async-processes local-process)
        (when-let* ((stderr-process (plist-get info :stderr-process)))
          (when (process-live-p stderr-process)
-           (ignore-errors (delete-process stderr-process))))
+           (tramp-rpc--best-effort (delete-process stderr-process))))
        ;; Keep tracking while delete-process dispatches the wrapped sentinel.
        (process-put local-process :tramp-rpc-transport-cleanup t)
        (process-put local-process :tramp-rpc-transport-dead t)

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -55,6 +55,8 @@
 (declare-function tramp-rpc--ssh-detail-user "tramp-rpc")
 (declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc--add-external-operation "tramp-rpc")
+(declare-function tramp-rpc--remove-external-operation "tramp-rpc")
 
 ;; Variables from tramp-rpc.el
 (defvar tramp-rpc-use-direct-ssh-pty)
@@ -1640,21 +1642,21 @@ transport is live."
 (defun tramp-rpc-process-install-optional-handlers ()
   "Install handlers for loaded optional terminal packages."
   (when (featurep 'vterm)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
      'vterm--window-adjust-process-window-size
      #'tramp-rpc-handle-vterm--window-adjust-process-window-size
      'tramp-rpc 'process))
   (when (featurep 'eat)
-    (tramp-add-external-operation
+    (tramp-rpc--add-external-operation
      'eat--adjust-process-window-size
      #'tramp-rpc-handle-eat--adjust-process-window-size
      'tramp-rpc 'process)))
 
 (defun tramp-rpc--process-handler-remove ()
   "Remove handlers."
-  (tramp-remove-external-operation
+  (tramp-rpc--remove-external-operation
    'vterm--window-adjust-process-window-size 'tramp-rpc)
-  (tramp-remove-external-operation
+  (tramp-rpc--remove-external-operation
    'eat--adjust-process-window-size 'tramp-rpc))
 
 ;; ============================================================================

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -27,19 +27,17 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'msgpack)
 (require 'tramp)
+(require 'tramp-sh)
 (require 'tramp-rpc-protocol)
 
-;; Functions from tramp.el
-(declare-function tramp-add-external-operation "tramp")
-(declare-function tramp-remove-external-operation "tramp")
 (declare-function tramp-rpc--sudo-password-required-p "tramp-rpc")
 (declare-function tramp-rpc--sudo-read-password "tramp-rpc")
 
 ;; Silence byte-compiler warnings for variables defined in vterm
 (defvar vterm-copy-mode)
 (defvar vterm-min-window-width)
-(defvar vterm--term)
 
 ;; Functions from tramp-rpc.el (loaded before us)
 (declare-function tramp-rpc--debug "tramp-rpc")
@@ -128,6 +126,7 @@ the next read cannot discard output waiting for relay delivery."
   "TRAMP-RPC process write failed" 'remote-file-error)
 
 (declare-function tramp-rpc--get-connection "tramp-rpc" (vec))
+(declare-function tramp-rpc--connection-key "tramp-rpc")
 
 (defun tramp-rpc--process-write-queue-key (vec pid &optional connection)
   "Return the write queue key for VEC and remote PID.
@@ -1457,9 +1456,11 @@ WINDOWS is the list of windows displaying the process buffer."
            (cons (max width vterm-min-window-width) height))
          ;; Display updater: call vterm--set-size
          (lambda (width height)
-           (when (and (boundp 'vterm--term) vterm--term
-                    (fboundp 'vterm--set-size))
-             (vterm--set-size vterm--term height width))))))
+           (when-let* (((boundp 'vterm--term))
+                       (term (symbol-value 'vterm--term))
+                       ((fboundp 'vterm--set-size)))
+             (funcall (symbol-function 'vterm--set-size)
+                      term height width))))))
    ;; Not our process, call original
    (t (tramp-run-real-handler
        'vterm--window-adjust-process-window-size (list process windows)))))
@@ -1610,21 +1611,15 @@ transport is live."
    tramp-rpc--async-processes)
   (tramp-rpc--cleanup-process-write-queues vec connection-process))
 
-;; Forward declare for cleanup
-(declare-function tramp-rpc--connection-key "tramp-rpc")
-
-;; Install terminal emulator handler.  When vterm/eat is already loaded while
-;; `tramp-rpc' is being required, defer until `tramp-rpc' is provided; otherwise
-;; `tramp-add-external-operation' calls `(require 'tramp-rpc)' recursively.
-(with-eval-after-load 'vterm
-  (with-eval-after-load 'tramp-rpc
+;; Install optional terminal emulator handlers after their packages load.
+(defun tramp-rpc-process-install-optional-handlers ()
+  "Install handlers for loaded optional terminal packages."
+  (when (featurep 'vterm)
     (tramp-add-external-operation
      'vterm--window-adjust-process-window-size
      #'tramp-rpc-handle-vterm--window-adjust-process-window-size
-     'tramp-rpc 'process)))
-
-(with-eval-after-load 'eat
-  (with-eval-after-load 'tramp-rpc
+     'tramp-rpc 'process))
+  (when (featurep 'eat)
     (tramp-add-external-operation
      'eat--adjust-process-window-size
      #'tramp-rpc-handle-eat--adjust-process-window-size
@@ -1652,11 +1647,6 @@ Removes handlers and cleans up async processes."
   (tramp-rpc--cleanup-pty-processes)
   ;; Return nil to allow normal unload to proceed
   nil)
-
-(add-hook 'tramp-rpc-unload-hook
-	  (lambda ()
-	    (when (featurep 'tramp-rpc-process)
-	      (unload-feature 'tramp-rpc-process 'force))))
 
 (provide 'tramp-rpc-process)
 ;;; tramp-rpc-process.el ends here

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -169,7 +169,7 @@ with :notification t, :method, and :params keys."
     result))
 
 (defun tramp-rpc-protocol-error-p (response)
-  "Return non-nil if RESPONSE contains an error."
+  "Return non-nil for an error RESPONSE."
   (plist-get response :error))
 
 (defun tramp-rpc-protocol-error-message (response)

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -136,7 +136,7 @@ with :notification t, :method, and :params keys."
                                 :key-type 'symbol
                                 :array-type 'list
                                 :bin-type 'msgpack-bin)
-		(when (and end (/= (point) (point-max)))
+		(when (and end (not (eobp)))
 		  (error "Trailing data in MessagePack frame"))))))
          (id (alist-get 'id response))
          (method (alist-get 'method response))

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -264,10 +264,5 @@ Returns a list where each element is either:
 ;; Unload support
 ;; ============================================================================
 
-(add-hook 'tramp-rpc-unload-hook
-	  (lambda ()
-	    (when (featurep 'tramp-rpc-protocol)
-	      (unload-feature 'tramp-rpc-protocol 'force))))
-
 (provide 'tramp-rpc-protocol)
 ;;; tramp-rpc-protocol.el ends here

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -632,10 +632,10 @@ passing any SSH command-line arguments."
 
 (defcustom tramp-rpc-use-direct-ssh-pty t
   "Whether to use direct SSH connections for PTY processes.
-When non-nil, interactive terminal processes (vterm, shell-mode, term-mode)
-use a direct SSH connection with `-t` for the PTY, providing much lower
-latency than the RPC-based PTY.  The SSH connection reuses the existing
-ControlMaster socket, so authentication is already handled.
+When non-nil, interactive terminal processes (`vterm', `shell-mode',
+`term-mode') use a direct SSH connection with `-t` for the PTY.  This provides
+much lower latency than the RPC-based PTY.  The SSH connection reuses the
+existing ControlMaster socket, so authentication is already handled.
 
 Note: `signal-process' on direct SSH PTY sends signal to the local SSH
 process, which may not propagate to the remote process in all cases."
@@ -1449,9 +1449,9 @@ Creates the directory from `tramp-rpc-controlmaster-path' if needed."
         ;; Set restrictive permissions for security
         (set-file-modes dir #o700)))))
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Authentication via tramp-process-actions
-;;; ============================================================================
+;; ============================================================================
 
 ;; Reuse upstream TRAMP's `tramp-process-actions' state machine for all
 ;; interactive authentication (SSH passwords, sudo, host-key prompts,
@@ -1499,9 +1499,9 @@ for the socket to appear before declaring the attempt dead."
 Handles password prompts, host-key verification, and detects the
 ControlMaster socket file appearing as the success condition.")
 
-;;; ============================================================================
+;; ============================================================================
 ;;; Multi-hop support
-;;; ============================================================================
+;; ============================================================================
 
 (defun tramp-rpc--hops-to-proxyjump (vec)
   "Convert VEC's hop chain to an SSH ProxyJump (-J) string.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -223,12 +223,24 @@ This is called from `tramp-multi-hop-p-hook'."
 (require 'tramp-sh)
 (require 'tramp-rpc-protocol)
 
-;; Check for minimum Tramp version.  The Package-Requires header declares
-;; (tramp "2.8.1.4") but that is only enforced by package.el at install
-;; time.  Guard at load time so that manual installations fail clearly.
-(when (version< tramp-version "2.8.1.4")
-  (error "Tramp RPC requires Tramp >= 2.8.1.4, but %s is loaded"
-         tramp-version))
+;; Package-Requires enforces this for package installations.  Keep loading
+;; harmless for tooling that checks each file against Emacs's older bundled
+;; TRAMP, and report the actionable error when the backend is actually used.
+(defun tramp-rpc--check-tramp-version ()
+  "Signal a clear error unless the loaded TRAMP version is supported."
+  (when (version< tramp-version "2.8.1.4")
+    (error "Tramp RPC requires Tramp >= 2.8.1.4, but %s is loaded"
+           tramp-version)))
+
+(defun tramp-rpc--add-external-operation (&rest args)
+  "Call `tramp-add-external-operation' with ARGS when available."
+  (when (fboundp 'tramp-add-external-operation)
+    (apply (symbol-function 'tramp-add-external-operation) args)))
+
+(defun tramp-rpc--remove-external-operation (&rest args)
+  "Call `tramp-remove-external-operation' with ARGS when available."
+  (when (fboundp 'tramp-remove-external-operation)
+    (apply (symbol-function 'tramp-remove-external-operation) args)))
 
 (declare-function dired-compress-file "dired-aux")
 ;; These predicates are emitted inside the single autoload form above.  The
@@ -647,7 +659,7 @@ When TRAMP_RPC_DEBUG_LOG or TRAMP_RPC_DEBUG_DIR is set in the environment,
 also append each line directly to a local log file.  This preserves CI
 telemetry even when later tests unload TRAMP and remove debug buffers."
   (when tramp-rpc-debug
-    (let* ((line (concat (format-time-string "[%Y-%m-%d %H:%M:%S.%3N] ")
+    (let* ((line (concat (format-time-string "[%F %T.%3N] ")
                          (apply #'format format-string args)
                          "\n"))
            (log-file (or (getenv "TRAMP_RPC_DEBUG_LOG")
@@ -5803,10 +5815,10 @@ Also controls process exit detection latency."
 
 (defun tramp-rpc--install-core-external-operations ()
   "Install external operations implemented by the core module."
-  (tramp-add-external-operation 'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
-  (tramp-add-external-operation 'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc)
-  (tramp-add-external-operation 'dir-locals-find-file 'tramp-rpc-handle-dir-locals-find-file 'tramp-rpc)
-  (tramp-add-external-operation 'move-file-to-trash 'tramp-rpc-handle-move-file-to-trash 'tramp-rpc 'file))
+  (tramp-rpc--add-external-operation 'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
+  (tramp-rpc--add-external-operation 'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc)
+  (tramp-rpc--add-external-operation 'dir-locals-find-file 'tramp-rpc-handle-dir-locals-find-file 'tramp-rpc)
+  (tramp-rpc--add-external-operation 'move-file-to-trash 'tramp-rpc-handle-move-file-to-trash 'tramp-rpc 'file))
 
 ;;;###autoload
 (defun tramp-rpc-file-name-handler (operation &rest args)
@@ -5815,6 +5827,7 @@ Falls back to the local handler when `non-essential' is non-nil and
 a backend function throws `non-essential' (e.g. because no connection
 exists and opening one would block).  This mirrors the catch/throw
 pattern in `tramp-file-name-handler'."
+  (tramp-rpc--check-tramp-version)
   ;; `file-remote-p' is called for everything, even for symbolic
   ;; links which look remote.  We don't want to get an error.
   (let ((non-essential (or non-essential (eq operation 'file-remote-p))))
@@ -5961,10 +5974,10 @@ cleanup of all connections has run."
   "Unload function for tramp-rpc.
 Removes advice and cleans up async processes."
   ;; Remove high-level external operations from tramp-rpc core.
-  (tramp-remove-external-operation 'locate-dominating-file 'tramp-rpc)
-  (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc)
-  (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
-  (tramp-remove-external-operation 'move-file-to-trash 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'locate-dominating-file 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'dir-locals--all-files 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'dir-locals-find-file 'tramp-rpc)
+  (tramp-rpc--remove-external-operation 'move-file-to-trash 'tramp-rpc)
   ;; Unload helper modules explicitly.  Their standard feature unload
   ;; functions perform module-specific cleanup.
   (dolist (feature '(tramp-rpc-advice tramp-rpc-magit tramp-rpc-process

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -217,6 +217,8 @@ This is called from `tramp-multi-hop-p-hook'."
 
 ;; Now the actual implementation
 (require 'cl-lib)
+(require 'json)
+(require 'seq)
 (require 'tramp)
 (require 'tramp-sh)
 (require 'tramp-rpc-protocol)
@@ -496,72 +498,19 @@ proxy hops remain."
                            tramp-postfix-hop-format)
                 tramp-postfix-hop-format)))))
 
-(require 'tramp-rpc-deploy)
-
-(define-error 'tramp-rpc-server-unavailable
-  "TRAMP-RPC server binary is unavailable" 'remote-file-error)
-
-;; Silence byte-compiler warnings for functions defined elsewhere
-;; (vterm variables are declared in tramp-rpc-process.el)
-
-;; Forward declarations for protocol and cache/watch functions.
-(declare-function tramp-rpc-protocol--clear-deferred-polls-for-target
-                  "tramp-rpc-protocol" (target))
-(declare-function tramp-rpc-protocol--clear-deferred-polls
-                  "tramp-rpc-protocol" ())
-
-;; Cache/watch functions (tramp-rpc-magit.el).
-(defvar tramp-rpc--cache-ttl)
-(defvar tramp-rpc--file-exists-cache)
-(defvar tramp-rpc--file-truename-cache)
-(defvar tramp-rpc--file-stat-cache)
-(defvar tramp-rpc--suppress-fs-notifications)
-(defvar tramp-rpc--watched-directories)
-(defvar tramp-rpc-magit--allow-process-cache)
-(declare-function tramp-rpc--cache-get "tramp-rpc-magit")
-(declare-function tramp-rpc--cache-put "tramp-rpc-magit")
-(declare-function tramp-rpc--cache-lookup "tramp-rpc-magit")
-(declare-function tramp-rpc--cache-entry-valid-p "tramp-rpc-magit")
-(declare-function tramp-rpc--file-stat-cache-key "tramp-rpc-magit")
-(declare-function tramp-rpc--cache-file-stat-result "tramp-rpc-magit")
-(declare-function tramp-rpc--invalidate-cache-for-path "tramp-rpc-magit")
-(declare-function tramp-rpc--invalidate-cache-for-subtree "tramp-rpc-magit")
-(declare-function tramp-rpc--connection-key-string "tramp-rpc-magit")
-(declare-function tramp-rpc--directory-watched-p "tramp-rpc-magit")
-(declare-function tramp-rpc--handle-notification "tramp-rpc-magit")
-(declare-function tramp-rpc-watch-directory "tramp-rpc-magit")
-(declare-function tramp-rpc-unwatch-directory "tramp-rpc-magit")
-(declare-function tramp-rpc-clear-file-exists-cache "tramp-rpc-magit")
-(declare-function tramp-rpc-clear-file-truename-cache "tramp-rpc-magit")
-(declare-function tramp-rpc-clear-file-stat-cache "tramp-rpc-magit")
-(declare-function tramp-rpc--clear-file-metadata-caches "tramp-rpc-magit")
-(declare-function tramp-rpc--cleanup-watches-for-connection "tramp-rpc-magit"
-                  (vec &optional connection-process))
-(declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
-(declare-function tramp-rpc--cleanup-pty-processes "tramp-rpc-process")
-(declare-function tramp-rpc--cleanup-process-write-queues "tramp-rpc-process")
-(declare-function tramp-rpc--terminate-async-processes "tramp-rpc-process")
-(declare-function tramp-rpc--terminate-pty-processes "tramp-rpc-process")
-(declare-function tramp-rpc--clear-file-caches-for-connection "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--clear-cache "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--clear-cache-for-connection
-                  "tramp-rpc-magit" (vec))
-(declare-function tramp-rpc-magit--process-cache-lookup "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--process-cache-store "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--file-exists-p "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--clear-status-cache "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--clear-status-cache-for-connection
-                  "tramp-rpc-magit" (vec))
-(declare-function tramp-rpc-magit--prefetch "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--strip-git-prefix-args "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--git-cache-safe-environment-p "tramp-rpc-magit")
-(declare-function tramp-rpc-magit--clear-cache "tramp-rpc-magit")
-(defvar tramp-rpc-magit--debug)
-(defvar tramp-rpc-magit--process-caches)
-
 (defgroup tramp-rpc nil
   "TRAMP backend using RPC."
   :group 'tramp)
+
+;; Helper modules only define functions while the main package is loading.
+;; Runtime integration is installed explicitly after `tramp-rpc' is provided.
+(require 'tramp-rpc-deploy)
+(require 'tramp-rpc-process)
+(require 'tramp-rpc-advice)
+(require 'tramp-rpc-magit)
+
+(define-error 'tramp-rpc-server-unavailable
+  "TRAMP-RPC server binary is unavailable" 'remote-file-error)
 
 (defcustom tramp-rpc-call-timeout 30
   "Maximum seconds to wait for a synchronous RPC call to complete.
@@ -5689,16 +5638,6 @@ Also controls process exit detection latency."
   :type 'integer
   :group 'tramp-rpc)
 
-;; Process support, advice functions, and magit integration are now in
-;; separate modules for better organization and maintainability.
-(require 'tramp-rpc-process)
-;; Loading tramp-rpc-advice while this file is being byte-compiled can
-;; recurse on some Emacs/TRAMP combinations.  Advice is still loaded at
-;; runtime when `tramp-rpc' is required normally.
-(unless (bound-and-true-p byte-compile-current-file)
-  (require 'tramp-rpc-advice))
-(require 'tramp-rpc-magit)
-
 ;; ============================================================================
 ;; File name handler registration
 ;; ============================================================================
@@ -5840,9 +5779,8 @@ Also controls process exit detection latency."
     )
   "Alist of handler functions for TRAMP-RPC method.")
 
-;; Defer registration until tramp-rpc is fully loaded so
-;; `tramp-add-external-operation' can safely `(require 'tramp-rpc)'.
-(with-eval-after-load 'tramp-rpc
+(defun tramp-rpc--install-core-external-operations ()
+  "Install external operations implemented by the core module."
   (tramp-add-external-operation 'locate-dominating-file 'tramp-rpc-handle-locate-dominating-file 'tramp-rpc)
   (tramp-add-external-operation 'dir-locals--all-files 'tramp-rpc-handle-dir-locals--all-files 'tramp-rpc)
   (tramp-add-external-operation 'dir-locals-find-file 'tramp-rpc-handle-dir-locals-find-file 'tramp-rpc)
@@ -5971,16 +5909,31 @@ cleanup of all connections has run."
   ;; `tramp-cleanup-all-connections-hook'.
   )
 
-;; Register cleanup hooks.
-(add-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
-(add-hook 'tramp-cleanup-all-connections-hook #'tramp-rpc-cleanup-all-connections)
-
 ;; ============================================================================
 ;; Unload support
 ;; ============================================================================
 
-(defvar tramp-rpc-unload-hook nil
-  "Hook run by `tramp-rpc-unload-function' to unload helper modules.")
+(defun tramp-rpc--after-load-integrations (_file)
+  "Install integrations whose optional packages have just loaded."
+  (tramp-rpc-process-install-optional-handlers)
+  (tramp-rpc-advice-install-optional-handlers)
+  (tramp-rpc-magit-install-optional-handlers))
+
+(defun tramp-rpc--unload-from-tramp ()
+  "Unload tramp-rpc when TRAMP itself is unloaded."
+  (when (featurep 'tramp-rpc)
+    (unload-feature 'tramp-rpc 'force)))
+
+(defun tramp-rpc--install ()
+  "Install TRAMP-RPC operations, advice, and lifecycle hooks."
+  (tramp-rpc--install-core-external-operations)
+  (tramp-rpc-handler-install)
+  (tramp-rpc--after-load-integrations nil)
+  (add-hook 'after-load-functions #'tramp-rpc--after-load-integrations)
+  (add-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
+  (add-hook 'tramp-cleanup-all-connections-hook
+            #'tramp-rpc-cleanup-all-connections)
+  (add-hook 'tramp-unload-hook #'tramp-rpc--unload-from-tramp))
 
 (defun tramp-rpc-unload-function ()
   "Unload function for tramp-rpc.
@@ -5990,17 +5943,18 @@ Removes advice and cleans up async processes."
   (tramp-remove-external-operation 'dir-locals--all-files 'tramp-rpc)
   (tramp-remove-external-operation 'dir-locals-find-file 'tramp-rpc)
   (tramp-remove-external-operation 'move-file-to-trash 'tramp-rpc)
-  ;; Unload helper modules.  `tramp-rpc.el' requires these modules, so
-  ;; unloading only the top-level feature and loading it again would otherwise
-  ;; leave stale definitions in place (notably `tramp-rpc-process.el').  Helper
-  ;; unload functions also perform their own cleanup before removing symbols.
-  ;; Helper hook entries are idempotent because unloading one helper can unload
-  ;; another as a dependency before its hook entry is reached.
-  (run-hooks 'tramp-rpc-unload-hook)
+  ;; Unload helper modules explicitly.  Their standard feature unload
+  ;; functions perform module-specific cleanup.
+  (dolist (feature '(tramp-rpc-advice tramp-rpc-magit tramp-rpc-process
+                     tramp-rpc-deploy tramp-rpc-protocol))
+    (when (featurep feature)
+      (unload-feature feature 'force)))
   ;; Remove multi-hop hook and cleanup hooks.
+  (remove-hook 'after-load-functions #'tramp-rpc--after-load-integrations)
   (remove-hook 'tramp-multi-hop-p-hook #'tramp-rpc-multi-hop-p)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)
   (remove-hook 'tramp-cleanup-all-connections-hook #'tramp-rpc-cleanup-all-connections)
+  (remove-hook 'tramp-unload-hook #'tramp-rpc--unload-from-tramp)
   ;; Remove method registrations.
   (setq tramp-methods (delete (assoc tramp-rpc-method tramp-methods) tramp-methods))
   (setq tramp-foreign-file-name-handler-alist
@@ -6014,9 +5968,13 @@ Removes advice and cleans up async processes."
   ;; Return nil to allow normal unload to proceed
   nil)
 
-(add-hook 'tramp-unload-hook
-	  (lambda ()
-	    (unload-feature 'tramp-rpc 'force)))
-
 (provide 'tramp-rpc)
+(condition-case err
+    (tramp-rpc--install)
+  (error
+   ;; `tramp-add-external-operation' requires the backend feature, so the
+   ;; feature must be visible during installation.  Do not leave a partially
+   ;; initialized package marked as loaded when installation fails.
+   (setq features (delq 'tramp-rpc features))
+   (signal (car err) (cdr err))))
 ;;; tramp-rpc.el ends here

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -67,7 +67,11 @@
   "TRAMP method for RPC-based remote access.")
 
 ;;;###autoload
-(with-eval-after-load 'tramp
+(eval-and-compile
+  ;; The autoload file must initialize TRAMP before registering the method.
+  ;; This avoids deferred definitions and lets the byte compiler validate every
+  ;; TRAMP variable and function referenced by the registration code.
+  (require 'tramp)
   ;; Check, that `tramp-rpc-method' is still bound.  It isn't after
   ;; unloading `tramp-rpc', but this body still exists as compiled
   ;; function in `after-load-alist'.
@@ -109,15 +113,14 @@
    `(:application tramp :protocol ,tramp-rpc-method)
    'tramp-rpc-connection-local-default-profile)
 
-  ;; Define the predicate inline (as defsubst) so it's available without
+  ;; Define the predicate in the autoload file so it is available without
   ;; loading tramp-rpc.el.  This avoids recursive autoloading: TRAMP calls
   ;; the predicate to decide which handler to use, and if it were an
   ;; autoload stub it would load tramp-rpc.el which `(require 'tramp)'.
-  ;; Reference TRAMP uses the same pattern (defsubst in tramp-loaddefs.el).
   (defvar tramp-rpc--sudo-file-name-p-in-progress nil
     "Non-nil while checking hidden rpc+sudo proxy expansion.")
 
-  (defsubst tramp-rpc-file-name-p (vec-or-filename)
+  (defun tramp-rpc-file-name-p (vec-or-filename)
     "Check if VEC-OR-FILENAME is handled by TRAMP-RPC."
     (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename)))
       (string= (tramp-file-name-method vec) tramp-rpc-method)))
@@ -125,7 +128,7 @@
   ;; Detect privilege elevation paths with rpc hops, e.g.
   ;; /rpc:user@host|sudo:root@host:/path.  These are handled by the
   ;; tramp-rpc handler which starts the RPC server via sudo.
-  (defsubst tramp-rpc--sudo-file-name-p (vec-or-filename)
+  (defun tramp-rpc--sudo-file-name-p (vec-or-filename)
     "Check if VEC-OR-FILENAME is a privilege elevation with an rpc hop."
     (when-let* ((vec (tramp-ensure-dissected-file-name vec-or-filename))
                 (target-host (tramp-file-name-host vec)))
@@ -225,11 +228,10 @@ This is called from `tramp-multi-hop-p-hook'."
   (error "Tramp RPC requires Tramp >= 2.8.1.4, but %s is loaded"
          tramp-version))
 
-;; Silence byte-compiler warnings for functions defined in with-eval-after-load
-(declare-function tramp-add-external-operation "tramp")
-(declare-function tramp-remove-external-operation "tramp")
-(declare-function tramp-handle-insert-directory "tramp")
 (declare-function dired-compress-file "dired-aux")
+;; These predicates are emitted inside the single autoload form above.  The
+;; compiler does not discover nested definitions, so declare only those two
+;; autoload-owned functions used by the full implementation below.
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
 
@@ -390,9 +392,6 @@ avoids breakage if callers supply numeric defaults."
   (cond ((stringp port) port)
         ((numberp port) (number-to-string port))
         (t nil)))
-
-(declare-function tramp-read-passwd "tramp")
-(declare-function tramp-clear-passwd "tramp" (vec))
 
 (defun tramp-rpc--sudo-auth-vec (vec)
   "Return the unprivileged rpc vector used to validate sudo for VEC."
@@ -5871,8 +5870,8 @@ pattern in `tramp-file-name-handler'."
 ;; Method predicate and handler registration
 ;; ============================================================================
 
-;; `tramp-rpc-file-name-p' is defined as defsubst in the with-eval-after-load
-;; block above (extracted into autoloads).  Re-define it here as defun for
+;; `tramp-rpc-file-name-p' is defined in the autoload block above.  Re-define
+;; it here so the installed implementation is associated with this source file for
 ;; the full-load case so it gets proper byte-compilation.
 (defun tramp-rpc-file-name-p (vec-or-filename)
   "Check if VEC-OR-FILENAME is handled by TRAMP-RPC.
@@ -5881,7 +5880,7 @@ VEC-OR-FILENAME can be either a tramp-file-name struct or a filename string."
     (string= (tramp-file-name-method vec) tramp-rpc-method)))
 
 ;; Re-register with the full defun now that the file is loaded.
-;; (Already registered via with-eval-after-load, but this ensures the
+;; (Already registered by the autoload code, but this ensures the
 ;; byte-compiled defun version is used.)
 (tramp-register-foreign-file-name-handler
  #'tramp-rpc-file-name-p #'tramp-rpc-file-name-handler)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1590,7 +1590,7 @@ Returns non-nil on success."
     ;; create a ControlMaster on top of a stale ControlPath, which later shows
     ;; up as a generic "Tramp failed to connect" during unrelated file ops.
     (when (file-exists-p socket-path)
-      (ignore-errors (delete-file socket-path)))
+      (delete-file socket-path))
     (with-current-buffer buffer
       (erase-buffer))
     (let (success)
@@ -1881,7 +1881,9 @@ probe can then interleave with RPC startup and corrupt the protocol stream."
              ;; Do not tear down a socket that still answers ControlMaster
              ;; checks merely because authentication failed for another reason.
              (signal (car err) (cdr err))
-           (ignore-errors (delete-file socket-path))
+           (condition-case nil
+               (delete-file socket-path)
+             (file-missing nil))
            (sleep-for 0.1)
            (condition-case nil
                (tramp-rpc--establish-controlmaster vec)
@@ -1991,12 +1993,15 @@ down VEC's ControlMaster in that case would disrupt the still-live connection."
       ;; Close the ControlMaster socket gracefully via ssh -O exit.
       ;; This is a local control message (no network round-trip), so fast.
       (when (file-exists-p socket-path)
-        (ignore-errors
-          (apply #'call-process "ssh" nil nil nil
-                 (append
-                  (tramp-rpc--ssh-identity-args user port proxyjump)
-                  (list "-o" (format "ControlPath=%s" socket-path)
-                        "-O" "exit" host)))))
+        (condition-case err
+            (apply #'call-process "ssh" nil nil nil
+                   (append
+                    (tramp-rpc--ssh-identity-args user port proxyjump)
+                    (list "-o" (format "ControlPath=%s" socket-path)
+                          "-O" "exit" host)))
+          (file-error
+           (tramp-rpc--debug "ControlMaster cleanup failed: %s"
+                             (error-message-string err)))))
       ;; Kill the auth process.
       (when (and auth-process (process-live-p auth-process))
         (delete-process auth-process))
@@ -5128,7 +5133,12 @@ Keys are the same connection/path keys as `tramp-rpc--watched-directories'.")
 
 (defun tramp-rpc--file-notify-monitor (vec)
   "Return the file notification monitor symbol for VEC."
-  (let* ((info (ignore-errors (tramp-rpc--system-info vec)))
+  (let* ((info (condition-case err
+                   (tramp-rpc--system-info vec)
+                 (error
+                  (tramp-rpc--debug "system.info probe failed: %s"
+                                    (error-message-string err))
+                  nil)))
          (watcher (and (listp info)
                        (tramp-rpc--decode-string (alist-get 'watcher info))))
          (os (and (listp info)
@@ -5507,7 +5517,13 @@ FLAGS controls the requested operation."
            ;; file-notify does not follow symlinks.  Ask the server for a
            ;; nofollow symlink watch when needed, falling back to a synthetic
            ;; client-side descriptor on platforms without nofollow support.
-           (symlink-watch (ignore-errors (file-symlink-p directory)))
+           (symlink-watch
+            (condition-case err
+                (file-symlink-p directory)
+              (error
+               (tramp-rpc--debug "symlink watch probe failed for %s: %s"
+                                 directory (error-message-string err))
+               nil)))
            (descriptor (tramp-rpc--make-file-notify-descriptor
                         v directory localname)))
       (if entry
@@ -5555,8 +5571,14 @@ FLAGS controls the requested operation."
                                      ;; truename path as a best-effort match key
                                      ;; for symlinked watched directories.
                                      (preexisting
-                                      (ignore-errors
-                                        (file-truename directory))))))
+                                      (condition-case err
+                                          (file-truename directory)
+                                        (error
+                                         (tramp-rpc--debug
+                                          "watch truename probe failed for %s: %s"
+                                          directory
+                                          (error-message-string err))
+                                         nil))))))
           (puthash watch-key
                    (list :count 1
                          :owned (and (not preexisting) (not synthetic))

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Command execution and ancestor scanning for TRAMP-RPC
 //!
 //! This module provides:

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Directory operations
 //!
 //! Optimized to use:

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! File metadata operations
 
 use crate::protocol::{FileAttributes, FileType, RpcError, from_value};

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! File I/O operations
 
 use crate::msgpack_map;

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Request handlers for TRAMP-RPC operations
 
 pub mod commands;

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Process execution operations
 
 use crate::msgpack_map;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! TRAMP-RPC Server
 //!
 //! A MessagePack-RPC server for TRAMP remote file access.

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! MessagePack-RPC protocol types for TRAMP-RPC
 
 use rmpv::Value;

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Filesystem watcher for cache invalidation notifications.
 //!
 //! Uses inotify (Linux) / kqueue (macOS) via the `notify` crate to watch

--- a/test/tramp-rpc-autoload-tests.el
+++ b/test/tramp-rpc-autoload-tests.el
@@ -165,19 +165,18 @@ This allows testing autoload behavior in a clean state."
   ;; Handler should be defined as autoload stub
   (should (fboundp 'tramp-rpc-file-name-handler))
   (should (autoloadp (symbol-function 'tramp-rpc-file-name-handler)))
-  ;; Predicate is NOT defined yet -- it's inside with-eval-after-load 'tramp
-  ;; so it only becomes available after tramp loads
-  (should-not (fboundp 'tramp-rpc-file-name-p)))
+  ;; The predicate is defined directly by the autoload registration form so
+  ;; handler lookup never recursively loads the full package.
+  (should (fboundp 'tramp-rpc-file-name-p))
+  (should-not (autoloadp (symbol-function 'tramp-rpc-file-name-p))))
 
 (ert-deftest tramp-rpc-autoload-test-method-registration ()
   "Test that the method inherits ssh parameters when tramp loads."
   (tramp-rpc-autoload-test--clean-environment)
   (tramp-rpc-autoload-test--generate-autoloads)
   (load tramp-rpc-autoload-test--autoloads-file nil t)
-  ;; Before loading tramp, method should not be in tramp-methods
-  ;; (tramp-methods may not even exist yet)
-  ;; Load tramp
-  (require 'tramp)
+  ;; Loading the autoload file initializes TRAMP before registering the method.
+  (should (featurep 'tramp))
   ;; Shell-based chains through an rpc hop are handled by tramp-sh without
   ;; loading tramp-rpc.el, so the autoloaded method must be usable as ssh.
   (should (assoc "rpc" tramp-methods))
@@ -211,7 +210,7 @@ This allows testing autoload behavior in a clean state."
   (add-to-list 'load-path tramp-rpc-autoload-test--lisp-dir)
   (load tramp-rpc-autoload-test--autoloads-file nil t)
   (require 'tramp)
-  ;; Predicate should be defined inline (defsubst from with-eval-after-load),
+  ;; Predicate should be defined directly by the autoload registration form,
   ;; NOT as an autoload stub.  This is the key fix: calling the predicate
   ;; must not trigger loading tramp-rpc.el to avoid recursive autoloading.
   (should (fboundp 'tramp-rpc-file-name-p))
@@ -225,15 +224,11 @@ This allows testing autoload behavior in a clean state."
   (tramp-rpc-autoload-test--generate-autoloads)
   (add-to-list 'load-path tramp-rpc-autoload-test--lisp-dir)
   (load tramp-rpc-autoload-test--autoloads-file nil t)
-  ;; Before loading tramp, handler should not be registered
-  (should-not (rassq 'tramp-rpc-file-name-handler
-                     tramp-foreign-file-name-handler-alist))
-  ;; Load tramp - this triggers with-eval-after-load which registers handler
-  (require 'tramp)
-  ;; Now handler should be registered via tramp-register-foreign-file-name-handler
+  ;; Loading autoloads initializes TRAMP and registers the handler immediately.
+  (should (featurep 'tramp))
   (should (rassq 'tramp-rpc-file-name-handler
                  tramp-foreign-file-name-handler-alist))
-  ;; The predicate should be a real function (defsubst), not an autoload
+  ;; The predicate should be a real function, not an autoload.
   (should (fboundp 'tramp-rpc-file-name-p))
   (should-not (autoloadp (symbol-function 'tramp-rpc-file-name-p))))
 
@@ -319,10 +314,10 @@ This allows testing autoload behavior in a clean state."
       (should (string-match-p "defconst tramp-rpc-method" content))
       ;; Should have autoload for handler
       (should (string-match-p "autoload.*tramp-rpc-file-name-handler" content))
-      ;; Should have with-eval-after-load
-      (should (string-match-p "with-eval-after-load 'tramp" content))
-      ;; Should define predicate inline (defsubst, not autoload stub)
-      (should (string-match-p "defsubst tramp-rpc-file-name-p" content))
+      ;; Should initialize TRAMP within the autoload registration form.
+      (should (string-match-p "require 'tramp" content))
+      ;; Should define predicate inline, not as an autoload stub.
+      (should (string-match-p "defun tramp-rpc-file-name-p" content))
       ;; Should NOT have an autoload stub for file-name-p
       (should-not (string-match-p "autoload.*tramp-rpc-file-name-p" content))
       ;; Should add to tramp-methods


### PR DESCRIPTION
## Summary

- fix the byte-compiler, package-lint, checkdoc, check-declare, melpazoid, style, and license findings reported in melpa/melpa#10181
- replace deferred internal setup and broad error suppression with explicit installers and logged/checked cleanup
- make CI fail on the same warning classes and add a warning-fatal melpazoid workflow using the submitted MELPA recipe
- preserve a clear runtime error when an unsupported bundled TRAMP is used while allowing MELPA tooling to inspect the package
- do not persist the Actions token on the runner and restrict the melpazoid job to read-only permission, since the job executes third-party code




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection, deployment, process, and cache error handling with clearer diagnostics.
  - Improved protocol response parsing and cleanup behavior.
  - Improved compatibility with TRAMP and optional integrations, including Magit, Projectile, vterm, and eat.

- **Maintenance**
  - Added automated package-quality checks and strengthened build validation.
  - Added license identification across server components.
  - Expanded autoload and initialization tests for more reliable startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->