### PR TITLE
Reduce duplication and prevent cache drift

### DIFF
--- a/benchmark/benchmark-magit-detailed.el
+++ b/benchmark/benchmark-magit-detailed.el
@@ -22,7 +22,7 @@
 ;; Silence byte-compiler warnings
 (declare-function tramp-rpc--call "tramp-rpc")
 (declare-function tramp-rpc--call-pipelined "tramp-rpc")
-(declare-function tramp-rpc-run-git-commands "tramp-rpc")
+
 (declare-function tramp-rpc-magit--prefetch-git-commands "tramp-rpc-magit")
 (declare-function tramp-rpc--decode-output "tramp-rpc")
 (declare-function tramp-rpc-magit-enable "tramp-rpc-magit")
@@ -42,9 +42,32 @@
 
 (defmacro tramp-rpc-magit-bench--time (&rest body)
   "Execute BODY and return elapsed time in seconds."
+  (declare (indent 0) (debug t))
   `(let ((start (current-time)))
      ,@body
      (float-time (time-subtract (current-time) start))))
+
+(defun tramp-rpc-magit-bench--run-git-commands (directory commands)
+  "Run git COMMANDS in DIRECTORY using pipelined RPC."
+  (with-parsed-tramp-file-name directory nil
+    (let* ((requests
+            (mapcar (lambda (args)
+                      (cons "process.run"
+                            `((cmd . "git")
+                              (args . ,(vconcat args))
+                              (cwd . ,(file-name-unquote localname)))))
+                    commands))
+           (results (tramp-rpc--call-pipelined v requests)))
+      (mapcar (lambda (result)
+                (if (plist-get result :error)
+                    (list :exit-code -1 :stdout ""
+                          :stderr (or (plist-get result :message) "RPC error"))
+                  (list :exit-code (alist-get 'exit_code result)
+                        :stdout (tramp-rpc--decode-output
+                                 (alist-get 'stdout result))
+                        :stderr (tramp-rpc--decode-output
+                                 (alist-get 'stderr result)))))
+              results))))
 
 (defvar tramp-rpc-magit-bench--process-file-log nil
   "Log of process-file calls during benchmarking.")
@@ -129,7 +152,8 @@
       ;; Time batched execution using new API
       (setq batch-time
             (tramp-rpc-magit-bench--time
-             (tramp-rpc-run-git-commands default-directory commands)))
+             (tramp-rpc-magit-bench--run-git-commands
+              default-directory commands)))
 
       (with-current-buffer (get-buffer-create "*Batching Comparison*")
         (erase-buffer)

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -156,7 +156,7 @@ Return `not-managed' when PROCESS must use the native handler."
          proc)))
 
 (defun tramp-rpc-handle-process-send-string (process string)
-  "Handler for `process-send-string' for TRAMP-RPC processes."
+  "Send STRING to the TRAMP-RPC PROCESS."
   (when (eq (tramp-rpc--send-managed-process-string
              process string "SEND-STRING")
             'not-managed)

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -33,7 +33,6 @@
 
 (require 'tramp)
 (require 'msgpack)
-(require 'seq)
 
 ;; Functions from tramp-rpc-process.el
 (declare-function tramp-rpc--write-remote-process "tramp-rpc-process"
@@ -44,7 +43,6 @@
                   (vec pid &optional owner-process))
 (declare-function tramp-rpc--kill-remote-process "tramp-rpc-process"
                   (vec pid &optional signal connection))
-(declare-function tramp-rpc--cleanup-async-processes "tramp-rpc-process")
 
 ;; Functions from tramp-rpc.el
 (declare-function tramp-rpc--debug "tramp-rpc")
@@ -57,7 +55,6 @@
 ;; Variables from tramp-rpc.el / tramp-rpc-process.el
 (defvar tramp-rpc--delivering-output)
 (defvar tramp-rpc--closing-local-relay)
-(defvar tramp-rpc--pty-processes)
 (defvar tramp-rpc--async-processes)
 (defvar tramp-rpc-synchronous-pipe-writes)
 
@@ -114,98 +111,67 @@ PROCESS is the process being handled."
 ;; Process I/O handler
 ;; ============================================================================
 
+(defun tramp-rpc--resolve-process (process)
+  "Return the process object denoted by PROCESS, or nil."
+  (cond
+   ((processp process) process)
+   ((bufferp process) (get-buffer-process process))
+   ((stringp process)
+    (when-let* ((buffer (get-buffer process)))
+      (get-buffer-process buffer)))))
+
+(defun tramp-rpc--send-managed-process-string (process string operation)
+  "Send STRING to RPC-managed PROCESS for OPERATION.
+Return `not-managed' when PROCESS must use the native handler."
+  (let ((proc (tramp-rpc--managed-send-process process)))
+    (cond
+     ((not proc) 'not-managed)
+     ((process-get proc :tramp-rpc-pty)
+      (let ((vec (process-get proc :tramp-rpc-vec))
+            (pid (process-get proc :tramp-rpc-pid)))
+        (tramp-rpc--debug "%s PTY pid=%s len=%d" operation pid (length string))
+        (tramp-rpc--call
+         vec "process.write_pty"
+         `((pid . ,pid)
+           (data . ,(msgpack-bin-make
+                     (tramp-rpc--encode-process-input proc string))))
+         (process-get proc :tramp-rpc-connection))
+        nil))
+     (t
+      (let ((vec (process-get proc :tramp-rpc-vec))
+            (pid (process-get proc :tramp-rpc-pid)))
+        (tramp-rpc--debug "%s pipe pid=%s len=%d" operation pid (length string))
+        (tramp-rpc--write-remote-process
+         vec pid (tramp-rpc--encode-process-input proc string) proc)
+        (when tramp-rpc-synchronous-pipe-writes
+          (tramp-rpc--drain-write-queue vec pid proc)))))))
+
+(defun tramp-rpc--managed-send-process (process)
+  "Return PROCESS's RPC-managed process, or nil when native delivery is needed."
+  (when-let* ((proc (tramp-rpc--resolve-process process)))
+    (and (not tramp-rpc--delivering-output)
+         (not (process-get proc :tramp-rpc-direct-ssh))
+         (process-get proc :tramp-rpc-pid)
+         (process-get proc :tramp-rpc-vec)
+         proc)))
+
 (defun tramp-rpc-handle-process-send-string (process string)
-  "Handler for `process-send-string' for TRAMP-RPC processes.
-PROCESS is the process being handled.
-STRING is the text being handled."
-  ;; If we're delivering output to the local relay, bypass this handler
-  (if tramp-rpc--delivering-output
-      (tramp-run-real-handler #'process-send-string (list process string))
-    ;; process-send-string can receive a buffer/buffer-name instead of process
-    (let ((proc (cond
-                 ((processp process) process)
-                 ((or (bufferp process) (stringp process))
-                  (get-buffer-process (get-buffer process)))
-                 (t nil))))
-      (cond
-       ;; Direct SSH PTY - use normal process-send-string (low latency)
-       ((and proc (process-get proc :tramp-rpc-direct-ssh))
-        (tramp-run-real-handler #'process-send-string (list process string)))
-       ;; RPC-based PTY process - use PTY write (async, fire-and-forget)
-       ((and proc (process-get proc :tramp-rpc-pty)
-             (process-get proc :tramp-rpc-pid))
-        (let ((vec (process-get proc :tramp-rpc-vec))
-              (pid (process-get proc :tramp-rpc-pid)))
-          (tramp-rpc--debug "SEND-STRING PTY pid=%s len=%d" pid (length string))
-          ;; Match local `process-send-string' semantics: return only after the
-          ;; bytes reached the remote PTY's kernel buffer.
-          (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
-            (tramp-rpc--call vec "process.write_pty"
-                             `((pid . ,pid)
-                               (data . ,(msgpack-bin-make data-bytes)))
-                             (process-get proc :tramp-rpc-connection)))
-          nil))
-       ;; Regular async RPC process (pipe-based)
-       ((and proc
-             (process-get proc :tramp-rpc-pid)
-             (process-get proc :tramp-rpc-vec)
-             (not (process-get proc :tramp-rpc-pty)))
-        (tramp-rpc--debug "SEND-STRING pipe pid=%s len=%d"
-                         (process-get proc :tramp-rpc-pid) (length string))
-        (let ((vec (process-get proc :tramp-rpc-vec))
-              (pid (process-get proc :tramp-rpc-pid)))
-          (tramp-rpc--write-remote-process
-           vec pid (tramp-rpc--encode-process-input proc string) proc)
-          (when tramp-rpc-synchronous-pipe-writes
-            (tramp-rpc--drain-write-queue vec pid proc))))
-       ;; Not an RPC process, use original function
-       (t (tramp-run-real-handler #'process-send-string (list process string)))))))
+  "Handler for `process-send-string' for TRAMP-RPC processes."
+  (when (eq (tramp-rpc--send-managed-process-string
+             process string "SEND-STRING")
+            'not-managed)
+    (tramp-run-real-handler #'process-send-string (list process string))))
 
 (defun tramp-rpc-handle-process-send-region (process start end)
   "Handler for `process-send-region' for TRAMP-RPC processes.
 PROCESS is the process being handled.
 START and END are buffer positions delimiting the text to send."
-  ;; If we're delivering output to the local relay, bypass this handler
-  (if tramp-rpc--delivering-output
-      (tramp-run-real-handler #'process-send-region (list process start end))
-    (let ((proc (cond
-                 ((processp process) process)
-                 ((or (bufferp process) (stringp process))
-                  (get-buffer-process (get-buffer process)))
-                 (t nil))))
-      (cond
-       ;; Direct SSH PTY - use normal process-send-region (low latency)
-       ((and proc (process-get proc :tramp-rpc-direct-ssh))
-        (tramp-run-real-handler #'process-send-region (list process start end)))
-       ;; RPC-based PTY process - use PTY write
-       ((and proc (process-get proc :tramp-rpc-pty)
-             (process-get proc :tramp-rpc-pid))
-        (let ((vec (process-get proc :tramp-rpc-vec))
-              (pid (process-get proc :tramp-rpc-pid))
-              (string (buffer-substring-no-properties start end)))
-          (tramp-rpc--debug "SEND-REGION PTY pid=%s len=%d" pid (length string))
-          (let ((data-bytes (tramp-rpc--encode-process-input proc string)))
-            (tramp-rpc--call vec "process.write_pty"
-                             `((pid . ,pid)
-                               (data . ,(msgpack-bin-make data-bytes)))
-                             (process-get proc :tramp-rpc-connection)))
-          nil))
-       ;; Regular async RPC process (pipe-based)
-       ((and proc
-             (process-get proc :tramp-rpc-pid)
-             (process-get proc :tramp-rpc-vec)
-             (not (process-get proc :tramp-rpc-pty)))
-        (let ((string (buffer-substring-no-properties start end)))
-          (tramp-rpc--debug "SEND-REGION pipe pid=%s len=%d"
-                           (process-get proc :tramp-rpc-pid) (length string))
-          (let ((vec (process-get proc :tramp-rpc-vec))
-                (pid (process-get proc :tramp-rpc-pid)))
-            (tramp-rpc--write-remote-process
-             vec pid (tramp-rpc--encode-process-input proc string) proc)
-            (when tramp-rpc-synchronous-pipe-writes
-              (tramp-rpc--drain-write-queue vec pid proc)))))
-       ;; Not an RPC process, use original function
-       (t (tramp-run-real-handler #'process-send-region (list process start end)))))))
+  (if-let* ((proc (tramp-rpc--managed-send-process process)))
+      (tramp-rpc--send-managed-process-string
+       proc (buffer-substring-no-properties start end) "SEND-REGION")
+    ;; Preserve native region delivery for bypasses and non-RPC processes.
+    (tramp-run-real-handler #'process-send-region
+                            (list process start end))))
 
 (defun tramp-rpc-handle-process-send-eof (&optional process)
   "Handler for `process-send-eof' for TRAMP-RPC processes.

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -270,7 +270,9 @@ Legacy methods (use inline encoding for file transfer):
 
 (defcustom tramp-rpc-deploy-debug nil
   "When non-nil, log verbose debug messages during deployment.
-Messages are logged to *tramp-rpc-deploy* buffer."
+Messages are logged to *tramp-rpc-deploy*.  TRAMP_RPC_DEPLOY_DEBUG_LOG names
+an additional log file; otherwise TRAMP_RPC_DEBUG_DIR writes
+tramp-rpc-deploy-live.log in that directory."
   :type 'boolean
   :group 'tramp-rpc-deploy)
 
@@ -349,6 +351,33 @@ standard TRAMP can traverse them."
                  (tramp-rpc--proxy-hop-string vec)
                (tramp-file-name-hop vec)))))))
 
+(defconst tramp-rpc-deploy--architecture-aliases
+  '(("amd64" . "x86_64")
+    ("arm64" . "aarch64")
+    ("armv7l" . "armv7")
+    ("armv6l" . "arm")
+    ("armv5tel" . "armv5te"))
+  "Machine-name aliases accepted during architecture detection.")
+
+(defconst tramp-rpc-deploy--artifact-targets
+  '(("x86_64-linux" . "x86_64-unknown-linux-musl")
+    ("aarch64-linux" . "aarch64-unknown-linux-musl")
+    ("i686-linux" . "i686-unknown-linux-musl")
+    ("armv7-linux" . "armv7-unknown-linux-musleabihf")
+    ("armv5te-linux" . "armv5te-unknown-linux-musleabi")
+    ("arm-linux" . "arm-unknown-linux-musleabihf")
+    ("x86_64-darwin" . "x86_64-apple-darwin")
+    ("aarch64-darwin" . "aarch64-apple-darwin"))
+  "Supported release artifact architectures and Rust target triples.")
+
+(defun tramp-rpc-deploy--normalize-machine (machine)
+  "Return canonical spelling for MACHINE while accepting known aliases."
+  (or (cdr (assoc machine tramp-rpc-deploy--architecture-aliases)) machine))
+
+(defun tramp-rpc-deploy--supported-architectures ()
+  "Return supported release artifact architecture names."
+  (mapcar #'car tramp-rpc-deploy--artifact-targets))
+
 (defun tramp-rpc-deploy--detect-remote-arch (vec)
   "Detect the architecture of remote host specified by VEC.
 Returns a string like \"x86_64-linux\" or \"aarch64-darwin\"."
@@ -358,46 +387,27 @@ Returns a string like \"x86_64-linux\" or \"aarch64-darwin\"."
          (uname-s (string-trim
                    (tramp-send-command-and-read
                     vec "echo \\\"`uname -s`\\\"")))
-         (arch (pcase uname-m
-                 ("x86_64" "x86_64")
-                 ("amd64" "x86_64")
-                 ("aarch64" "aarch64")
-                 ("arm64" "aarch64")
-                 ("i686" "i686")
-                 (_ uname-m)))
-         (os (pcase (downcase uname-s)
-               ("linux" "linux")
-               ("darwin" "darwin")
-               (_ (downcase uname-s)))))
-    (format "%s-%s" arch os)))
+         (machine (tramp-rpc-deploy--normalize-machine uname-m))
+         (os (downcase uname-s)))
+    (format "%s-%s" machine os)))
 
 (defun tramp-rpc-deploy--detect-local-arch ()
   "Detect the architecture of the local system.
 Returns a string like \"x86_64-linux\" or \"aarch64-darwin\"."
-  (let* ((arch (pcase system-type
-                 ('gnu/linux "linux")
-                 ('darwin "darwin")
-                 (_ (symbol-name system-type))))
+  (let* ((os (pcase system-type
+               ('gnu/linux "linux")
+               ('darwin "darwin")
+               (_ (symbol-name system-type))))
          (machine (car (split-string system-configuration "-")))
-         (normalized-machine (pcase machine
-                               ("x86_64" "x86_64")
-                               ("aarch64" "aarch64")
-                               ("arm64" "aarch64")
-                               ("i686" "i686")
-                               (_ machine))))
-    (format "%s-%s" normalized-machine arch)))
+         (normalized-machine (tramp-rpc-deploy--normalize-machine machine)))
+    (format "%s-%s" normalized-machine os)))
 
 (defun tramp-rpc-deploy--arch-to-rust-target (arch)
   "Convert ARCH string to Rust target triple.
 E.g., \"x86_64-linux\" -> \"x86_64-unknown-linux-musl\".
 Linux targets use musl for fully static binaries."
-  (pcase arch
-    ("x86_64-linux" "x86_64-unknown-linux-musl")
-    ("aarch64-linux" "aarch64-unknown-linux-musl")
-    ("i686-linux" "i686-unknown-linux-musl")
-    ("x86_64-darwin" "x86_64-apple-darwin")
-    ("aarch64-darwin" "aarch64-apple-darwin")
-    (_ (signal 'remote-file-error (list "Unknown architecture" arch)))))
+  (or (cdr (assoc arch tramp-rpc-deploy--artifact-targets))
+      (signal 'remote-file-error (list "Unknown architecture" arch))))
 
 (defun tramp-rpc-deploy--source-root ()
   "Return the configured source root as a directory name, or nil."
@@ -1030,15 +1040,44 @@ Returns the path to the local binary."
 ;;; Remote deployment
 ;; ============================================================================
 
+(defun tramp-rpc-deploy--regular-nonsymlink-test (path &optional executable)
+  "Return a shell test for regular, non-symlink PATH.
+When EXECUTABLE is non-nil, require execute permission too."
+  (let ((quoted (tramp-shell-quote-argument path)))
+    (format "test -f %s && ! test -L %s%s"
+            quoted quoted (if executable (format " && test -x %s" quoted) ""))))
+
+(defun tramp-rpc-deploy--checksum-shell-fragment (path)
+  "Return a shell fragment that prints PATH's SHA256 digest."
+  (let ((quoted (tramp-shell-quote-argument path)))
+    (format "{ sha256sum %s 2>/dev/null || shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1"
+            quoted quoted)))
+
+(defun tramp-rpc-deploy--activation-command (temporary destination checksum)
+  "Build the atomic remote activation transaction.
+TEMPORARY and DESTINATION are remote local names.  CHECKSUM is the expected
+SHA256 digest."
+  (let ((tmp (tramp-shell-quote-argument temporary))
+        (dest (tramp-shell-quote-argument destination))
+        (digest (tramp-shell-quote-argument checksum)))
+    (format
+     "%s && chmod +x %s && %s && (test ! -e %s && ! test -L %s || %s) && actual=$(%s) && test \"$actual\" = %s && mv -f %s %s && %s"
+     (tramp-rpc-deploy--regular-nonsymlink-test temporary)
+     tmp
+     (tramp-rpc-deploy--regular-nonsymlink-test temporary)
+     dest dest
+     (tramp-rpc-deploy--regular-nonsymlink-test destination)
+     (tramp-rpc-deploy--checksum-shell-fragment temporary)
+     digest tmp dest
+     (tramp-rpc-deploy--regular-nonsymlink-test destination t))))
+
 (defun tramp-rpc-deploy--remote-binary-exists-p (vec)
   "Check if a regular non-symlink executable binary exists on remote VEC."
   (let* ((remote-path (tramp-rpc-deploy--remote-binary-path vec))
-         (path (tramp-shell-quote-argument
-                (tramp-file-local-name remote-path))))
+         (path (tramp-file-local-name remote-path)))
     ;; Use tramp-sh operations for checking since we're bootstrapping.
     (tramp-send-command-and-check
-     vec (format "test -f %s && ! test -L %s && test -x %s"
-                 path path path))))
+     vec (tramp-rpc-deploy--regular-nonsymlink-test path t))))
 
 (defun tramp-rpc-deploy--ensure-remote-directory (vec)
   "Ensure the remote deployment directory exists on VEC."
@@ -1057,10 +1096,7 @@ Returns the path to the local binary."
   "Get SHA256 checksum of remote PATH on VEC.
 Tries sha256sum first, then shasum -a 256 for macOS compatibility."
   ;; Try sha256sum first (Linux), then shasum -a 256 (macOS)
-  (tramp-send-command vec
-   (format "{ sha256sum %s 2>/dev/null || shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1"
-           (tramp-shell-quote-argument path)
-           (tramp-shell-quote-argument path)))
+  (tramp-send-command vec (tramp-rpc-deploy--checksum-shell-fragment path))
   (with-current-buffer (tramp-get-connection-buffer vec)
     (goto-char (point-min))
     ;; Match exactly 64 hex chars to avoid false positives from error messages
@@ -1188,18 +1224,8 @@ to inline encoding (base64 through the shell), which can be fragile."
                   (unless
                       (tramp-send-command-and-check
                        vec
-                       (let ((tmp (tramp-shell-quote-argument remote-tmp-local))
-                             (dest (tramp-shell-quote-argument remote-local))
-                             (digest (tramp-shell-quote-argument local-checksum)))
-                         (format
-                          "test -f %s && ! test -L %s && chmod +x %s && \
-test -f %s && ! test -L %s && \
-(test ! -e %s && ! test -L %s || test -f %s && ! test -L %s) && \
-actual=$({ sha256sum %s 2>/dev/null || shasum -a 256 %s 2>/dev/null; } | cut -d' ' -f1) && \
-test \"$actual\" = %s && mv -f %s %s && \
-test -f %s && ! test -L %s && test -x %s"
-                          tmp tmp tmp tmp tmp dest dest dest dest tmp tmp digest tmp dest
-                          dest dest dest)))
+                       (tramp-rpc-deploy--activation-command
+                        remote-tmp-local remote-local local-checksum))
                     (signal 'remote-file-error
                             (list "Remote activation failed; existing binary was preserved")))
                   (setq success t)
@@ -1459,7 +1485,7 @@ binary lookup, and remote installation target."
 
       (insert "Cached Binaries:\n")
       (insert "----------------\n")
-      (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
+      (dolist (arch (tramp-rpc-deploy--supported-architectures))
         (let ((path (tramp-rpc-deploy--local-cache-path arch)))
           (insert (format "  %s: %s\n"
                           arch
@@ -1471,9 +1497,21 @@ binary lookup, and remote installation target."
       (insert "\n")
       (insert "Download URLs:\n")
       (insert "--------------\n")
-      (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
+      (dolist (arch (tramp-rpc-deploy--supported-architectures))
         (insert (format "  %s:\n    %s\n" arch (tramp-rpc-deploy--download-url arch)))))
     (display-buffer buf)))
+
+(defun tramp-rpc-deploy--diagnose-ssh (host user command &optional connect-timeout)
+  "Run SSH COMMAND on HOST as USER and return (STATUS . OUTPUT).
+When CONNECT-TIMEOUT is non-nil, use a ten-second connection timeout."
+  (let ((args (append
+               (list "-o" "BatchMode=yes")
+               (when connect-timeout (list "-o" "ConnectTimeout=10"))
+               (when user (list "-l" user))
+               (list "--" host command))))
+    (with-temp-buffer
+      (let ((status (apply #'call-process "ssh" nil t nil args)))
+        (cons status (buffer-string))))))
 
 (defun tramp-rpc-deploy-diagnose (host &optional user)
   "Run diagnostics for deploying to HOST.
@@ -1507,14 +1545,10 @@ This helps troubleshoot deployment issues."
         ;; SSH connectivity
         (cl-incf test-num)
         (insert (format "\n%d. Testing SSH connectivity...\n" test-num))
-        (let* ((ssh-cmd (append
-                         (list "ssh" "-o" "BatchMode=yes" "-o" "ConnectTimeout=10")
-                         (when user (list "-l" user))
-                         (list host "echo 'SSH_OK'")))
-               (output (with-temp-buffer
-                         (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd))
-                         (buffer-string))))
-          (if (string-match-p "SSH_OK" output)
+        (let* ((result (tramp-rpc-deploy--diagnose-ssh
+                        host user "echo 'SSH_OK'" t))
+               (output (cdr result)))
+          (if (and (zerop (car result)) (string-match-p "SSH_OK" output))
               (insert "   [OK] SSH connection successful\n")
             (insert "   [FAIL] SSH connection failed\n")
             (insert (format "   Output: %s\n" (string-trim output)))))
@@ -1522,15 +1556,10 @@ This helps troubleshoot deployment issues."
         ;; Remote architecture
         (cl-incf test-num)
         (insert (format "\n%d. Detecting remote architecture...\n" test-num))
-        (let* ((ssh-cmd (append
-                         (list "ssh" "-o" "BatchMode=yes")
-                         (when user (list "-l" user))
-                         (list host "uname -m && uname -s")))
-               (output (with-temp-buffer
-                         (if (zerop (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd)))
-                             (buffer-string)
-                           "FAILED"))))
-          (if (string-match-p "FAILED" output)
+        (let* ((result (tramp-rpc-deploy--diagnose-ssh
+                        host user "uname -m && uname -s"))
+               (output (cdr result)))
+          (if (not (zerop (car result)))
               (insert "   [FAIL] Could not detect architecture\n")
             (insert (format "   [OK] Architecture: %s\n" (string-trim output)))))
 
@@ -1538,30 +1567,26 @@ This helps troubleshoot deployment issues."
         (cl-incf test-num)
         (insert (format "\n%d. Testing remote directory access...\n" test-num))
         (let* ((dir tramp-rpc-deploy-remote-directory)
-               (ssh-cmd (append
-                         (list "ssh" "-o" "BatchMode=yes")
-                          (when user (list "-l" user))
-                          (list host (format "mkdir -p %s && test -w %s && echo 'WRITABLE'"
-                                             (tramp-shell-quote-argument dir)
-                                             (tramp-shell-quote-argument dir)))))
-               (output (with-temp-buffer
-                         (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd))
-                         (buffer-string))))
-          (if (string-match-p "WRITABLE" output)
+               (result
+                (tramp-rpc-deploy--diagnose-ssh
+                 host user
+                 (format "mkdir -p %s && test -w %s && echo 'WRITABLE'"
+                         (tramp-shell-quote-argument dir)
+                         (tramp-shell-quote-argument dir))))
+               (output (cdr result)))
+          (if (and (zerop (car result)) (string-match-p "WRITABLE" output))
               (insert (format "   [OK] Directory %s is writable\n" dir))
             (insert (format "   [FAIL] Directory %s not writable\n" dir))))
 
         ;; Checksum command
         (cl-incf test-num)
         (insert (format "\n%d. Testing checksum command availability...\n" test-num))
-        (let* ((ssh-cmd (append
-                         (list "ssh" "-o" "BatchMode=yes")
-                         (when user (list "-l" user))
-                         (list host "which sha256sum || which shasum || echo 'NONE'")))
-               (output (with-temp-buffer
-                         (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd))
-                         (string-trim (buffer-string)))))
-          (if (string-match-p "NONE" output)
+        (let* ((result (tramp-rpc-deploy--diagnose-ssh
+                        host user
+                        "which sha256sum || which shasum || echo 'NONE'"))
+               (output (string-trim (cdr result))))
+          (if (or (not (zerop (car result)))
+                  (string-match-p "NONE" output))
               (insert "   [FAIL] No checksum command found (need sha256sum or shasum)\n")
             (insert (format "   [OK] Found: %s\n" output))))
 
@@ -1569,21 +1594,18 @@ This helps troubleshoot deployment issues."
         (when (string= tramp-rpc-deploy-bootstrap-method "rsync")
           (cl-incf test-num)
           (insert (format "\n%d. Testing rsync availability on remote...\n" test-num))
-          (let* ((ssh-cmd (append
-                           (list "ssh" "-o" "BatchMode=yes")
-                           (when user (list "-l" user))
-                           (list host "which rsync || echo 'NONE'")))
-                 (output (with-temp-buffer
-                           (apply #'call-process (car ssh-cmd) nil t nil (cdr ssh-cmd))
-                           (string-trim (buffer-string)))))
-            (if (string-match-p "NONE" output)
+          (let* ((result (tramp-rpc-deploy--diagnose-ssh
+                          host user "which rsync || echo 'NONE'"))
+                 (output (string-trim (cdr result))))
+            (if (or (not (zerop (car result)))
+                    (string-match-p "NONE" output))
                 (insert "   [FAIL] rsync not found on remote (needed for rsync bootstrap method)\n")
               (insert (format "   [OK] Found: %s\n" output)))))
 
         ;; Local binary availability
         (cl-incf test-num)
         (insert (format "\n%d. Checking local binary cache...\n" test-num))
-        (dolist (arch '("x86_64-linux" "aarch64-linux" "i686-linux" "x86_64-darwin" "aarch64-darwin"))
+        (dolist (arch (tramp-rpc-deploy--supported-architectures))
           (let ((path (tramp-rpc-deploy--local-cache-path arch))
                 (bundled (tramp-rpc-deploy--bundled-binary-path arch)))
             (cond
@@ -1599,10 +1621,6 @@ This helps troubleshoot deployment issues."
         (insert "  2. Retry the connection and check *tramp-rpc-deploy* buffer\n")
         (insert "  3. Manually test: ssh " (if user (concat user "@") "") host " echo success\n")))
     (display-buffer buf)))
-
-;; ============================================================================
-;; Unload support
-;; ============================================================================
 
 (provide 'tramp-rpc-deploy)
 ;;; tramp-rpc-deploy.el ends here

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -34,6 +34,13 @@
 ;; tramp-rpc.el after these helpers have been defined.
 (declare-function tramp-rpc--proxy-hop-string "tramp-rpc")
 (declare-function tramp-rpc--sudo-rpc-hop-vec "tramp-rpc")
+(declare-function tramp-send-command
+                  "tramp-sh" (vec command &optional neveropen nooutput))
+(declare-function tramp-send-command-and-check
+                  "tramp-sh"
+                  (vec command &optional subshell dont-suppress-err exit-status))
+(declare-function tramp-send-command-and-read
+                  "tramp-sh" (vec command &optional noerror marker))
 
 ;; ============================================================================
 ;;; Customization
@@ -1521,7 +1528,7 @@ When CONNECT-TIMEOUT is non-nil, use a ten-second connection timeout."
                     (concat output
                             (unless (string-empty-p output) "\n")
                             status))))
-        (file-missing
+        (file-error
          (cons 127 (error-message-string error-data)))))))
 
 (defun tramp-rpc-deploy-diagnose (host &optional user)

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -292,7 +292,8 @@ FORMAT-STRING and ARGS are passed to `format'."
       (when log-file
         (condition-case nil
             (progn
-              (make-directory (file-name-directory log-file) t)
+              (when-let* ((directory (file-name-directory log-file)))
+                (make-directory directory t))
               (write-region line nil log-file 'append 'silent))
           (error nil))))))
 
@@ -1503,6 +1504,7 @@ binary lookup, and remote installation target."
 
 (defun tramp-rpc-deploy--diagnose-ssh (host user command &optional connect-timeout)
   "Run SSH COMMAND on HOST as USER and return (STATUS . OUTPUT).
+STATUS is always numeric; signal termination is reported as failure in OUTPUT.
 When CONNECT-TIMEOUT is non-nil, use a ten-second connection timeout."
   (let ((args (append
                (list "-o" "BatchMode=yes")
@@ -1510,8 +1512,17 @@ When CONNECT-TIMEOUT is non-nil, use a ten-second connection timeout."
                (when user (list "-l" user))
                (list "--" host command))))
     (with-temp-buffer
-      (let ((status (apply #'call-process "ssh" nil t nil args)))
-        (cons status (buffer-string))))))
+      (condition-case error-data
+          (let ((status (apply #'call-process "ssh" nil t nil args))
+                (output (buffer-string)))
+            (if (integerp status)
+                (cons status output)
+              (cons 128
+                    (concat output
+                            (unless (string-empty-p output) "\n")
+                            status))))
+        (file-missing
+         (cons 127 (error-message-string error-data)))))))
 
 (defun tramp-rpc-deploy-diagnose (host &optional user)
   "Run diagnostics for deploying to HOST.
@@ -1560,7 +1571,9 @@ This helps troubleshoot deployment issues."
                         host user "uname -m && uname -s"))
                (output (cdr result)))
           (if (not (zerop (car result)))
-              (insert "   [FAIL] Could not detect architecture\n")
+              (progn
+                (insert "   [FAIL] Could not detect architecture\n")
+                (insert (format "   Output: %s\n" (string-trim output))))
             (insert (format "   [OK] Architecture: %s\n" (string-trim output)))))
 
         ;; Remote directory writable
@@ -1576,7 +1589,8 @@ This helps troubleshoot deployment issues."
                (output (cdr result)))
           (if (and (zerop (car result)) (string-match-p "WRITABLE" output))
               (insert (format "   [OK] Directory %s is writable\n" dir))
-            (insert (format "   [FAIL] Directory %s not writable\n" dir))))
+            (insert (format "   [FAIL] Directory %s not writable\n" dir))
+            (insert (format "   Output: %s\n" (string-trim output)))))
 
         ;; Checksum command
         (cl-incf test-num)
@@ -1587,7 +1601,9 @@ This helps troubleshoot deployment issues."
                (output (string-trim (cdr result))))
           (if (or (not (zerop (car result)))
                   (string-match-p "NONE" output))
-              (insert "   [FAIL] No checksum command found (need sha256sum or shasum)\n")
+              (progn
+                (insert "   [FAIL] No checksum command found (need sha256sum or shasum)\n")
+                (insert (format "   Output: %s\n" output)))
             (insert (format "   [OK] Found: %s\n" output))))
 
         ;; Conditional: rsync availability (when using rsync bootstrap method)
@@ -1599,7 +1615,9 @@ This helps troubleshoot deployment issues."
                  (output (string-trim (cdr result))))
             (if (or (not (zerop (car result)))
                     (string-match-p "NONE" output))
-                (insert "   [FAIL] rsync not found on remote (needed for rsync bootstrap method)\n")
+                (progn
+                  (insert "   [FAIL] rsync not found on remote (needed for rsync bootstrap method)\n")
+                  (insert (format "   Output: %s\n" output)))
               (insert (format "   [OK] Found: %s\n" output)))))
 
         ;; Local binary availability

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -55,6 +55,13 @@
 (declare-function tramp-rpc--watch-entry-canonical-directory "tramp-rpc")
 (declare-function tramp-rpc--add-external-operation "tramp-rpc")
 (declare-function tramp-rpc--remove-external-operation "tramp-rpc")
+(declare-function tramp-rpc--clear-direnv-cache "tramp-rpc" (&optional vec))
+(declare-function tramp-rpc--flush-owned-route-connection-properties
+                  "tramp-rpc" (vec))
+
+(defvar tramp-rpc--connections)
+(defvar tramp-rpc--exec-path-cache)
+(defvar tramp-rpc--login-shell-cache)
 
 ;; Functions from magit-section.el.
 (autoload 'magit-section-show "magit-section")
@@ -134,7 +141,7 @@ Returns the cached value, or nil if not found or expired."
 
 (defun tramp-rpc--cache-put (cache key value)
   "Store VALUE for KEY in CACHE with current timestamp.
-Evicts oldest 25%% of entries when cache exceeds max size."
+Evicts the oldest 25% of entries when cache reaches the maximum size."
   ;; Check if eviction is needed
   (when (>= (hash-table-count cache) tramp-rpc--cache-max-size)
     (tramp-rpc--cache-evict cache))
@@ -171,7 +178,7 @@ must still report symlink type for lstat."
       (tramp-rpc--cache-put tramp-rpc--file-stat-cache key stat))))
 
 (defun tramp-rpc--cache-evict (cache)
-  "Evict oldest 25%% of entries from CACHE."
+  "Evict the oldest 25% of entries from CACHE."
   (let ((entries nil))
     ;; Collect all entries with timestamps
     (maphash (lambda (key value)
@@ -186,6 +193,21 @@ must still report symlink type for lstat."
           (remhash (caar entries) cache)
           (setq entries (cdr entries)))))))
 
+(defun tramp-rpc-magit--hash-remove-if (predicate table &optional callback)
+  "Remove TABLE entries satisfying PREDICATE without mutating during `maphash'.
+PREDICATE receives key and value.  CALLBACK, when non-nil, is called with each
+removed key and value.  Return the number of removed entries."
+  (let (entries)
+    (maphash (lambda (key value)
+               (when (funcall predicate key value)
+                 (push (cons key value) entries)))
+             table)
+    (dolist (entry entries)
+      (remhash (car entry) table)
+      (when callback
+        (funcall callback (car entry) (cdr entry))))
+    (length entries)))
+
 (defvar tramp-rpc-magit--ancestor-scan-caches)
 (defvar tramp-rpc-magit--prefetch-directories)
 
@@ -198,23 +220,16 @@ must still report symlink type for lstat."
 
 (defun tramp-rpc-magit--clear-ancestor-caches-for-connection (vec)
   "Clear ancestor caches belonging to the connection identified by VEC."
-  (let ((connection-key (tramp-rpc--connection-key-string vec))
-        ancestor-keys prefetch-keys)
-    (maphash
+  (let ((connection-key (tramp-rpc--connection-key-string vec)))
+    (tramp-rpc-magit--hash-remove-if
      (lambda (key _entry)
-       (when (and (consp key) (equal (car key) connection-key))
-         (push key ancestor-keys)))
+       (and (consp key) (equal (car key) connection-key)))
      tramp-rpc-magit--ancestor-scan-caches)
-    (dolist (key ancestor-keys)
-      (remhash key tramp-rpc-magit--ancestor-scan-caches))
-    (maphash
+    (tramp-rpc-magit--hash-remove-if
      (lambda (directory _timestamp)
-       (when (equal (tramp-rpc-magit--file-connection-key directory)
-                    connection-key)
-         (push directory prefetch-keys)))
-     tramp-rpc-magit--prefetch-directories)
-    (dolist (key prefetch-keys)
-      (remhash key tramp-rpc-magit--prefetch-directories))))
+       (equal (tramp-rpc-magit--file-connection-key directory)
+              connection-key))
+     tramp-rpc-magit--prefetch-directories)))
 
 (defun tramp-rpc--invalidate-cache-for-path (filename)
   "Invalidate cache entries for FILENAME."
@@ -266,26 +281,22 @@ must still report symlink type for lstat."
                       (tramp-flush-file-properties v localname)
                       (tramp-flush-directory-properties v localname))))
                 (drop-string-prefix (cache)
-                  (let (keys)
-                    (maphash (lambda (key _value)
-                               (when (and (stringp key)
-                                          (string-prefix-p expanded-dir key))
-                                 (push key keys)))
-                             cache)
-                    (dolist (key keys)
-                      (remhash key cache)
-                      (flush-tramp-properties key))))
+                  (tramp-rpc-magit--hash-remove-if
+                   (lambda (key _value)
+                     (and (stringp key)
+                          (string-prefix-p expanded-dir key)))
+                   cache
+                   (lambda (key _value)
+                     (flush-tramp-properties key))))
                 (drop-stat-prefix ()
-                  (let (keys)
-                    (maphash (lambda (key _value)
-                               (when (and (consp key)
-                                          (stringp (car key))
-                                          (string-prefix-p expanded-dir (car key)))
-                                 (push key keys)))
-                             tramp-rpc--file-stat-cache)
-                    (dolist (key keys)
-                      (remhash key tramp-rpc--file-stat-cache)
-                      (flush-tramp-properties (car key))))))
+                  (tramp-rpc-magit--hash-remove-if
+                   (lambda (key _value)
+                     (and (consp key)
+                          (stringp (car key))
+                          (string-prefix-p expanded-dir (car key))))
+                   tramp-rpc--file-stat-cache
+                   (lambda (key _value)
+                     (flush-tramp-properties (car key))))))
       (drop-string-prefix tramp-rpc--file-exists-cache)
       (drop-string-prefix tramp-rpc--file-truename-cache)
       (drop-stat-prefix))))
@@ -305,25 +316,27 @@ must still report symlink type for lstat."
   (interactive)
   (clrhash tramp-rpc--file-stat-cache))
 
-(defun tramp-rpc--clear-current-tramp-file-properties ()
-  "Clear TRAMP file properties for the current remote connection."
-  (when (file-remote-p default-directory)
-    (with-parsed-tramp-file-name default-directory nil
-      (tramp-flush-directory-properties v "/"))))
-
 (defun tramp-rpc--clear-file-metadata-caches ()
   "Clear cached file metadata."
   (clrhash tramp-rpc--file-exists-cache)
   (clrhash tramp-rpc--file-truename-cache)
   (clrhash tramp-rpc--file-stat-cache)
-  (tramp-rpc-magit--clear-ancestor-caches)
-  (tramp-rpc--clear-current-tramp-file-properties))
+  (tramp-rpc-magit--clear-ancestor-caches))
 
 (defun tramp-rpc-clear-all-caches ()
-  "Clear all tramp-rpc caches."
+  "Clear all project-owned caches and route-aware connection properties."
   (interactive)
   (tramp-rpc-magit--clear-cache)
-  (tramp-rpc--clear-file-metadata-caches))
+  (tramp-rpc--clear-file-metadata-caches)
+  (tramp-rpc--clear-direnv-cache)
+  (clrhash tramp-rpc--exec-path-cache)
+  (clrhash tramp-rpc--login-shell-cache)
+  (maphash
+   (lambda (_key connection)
+     (when-let* ((vec (plist-get connection :vec)))
+       (tramp-flush-directory-properties vec "/")
+       (tramp-rpc--flush-owned-route-connection-properties vec)))
+   tramp-rpc--connections))
 
 (defun tramp-rpc--clear-file-caches-for-connection (vec)
   "Clear file-exists and `file-truename' cache entries for connection VEC.
@@ -335,22 +348,13 @@ matching the remote prefix of VEC."
     ;; Match the prefix up to the colon-slash that starts the localname.
     ;; e.g. "/rpc:user@host:/" -- any key starting with this belongs to VEC.
     (dolist (cache (list tramp-rpc--file-exists-cache
-                        tramp-rpc--file-truename-cache))
-      (let ((keys-to-remove nil))
-        (maphash (lambda (key _value)
-                   (when (string-prefix-p prefix key)
-                     (push key keys-to-remove)))
-                 cache)
-        (dolist (key keys-to-remove)
-          (remhash key cache))))
-    (let ((keys-to-remove nil))
-      (maphash (lambda (key _value)
-                 (when (and (consp key)
-                            (string-prefix-p prefix (car key)))
-                   (push key keys-to-remove)))
-               tramp-rpc--file-stat-cache)
-      (dolist (key keys-to-remove)
-        (remhash key tramp-rpc--file-stat-cache)))))
+                         tramp-rpc--file-truename-cache))
+      (tramp-rpc-magit--hash-remove-if
+       (lambda (key _value) (string-prefix-p prefix key)) cache))
+    (tramp-rpc-magit--hash-remove-if
+     (lambda (key _value)
+       (and (consp key) (string-prefix-p prefix (car key))))
+     tramp-rpc--file-stat-cache)))
 
 ;; ============================================================================
 ;; Filesystem watching
@@ -371,11 +375,6 @@ Used during operations that will invalidate caches themselves.")
   (let ((key (tramp-rpc--connection-key vec)))
     (format "%S" key)))
 
-(defun tramp-rpc--directory-watched-p (localname vec)
-  "Return non-nil if LOCALNAME on VEC is being watched."
-  (let ((conn-key (tramp-rpc--connection-key-string vec)))
-    (gethash (format "%s:%s" conn-key localname)
-             tramp-rpc--watched-directories)))
 
 (defun tramp-rpc--watch-entry-recursive-p (entry)
   "Return non-nil if watched-directory ENTRY is recursive."
@@ -594,21 +593,19 @@ When RECURSIVE is non-nil, watch subdirectories too."
 
 (defun tramp-rpc--cleanup-watches-for-connection (vec &optional connection-process)
   "Remove watched directory entries for VEC's CONNECTION-PROCESS."
-  (let ((conn-key (tramp-rpc--connection-key-string vec))
-        (keys-to-remove nil))
-    (maphash (lambda (key value)
-               (when (and (string-prefix-p (concat conn-key ":") key)
-                          (or (null connection-process)
-                              (null (plist-get value :connection-process))
-                              (eq connection-process
-                                  (plist-get value :connection-process))))
-                 (push key keys-to-remove)))
-             tramp-rpc--watched-directories)
-    (dolist (key keys-to-remove)
-      (remhash key tramp-rpc--watched-directories))
-    (when keys-to-remove
+  (let* ((conn-key (tramp-rpc--connection-key-string vec))
+         (removed
+          (tramp-rpc-magit--hash-remove-if
+           (lambda (key value)
+             (and (string-prefix-p (concat conn-key ":") key)
+                  (or (null connection-process)
+                      (null (plist-get value :connection-process))
+                      (eq connection-process
+                          (plist-get value :connection-process)))))
+           tramp-rpc--watched-directories)))
+    (when (> removed 0)
       (tramp-rpc--debug "Cleaned up %d watches for %s"
-                        (length keys-to-remove) conn-key))))
+                        removed conn-key))))
 
 (defun tramp-rpc-list-watches ()
   "List currently watched directories."
@@ -689,20 +686,61 @@ large worktrees must be split without losing item/result ordering.")
 (defvar tramp-rpc-magit--ancestor-scan-caches (make-hash-table :test 'equal)
   "Cached ancestor scans keyed by remote search directory.")
 
+(defcustom tramp-rpc-magit-ancestor-cache-max-size 128
+  "Maximum number of cached ancestor scans."
+  :type 'integer
+  :group 'tramp-rpc)
+
 (defvar tramp-rpc-magit--prefetch-directories (make-hash-table :test 'equal)
   "Remote directories with active prefetch snapshots, keyed by directory.
 Values are creation timestamps so independent repositories cannot clobber
 one another's ancestor-discovery state.")
 
+(defcustom tramp-rpc-magit-prefetch-directory-max-size 128
+  "Maximum number of active prefetch directory snapshots."
+  :type 'integer
+  :group 'tramp-rpc)
+
+(defcustom tramp-rpc-magit-process-cache-max-size 64
+  "Maximum number of per-directory Magit process caches."
+  :type 'integer
+  :group 'tramp-rpc)
+
+(defun tramp-rpc-magit--bound-table
+    (table max-size &optional timestamp-function timestamp-valid-p)
+  "Prune expired entries and bound TABLE to MAX-SIZE.
+TIMESTAMP-FUNCTION extracts an entry timestamp.  TIMESTAMP-VALID-P checks
+that timestamp and defaults to the file metadata cache policy.  Overflow
+eviction follows the oldest timestamps without a full sort on normal cache
+admission."
+  (when timestamp-function
+    (let ((valid-p (or timestamp-valid-p
+                       #'tramp-rpc--cache-entry-valid-p)))
+      (tramp-rpc-magit--hash-remove-if
+       (lambda (_key value)
+         (when-let* ((timestamp (funcall timestamp-function value)))
+           (not (funcall valid-p timestamp))))
+       table)))
+  (let ((excess (- (hash-table-count table) (max 0 max-size))))
+    (dotimes (_ excess)
+      (let (oldest-key oldest-time)
+        (maphash
+         (lambda (key value)
+           (let ((time (and timestamp-function
+                            (funcall timestamp-function value))))
+             (when (or (null oldest-key)
+                       (null time)
+                       (and oldest-time (< time oldest-time)))
+               (setq oldest-key key oldest-time time))))
+         table)
+        (when oldest-key
+          (remhash oldest-key table))))))
+
 (defun tramp-rpc-magit--prune-prefetch-directories ()
   "Remove expired entries from `tramp-rpc-magit--prefetch-directories'."
-  (let (expired)
-    (maphash (lambda (directory timestamp)
-               (unless (tramp-rpc--cache-entry-valid-p timestamp)
-                 (push directory expired)))
-             tramp-rpc-magit--prefetch-directories)
-    (dolist (directory expired)
-      (remhash directory tramp-rpc-magit--prefetch-directories))))
+  (tramp-rpc-magit--bound-table
+   tramp-rpc-magit--prefetch-directories
+   tramp-rpc-magit-prefetch-directory-max-size #'identity))
 
 (defvar tramp-rpc-magit--debug nil
   "When non-nil, log cache hits/misses for debugging.")
@@ -742,9 +780,7 @@ Returns a cons cell (connection-key . directory) for hash table lookups."
     (cond
      ((not cache) nil)
      ((and time
-           tramp-rpc-magit-process-cache-ttl
-           (> (- (float-time) time)
-              tramp-rpc-magit-process-cache-ttl))
+           (not (tramp-rpc-magit--process-cache-timestamp-valid-p time)))
       (remhash key tramp-rpc-magit--process-caches)
       nil)
      (t cache))))
@@ -757,11 +793,22 @@ Returns the cache hash table, or nil if none."
       (tramp-rpc-magit--valid-process-cache
        (tramp-rpc-magit--get-cache-key v default-directory)))))
 
+(defun tramp-rpc-magit--process-cache-timestamp-valid-p (timestamp)
+  "Return non-nil when process cache TIMESTAMP is within its own TTL."
+  (or (null tramp-rpc-magit-process-cache-ttl)
+      (<= (- (float-time) timestamp)
+          tramp-rpc-magit-process-cache-ttl)))
+
 (defun tramp-rpc-magit--set-process-cache (vec directory cache)
   "Set the `process-file' CACHE for VEC and DIRECTORY."
   (let ((key (tramp-rpc-magit--get-cache-key vec directory)))
     (puthash key (list :time (float-time) :cache cache)
-             tramp-rpc-magit--process-caches)))
+             tramp-rpc-magit--process-caches)
+    (tramp-rpc-magit--bound-table
+     tramp-rpc-magit--process-caches tramp-rpc-magit-process-cache-max-size
+     (lambda (entry)
+       (and (listp entry) (plist-get entry :time)))
+     #'tramp-rpc-magit--process-cache-timestamp-valid-p)))
 
 
 (defun tramp-rpc-magit--process-cache-key (&rest args)
@@ -1413,6 +1460,9 @@ as the `process-file' cache.  Also fetches ancestor markers."
       (tramp-rpc-magit--prune-prefetch-directories)
       (puthash (expand-file-name directory) (float-time)
                tramp-rpc-magit--prefetch-directories)
+      (tramp-rpc-magit--bound-table
+       tramp-rpc-magit--prefetch-directories
+       tramp-rpc-magit-prefetch-directory-max-size #'identity)
       (with-parsed-tramp-file-name directory nil
         ;; Build command list and run in parallel on server.  `update-index
         ;; --refresh' is intentionally not part of this prefetch; it is run by
@@ -1449,7 +1499,10 @@ as the `process-file' cache.  Also fetches ancestor markers."
           (puthash (tramp-rpc-magit--ancestor-scan-cache-key
                     (file-name-as-directory (expand-file-name directory)))
                    (cons (float-time) scan)
-                   tramp-rpc-magit--ancestor-scan-caches))
+                   tramp-rpc-magit--ancestor-scan-caches)
+          (tramp-rpc-magit--bound-table
+           tramp-rpc-magit--ancestor-scan-caches
+           tramp-rpc-magit-ancestor-cache-max-size #'car))
         (when tramp-rpc-magit--debug
           (let ((cache (tramp-rpc-magit--get-process-cache)))
             (tramp-rpc--debug "tramp-rpc-magit: prefetched %d commands + ancestors for %s"
@@ -1524,6 +1577,9 @@ the server scans the entire tree in one operation."
                    directory tramp-rpc-magit--ancestor-marker-names)))
         (puthash key (cons (float-time) scan)
                  tramp-rpc-magit--ancestor-scan-caches)
+        (tramp-rpc-magit--bound-table
+         tramp-rpc-magit--ancestor-scan-caches
+         tramp-rpc-magit-ancestor-cache-max-size #'car)
         scan))))
 
 (defun tramp-rpc-magit--ancestor-cache-covers-p (scan-directory candidate-dir)
@@ -1619,21 +1675,13 @@ Returns t, nil, or \\='not-cached if not in cache."
 ;; Cache clearing
 ;; ============================================================================
 
-(defun tramp-rpc-magit--clear-status-cache ()
-  "Clear all frequently changing Git status caches."
-  (clrhash tramp-rpc-magit--process-caches))
-
 (defun tramp-rpc-magit--clear-status-cache-for-connection (vec)
   "Clear status caches belonging to the connection identified by VEC."
-  (let ((connection-key (tramp-rpc--connection-key-string vec))
-        process-keys)
-    (maphash
+  (let ((connection-key (tramp-rpc--connection-key-string vec)))
+    (tramp-rpc-magit--hash-remove-if
      (lambda (key _entry)
-       (when (and (consp key) (equal (car key) connection-key))
-         (push key process-keys)))
-     tramp-rpc-magit--process-caches)
-    (dolist (key process-keys)
-      (remhash key tramp-rpc-magit--process-caches))))
+       (and (consp key) (equal (car key) connection-key)))
+     tramp-rpc-magit--process-caches)))
 
 (defun tramp-rpc-magit--clear-cache-for-connection (vec)
   "Clear Magit caches belonging to the connection identified by VEC."

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -809,11 +809,16 @@ turn an explicit nil into the dynamic `process-connection-type'.  Native
 `make-process' treats explicit nil as a pipe, so pass `pipe' to the skeleton
 for that one case.
 
-String `:stderr' values retain TRAMP's same-remote file semantics."
+A remote string `:stderr' value retains TRAMP's same-remote file semantics.
+For compatibility, a non-remote string names an Emacs buffer."
   (let ((args (copy-sequence args)))
     (when (and (plist-member args :connection-type)
                (null (plist-get args :connection-type)))
       (setq args (plist-put args :connection-type 'pipe)))
+    (when-let* ((stderr (plist-get args :stderr)))
+      (when (and (stringp stderr)
+                 (not (tramp-tramp-file-p stderr)))
+        (setq args (plist-put args :stderr (get-buffer-create stderr)))))
     args))
 
 (defun tramp-rpc--redirect-command-stderr (command stderr-file)
@@ -870,11 +875,16 @@ Resolves program path and loads direnv environment from working directory."
                                       (cdr command)))
               (setq command (append (list (car command) "-n")
                                     (cdr command))))))
+        (when (and use-pty sudo-command stderr-file)
+          (tramp-error
+           v 'file-error
+           "Cannot redirect stderr for an interactive PTY sudo process"))
         (when use-pty
           (setq command (tramp-rpc--maybe-login-shell-command v command)))
         ;; TRAMP string :stderr means a same-remote file, in both pipe and PTY
         ;; modes.  Redirect in one argv-safe shell wrapper; buffer stderr keeps
-        ;; using the separate local relay below.
+        ;; using the separate local relay below.  PTY sudo is rejected above
+        ;; because redirecting its prompt would leave the user waiting blindly.
         (when stderr-file
           (setq command (tramp-rpc--redirect-command-stderr command stderr-file)
                 stderr nil))

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -262,12 +262,6 @@ Emacs to retain decoder state across RPC chunks."
   "Return the exact queue key for VEC, PID, and OWNER.
 Capture a connection only when this is the first operation for OWNER."
   (or (and (processp owner) (process-get owner :tramp-rpc-write-queue-key))
-      (let (key)
-        (maphash (lambda (candidate queue)
-                   (when (and owner (eq owner (plist-get queue :owner-process)))
-                     (setq key candidate)))
-                 tramp-rpc--process-write-queues)
-        key)
       (let* ((connection (or (and (processp owner)
                                   (process-get owner :tramp-rpc-connection))
                              (tramp-rpc--ensure-connection vec)))
@@ -815,18 +809,21 @@ turn an explicit nil into the dynamic `process-connection-type'.  Native
 `make-process' treats explicit nil as a pipe, so pass `pipe' to the skeleton
 for that one case.
 
-The skeleton also treats string `:stderr' as a remote stderr file.  Preserve
-tramp-rpc's existing compatibility behavior where non-remote strings name
-stderr buffers."
+String `:stderr' values retain TRAMP's same-remote file semantics."
   (let ((args (copy-sequence args)))
     (when (and (plist-member args :connection-type)
                (null (plist-get args :connection-type)))
       (setq args (plist-put args :connection-type 'pipe)))
-    (when-let* ((stderr (plist-get args :stderr)))
-      (when (and (stringp stderr)
-                 (not (tramp-tramp-file-p stderr)))
-        (setq args (plist-put args :stderr (get-buffer-create stderr)))))
     args))
+
+(defun tramp-rpc--redirect-command-stderr (command stderr-file)
+  "Return COMMAND wrapped to redirect stderr to remote STDERR-FILE safely."
+  (append
+   (list "/bin/sh" "-c"
+         (format "exec \"$@\" 2>%s"
+                 (tramp-shell-quote-argument stderr-file))
+         "tramp-rpc-stderr")
+   command))
 
 (defun tramp-rpc-handle-make-process (&rest args)
   "Create an async process on the remote host.
@@ -849,6 +846,9 @@ Resolves program path and loads direnv environment from working directory."
              ;; non-PTY from the RPC process launcher's perspective.
              (use-pty (eq connection-type 'pty))
              (pipe-sudo (and sudo-command (not use-pty)))
+             (stderr-file (when (stringp stderr)
+                            (tramp-file-local-name
+                             (expand-file-name stderr))))
              (sudo-password nil)
              ;; Native process creation resolves omitted/nil coding from
              ;; `default-process-coding-system'.
@@ -872,6 +872,12 @@ Resolves program path and loads direnv environment from working directory."
                                     (cdr command))))))
         (when use-pty
           (setq command (tramp-rpc--maybe-login-shell-command v command)))
+        ;; TRAMP string :stderr means a same-remote file, in both pipe and PTY
+        ;; modes.  Redirect in one argv-safe shell wrapper; buffer stderr keeps
+        ;; using the separate local relay below.
+        (when stderr-file
+          (setq command (tramp-rpc--redirect-command-stderr command stderr-file)
+                stderr nil))
         ;; Use the same effective environment as synchronous and parallel RPC
         ;; processes, including configured PATH, direnv, and caller overrides.
         (let ((process-env (tramp-rpc--process-environment v localname)))

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -212,7 +212,7 @@ Returns the length as an integer, or nil if the BUFFER is too short."
 
 (defun tramp-rpc-protocol-try-read-message (buffer)
   "Try to read a complete message from BUFFER.
-BUFFER should the process buffer containing received data.  Returns a
+BUFFER should be the process buffer containing received data.  Returns a
 MESSAGE if a complete message is available, where MESSAGE is the decoded
 response plist.  Returns nil if no complete message yet."
   (with-current-buffer buffer
@@ -259,10 +259,6 @@ Returns a list where each element is either:
                         :data (alist-get 'data error-obj))
                 (alist-get 'result result-obj)))
             results-array)))
-
-;; ============================================================================
-;; Unload support
-;; ============================================================================
 
 (provide 'tramp-rpc-protocol)
 ;;; tramp-rpc-protocol.el ends here

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -991,6 +991,83 @@ Otherwise clear all entries."
 (defvar tramp-rpc--login-shell-cache (make-hash-table :test 'equal)
   "Cache of remote login shell keyed by connection-key.")
 
+(defconst tramp-rpc--generic-route-connection-properties
+  '("uname" "uid-integer" "uid-string" "gid-integer" "gid-string" "~")
+  "Generic TRAMP properties populated by tramp-rpc that depend on the route.
+Home-directory properties named ~USER are route-sensitive as well.")
+
+(defconst tramp-rpc--owned-route-connection-properties
+  '("tramp-rpc-login-path" "rpc-signal-strings"
+    " rpc-acl-enabled" " rpc-selinux-enabled" "tramp-rpc-system-info")
+  "Project-specific route-aware TRAMP connection properties.")
+
+(defvar tramp-rpc--route-property-access nil
+  "Non-nil while accessing an explicitly route-qualified TRAMP property.")
+
+(defun tramp-rpc--generic-route-connection-property-p (vec property)
+  "Return non-nil when PROPERTY on VEC needs route-aware TRAMP storage."
+  (and (tramp-file-name-p vec)
+       (or (string= (tramp-file-name-method vec) tramp-rpc-method)
+           ;; The sudo predicate consults TRAMP method/connection metadata.
+           ;; Suppress this advice during that probe to avoid recursive
+           ;; property qualification.
+           (let ((tramp-rpc--route-property-access t))
+             (tramp-rpc--sudo-file-name-p vec)))
+       (stringp property)
+       (or (member property tramp-rpc--generic-route-connection-properties)
+           (string-prefix-p "~" property))))
+
+(defun tramp-rpc--route-property-name (vec property)
+  "Return route-aware TRAMP connection PROPERTY name for VEC."
+  (format "%s:%s" property
+          (secure-hash 'sha1 (prin1-to-string (tramp-rpc--connection-key vec)))))
+
+(defun tramp-rpc--route-generic-connection-property-advice
+    (original vec property &rest args)
+  "Call ORIGINAL with route-aware PROPERTY when VEC is an RPC target.
+ARGS contains the remaining arguments of the advised TRAMP property function."
+  (apply original vec
+         (if (and (not tramp-rpc--route-property-access)
+                  (tramp-rpc--generic-route-connection-property-p vec property))
+             (tramp-rpc--route-property-name vec property)
+           property)
+         args))
+
+(defmacro tramp-rpc--with-route-connection-property (vec property &rest body)
+  "Evaluate BODY once and cache it under route-aware PROPERTY for VEC."
+  (declare (indent 2) (debug t))
+  `(let ((tramp-rpc--route-property-access t))
+     (with-tramp-connection-property
+         ,vec (tramp-rpc--route-property-name ,vec ,property)
+       ,@body)))
+
+(defun tramp-rpc--get-route-connection-property (vec property default)
+  "Return route-aware connection PROPERTY for VEC, or DEFAULT."
+  (let ((tramp-rpc--route-property-access t))
+    (tramp-get-connection-property
+     vec (tramp-rpc--route-property-name vec property) default)))
+
+(defun tramp-rpc--set-route-connection-property (vec property value)
+  "Set route-aware connection PROPERTY for VEC to VALUE."
+  (let ((tramp-rpc--route-property-access t))
+    (tramp-set-connection-property
+     vec (tramp-rpc--route-property-name vec property) value)))
+
+(defun tramp-rpc--flush-route-connection-property (vec property)
+  "Flush route-aware connection PROPERTY for VEC."
+  (let ((tramp-rpc--route-property-access t))
+    (tramp-flush-connection-property
+     vec (tramp-rpc--route-property-name vec property))))
+
+(defun tramp-rpc--flush-owned-route-connection-properties (vec)
+  "Flush every route-dependent connection property owned for VEC."
+  (dolist (property (append tramp-rpc--owned-route-connection-properties
+                            tramp-rpc--generic-route-connection-properties
+                            (when-let* ((user (tramp-file-name-user vec)))
+                              (unless (string-empty-p user)
+                                (list (concat "~" user))))))
+    (tramp-rpc--flush-route-connection-property vec property)))
+
 (defun tramp-rpc--environment-with (env key value)
   "Return ENV with KEY set to VALUE.
 ENV is an alist of (KEY . VALUE) string pairs.  If KEY already exists,
@@ -1046,7 +1123,7 @@ Uses `tramp-remote-path' by default.  A non-nil deprecated
 
 (defun tramp-rpc--cached-login-path (vec)
   "Return the login shell PATH directories for VEC, caching the result."
-  (with-tramp-connection-property vec "tramp-rpc-login-path"
+  (tramp-rpc--with-route-connection-property vec "tramp-rpc-login-path"
     (or (tramp-rpc--fetch-remote-exec-path vec) '())))
 
 (defun tramp-rpc--process-path-environment (vec)
@@ -1199,7 +1276,7 @@ Also clears the executable, variable `exec-path', and login-shell caches."
       (when-let* ((transport (plist-get current :process)))
         (tramp-rpc-protocol--clear-deferred-polls-for-target transport))
       (remhash key tramp-rpc--connections)
-      (tramp-flush-connection-property vec "tramp-rpc-login-path")
+      (tramp-rpc--flush-owned-route-connection-properties vec)
       (remhash key tramp-rpc--exec-path-cache)
       (remhash key tramp-rpc--login-shell-cache))))
 
@@ -1816,9 +1893,8 @@ Returns the connection plist.  Signals `remote-file-error' on failure."
           ;; this connection and `tramp-cleanup-connection' can offer it
           ;; interactively.  The value is the connection buffer, matching the
           ;; convention in `tramp-get-buffer'.
-          ;; Emacs 30.x uses "process-buffer"; newer TRAMP (31+) uses
-          ;; " connected".  Set both for compatibility.
-          (tramp-set-connection-property vec "process-buffer" buffer)
+          ;; Keep TRAMP's private leading-space connection properties.
+          (tramp-set-connection-property vec " process-buffer" buffer)
           (tramp-set-connection-property vec " connected" buffer)
 
           (tramp-rpc--get-connection vec))
@@ -1874,7 +1950,6 @@ probe can then interleave with RPC startup and corrupt the protocol stream."
   (let* ((bootstrap-vec (tramp-rpc-deploy--bootstrap-vec vec))
          (proc (tramp-get-connection-process bootstrap-vec)))
     (when (or (process-live-p proc)
-              (tramp-connection-property-p bootstrap-vec "process-buffer")
               (tramp-connection-property-p bootstrap-vec " process-buffer")
               (tramp-connection-property-p bootstrap-vec " connected"))
       ;; Preserve authentication and unrelated asynchronous processes while
@@ -4320,7 +4395,8 @@ PROPERTY must start with a space so TRAMP keeps it ephemeral.  Successful
 probes cache both enabled and disabled results.  Transport and RPC errors
 return nil without caching so a later operation can retry."
   (let* ((missing (make-symbol "missing"))
-         (cached (tramp-get-connection-property vec property missing)))
+         (cached (tramp-rpc--get-route-connection-property
+                  vec property missing)))
     (if (not (eq cached missing))
         cached
       (condition-case nil
@@ -4329,7 +4405,7 @@ return nil without caching so a later operation can retry."
                                             (args . ,args)
                                             (cwd . "/"))))
                  (enabled (zerop (alist-get 'exit_code result))))
-            (tramp-set-connection-property vec property enabled)
+            (tramp-rpc--set-route-connection-property vec property enabled)
             enabled)
         (error nil)))))
 
@@ -4903,7 +4979,8 @@ REPLACE non-nil replaces the accessible buffer contents."
 (defun tramp-rpc--cache-system-info (vec info)
   "Store system.info INFO for VEC and seed related TRAMP properties."
   (when info
-    (tramp-set-connection-property vec tramp-rpc--system-info-property info)
+    (tramp-rpc--set-route-connection-property
+     vec tramp-rpc--system-info-property info)
     ;; Store remote uname so `tramp-check-remote-uname' works.  The server
     ;; returns "linux" or "macos"; map to the kernel names tramp-sh expects.
     (when-let* ((os (alist-get 'os info)))
@@ -4932,7 +5009,8 @@ REPLACE non-nil replaces the accessible buffer contents."
 
 (defun tramp-rpc--cached-system-info (vec)
   "Return the system.info cached for VEC, or nil.  Never issues an RPC."
-  (tramp-get-connection-property vec tramp-rpc--system-info-property nil))
+  (tramp-rpc--get-route-connection-property
+   vec tramp-rpc--system-info-property nil))
 
 (defun tramp-rpc--system-info (vec)
   "Return cached system.info for VEC, fetching it at most once per connection."
@@ -4943,7 +5021,7 @@ REPLACE non-nil replaces the accessible buffer contents."
         ;; connection setup so a cold caller does not immediately send a second
         ;; identical RPC.
         (tramp-rpc--ensure-connection vec)
-        (or (tramp-get-connection-property
+        (or (tramp-rpc--get-route-connection-property
              vec tramp-rpc--system-info-property nil)
             (tramp-rpc--cache-system-info
              vec (tramp-rpc--call vec "system.info" nil))))))
@@ -5900,6 +5978,14 @@ cleanup of all connections has run."
 (defun tramp-rpc--install ()
   "Install TRAMP-RPC operations, advice, and lifecycle hooks."
   (tramp-rpc--install-core-external-operations)
+  (dolist (function '(tramp-get-connection-property
+                      tramp-set-connection-property
+                      tramp-flush-connection-property
+                      tramp-connection-property-p))
+    (unless (advice-member-p
+             #'tramp-rpc--route-generic-connection-property-advice function)
+      (advice-add function :around
+                  #'tramp-rpc--route-generic-connection-property-advice)))
   (tramp-rpc-handler-install)
   (tramp-rpc--after-load-integrations nil)
   (add-hook 'after-load-functions #'tramp-rpc--after-load-integrations)
@@ -5922,7 +6008,12 @@ Removes advice and cleans up async processes."
                      tramp-rpc-deploy tramp-rpc-protocol))
     (when (featurep feature)
       (unload-feature feature 'force)))
-  ;; Remove multi-hop hook and cleanup hooks.
+  ;; Remove multi-hop hook, property advice, and cleanup hooks.
+  (dolist (function '(tramp-get-connection-property
+                      tramp-set-connection-property
+                      tramp-flush-connection-property
+                      tramp-connection-property-p))
+    (advice-remove function #'tramp-rpc--route-generic-connection-property-advice))
   (remove-hook 'after-load-functions #'tramp-rpc--after-load-integrations)
   (remove-hook 'tramp-multi-hop-p-hook #'tramp-rpc-multi-hop-p)
   (remove-hook 'tramp-cleanup-connection-hook #'tramp-rpc-cleanup-connection)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -3618,10 +3618,12 @@ OPERATION names the attempted operation."
     result))
 
 (cl-defun tramp-rpc--copy-file-same-remote
-    (filename newname ok-if-already-exists keep-time preserve-permissions)
+    (filename newname ok-if-already-exists keep-time preserve-uid-gid
+              preserve-permissions)
   "Copy FILENAME to NEWNAME on one TRAMP-RPC remote with fewer round-trips.
 OK-IF-ALREADY-EXISTS controls existing-destination handling.
 KEEP-TIME non-nil preserves timestamps.
+PRESERVE-UID-GID non-nil preserves ownership for regular files.
 PRESERVE-PERMISSIONS non-nil preserves file permissions."
   (with-parsed-tramp-file-name filename v1
     (with-parsed-tramp-file-name newname v2
@@ -3645,7 +3647,8 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
             (tramp-rpc--copy-file-same-remote
              filename
              (expand-file-name (file-name-nondirectory filename) newname)
-             ok-if-already-exists keep-time preserve-permissions)))
+             ok-if-already-exists keep-time preserve-uid-gid
+             preserve-permissions)))
         (unless ok-if-already-exists
           (when dest-stat
             (signal 'file-already-exists (list newname))))
@@ -3665,10 +3668,18 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
                                       (file-name-unquote v1-localname)))
                              (dest . ,(tramp-rpc--path-to-bin
                                        (file-name-unquote v2-localname)))
-                             (preserve . ,(if (or keep-time preserve-permissions)
+                             (preserve . ,(if (or keep-time preserve-uid-gid
+                                                   preserve-permissions)
                                               t :msgpack-false))
                              (overwrite . ,(if ok-if-already-exists
-                                               t :msgpack-false))))))
+                                               t :msgpack-false))))
+          (when preserve-uid-gid
+            (tramp-rpc--call
+             v2 "file.chown"
+             `((path . ,(tramp-rpc--path-to-bin
+                         (file-name-unquote v2-localname)))
+               (uid . ,(alist-get 'uid source-stat))
+               (gid . ,(alist-get 'gid source-stat)))))))
         (tramp-flush-file-properties v1 v1-localname)
         (tramp-flush-file-properties v2 v2-localname)
         (tramp-flush-directory-properties v2 v2-localname)
@@ -3862,9 +3873,20 @@ PRESERVE-UID-GID requests ownership preservation on generic fallback paths.
 PRESERVE-PERMISSIONS non-nil preserves file permissions."
   (setq filename (expand-file-name filename)
         newname (expand-file-name newname))
-  ;; The RPC copy primitive cannot reliably change ownership as an
-  ;; unprivileged user.  Preserve upstream behavior instead of silently
-  ;; dropping PRESERVE-UID-GID.
+  ;; Fast path for same-remote copies: batch source/destination stats, then do
+  ;; the server-side copy.  This avoids the generic preflight predicates each
+  ;; costing their own network round-trip.  Keep ownership preservation on the
+  ;; RPC connection: `tramp-sh-handle-copy-file' cannot drive an rpc method's
+  ;; non-shell transport and can wait forever when a file watch is active.
+  (when (and (tramp-tramp-file-p filename)
+             (tramp-tramp-file-p newname)
+             (tramp-equal-remote filename newname))
+    (cl-return-from tramp-rpc-handle-copy-file
+      (tramp-rpc--copy-file-same-remote
+       filename newname ok-if-already-exists keep-time preserve-uid-gid
+       preserve-permissions)))
+  ;; For copies crossing the RPC boundary, retain TRAMP's ownership-preserving
+  ;; fallback rather than silently ignoring PRESERVE-UID-GID.
   (when (and preserve-uid-gid
              (or (tramp-tramp-file-p filename)
                  (tramp-tramp-file-p newname)))
@@ -3872,15 +3894,6 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
       (tramp-sh-handle-copy-file
        filename newname ok-if-already-exists keep-time
        preserve-uid-gid preserve-permissions)))
-  ;; Fast path for same-remote copies: batch source/destination stats, then do
-  ;; the server-side copy.  This avoids the generic preflight predicates each
-  ;; costing their own network round-trip.
-  (when (and (tramp-tramp-file-p filename)
-             (tramp-tramp-file-p newname)
-             (tramp-equal-remote filename newname))
-    (cl-return-from tramp-rpc-handle-copy-file
-      (tramp-rpc--copy-file-same-remote
-       filename newname ok-if-already-exists keep-time preserve-permissions)))
   ;; When NEWNAME is a directory name (trailing /), copy INTO it.
   (when (and (directory-name-p newname)
              (file-directory-p newname))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -242,12 +242,12 @@ This is called from `tramp-multi-hop-p-hook'."
   (when (fboundp 'tramp-remove-external-operation)
     (apply (symbol-function 'tramp-remove-external-operation) args)))
 
-(declare-function dired-compress-file "dired-aux")
 ;; These predicates are emitted inside the single autoload form above.  The
 ;; compiler does not discover nested definitions, so declare only those two
 ;; autoload-owned functions used by the full implementation below.
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
+(declare-function tramp-sh-handle-copy-file "tramp-sh" (&rest args))
 
 (defvar tramp-rpc--sudo-file-name-p-in-progress nil
   "Non-nil while checking hidden rpc+sudo proxy expansion.")
@@ -2799,19 +2799,12 @@ ELOOP errors to nil (the file effectively doesn't exist for stat)."
 
 (defun tramp-rpc--file-exists-cache-lookup (filename)
   "Return cached `file-exists-p' value for FILENAME, or `not-cached'.
-Unlike `tramp-rpc--cache-get', this preserves cached nil values."
+FILENAME is expanded before lookup.  Full cache inhibition bypasses the
+stored entry without purging it."
   (if (eq remote-file-name-inhibit-cache t)
       'not-cached
-    (let* ((expanded (expand-file-name filename))
-         (entry (gethash expanded tramp-rpc--file-exists-cache)))
-    (if (not entry)
-        'not-cached
-      (let ((timestamp (car entry))
-            (value (cdr entry)))
-        (if (tramp-rpc--cache-entry-valid-p timestamp)
-            value
-          (remhash expanded tramp-rpc--file-exists-cache)
-          'not-cached))))))
+    (tramp-rpc--cache-lookup
+     tramp-rpc--file-exists-cache (expand-file-name filename))))
 
 (defun tramp-rpc-handle-file-exists-p (filename)
   "Like `file-exists-p' for TRAMP-RPC files.
@@ -3590,9 +3583,6 @@ MESSAGE describes the error."
     (signal 'file-error
             (tramp-rpc--error-args
              operation "Too many levels of symbolic links" message filename data)))
-   ((= code tramp-rpc-protocol-error-io)
-    (signal 'remote-file-error
-            (tramp-rpc--error-args operation nil message filename data)))
    (t
     (signal 'remote-file-error
             (tramp-rpc--error-args operation nil message filename data)))))
@@ -3671,6 +3661,15 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
         (tramp-flush-directory-properties v2 v2-localname)
         (tramp-rpc--invalidate-cache-for-path newname)))))
 
+(defun tramp-rpc--copy-directory-fallback
+    (dirname newname keep-date parents copy-contents)
+  "Run generic directory copy and invalidate only its source and destination."
+  (prog1
+      (tramp-handle-copy-directory
+       dirname newname keep-date parents copy-contents)
+    (tramp-rpc--invalidate-cache-for-path dirname)
+    (tramp-rpc--invalidate-cache-for-subtree newname)))
+
 (cl-defun tramp-rpc-handle-copy-directory
     (dirname newname &optional keep-date parents copy-contents)
   "Like `copy-directory' for TRAMP-RPC files.
@@ -3729,10 +3728,10 @@ COPY-CONTENTS non-nil copies directory contents."
                  (stats (tramp-rpc--call-batch
                          v1
                          `(("file.stat" . ,(append (tramp-rpc--encode-path src-localname)
-                                                    '((lstat . t))))
+                                                   '((lstat . t))))
                            ("file.stat" . ,(tramp-rpc--encode-path src-localname))
                            ("file.stat" . ,(append (tramp-rpc--encode-path actual-dest-localname)
-                                                    '((lstat . t))))
+                                                   '((lstat . t))))
                            ("file.stat" . ,(tramp-rpc--encode-path actual-dest-localname))
                            ("file.stat" . ,(tramp-rpc--encode-path parent-localname)))))
                  (source-lstat (tramp-rpc--batch-result-or-signal
@@ -3750,17 +3749,15 @@ COPY-CONTENTS non-nil copies directory contents."
             (if (or source-symlink-target
                     (and copy-directory-create-symlink
                          (equal source-lstat-type "symlink")))
-                (prog1
-                    (tramp-rpc--call
-                     v2 "file.make_symlink"
-                     `((target . ,(tramp-rpc--path-to-bin
-                                   (or source-symlink-target
-                                       (tramp-rpc--decode-string
-                                        (alist-get 'link_target source-lstat)))))
-                       (link_path . ,(tramp-rpc--path-to-bin symlink-dest-localname))))
-                  (tramp-rpc-clear-all-caches))
+                (tramp-rpc--call
+                 v2 "file.make_symlink"
+                 `((target . ,(tramp-rpc--path-to-bin
+                               (or source-symlink-target
+                                   (tramp-rpc--decode-string
+                                    (alist-get 'link_target source-lstat)))))
+                   (link_path . ,(tramp-rpc--path-to-bin symlink-dest-localname))))
               (let* ((source-stat (tramp-rpc--batch-result-or-signal
-                                    "file.stat" dirname source-stat-result))
+                                   "file.stat" dirname source-stat-result))
                      (actual-dest-lstat
                       (tramp-rpc--batch-result-or-signal
                        "file.stat" actual-dest actual-dest-lstat-result))
@@ -3801,7 +3798,7 @@ COPY-CONTENTS non-nil copies directory contents."
                     (signal 'file-error (list "Not a directory" parent))))
                 (when (zerop (logand (or (alist-get 'mode source-stat) 0) #o200))
                   (cl-return-from tramp-rpc-handle-copy-directory
-                    (tramp-handle-copy-directory
+                    (tramp-rpc--copy-directory-fallback
                      dirname newname keep-date parents copy-contents)))
                 (tramp-rpc--call v1 "file.copy"
                                  `((src . ,(tramp-rpc--path-to-bytes src-localname))
@@ -3834,7 +3831,8 @@ COPY-CONTENTS non-nil copies directory contents."
               (tramp-rpc--invalidate-cache-for-path dirname)
               (tramp-rpc--invalidate-cache-for-subtree
                (tramp-make-tramp-file-name v2 (file-name-quote copied-localname)))))))
-    (tramp-handle-copy-directory dirname newname keep-date parents copy-contents)))
+    (tramp-rpc--copy-directory-fallback
+     dirname newname keep-date parents copy-contents)))
 
 (cl-defun tramp-rpc-handle-copy-file
     (filename newname &optional ok-if-already-exists keep-time
@@ -3848,6 +3846,16 @@ PRESERVE-UID-GID requests ownership preservation on generic fallback paths.
 PRESERVE-PERMISSIONS non-nil preserves file permissions."
   (setq filename (expand-file-name filename)
         newname (expand-file-name newname))
+  ;; The RPC copy primitive cannot reliably change ownership as an
+  ;; unprivileged user.  Preserve upstream behavior instead of silently
+  ;; dropping PRESERVE-UID-GID.
+  (when (and preserve-uid-gid
+             (or (tramp-tramp-file-p filename)
+                 (tramp-tramp-file-p newname)))
+    (cl-return-from tramp-rpc-handle-copy-file
+      (tramp-sh-handle-copy-file
+       filename newname ok-if-already-exists keep-time
+       preserve-uid-gid preserve-permissions)))
   ;; Fast path for same-remote copies: batch source/destination stats, then do
   ;; the server-side copy.  This avoids the generic preflight predicates each
   ;; costing their own network round-trip.
@@ -3930,7 +3938,7 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
                                  (file-attributes filename))))
       (when preserve-permissions
         (set-file-extended-attributes newname (file-extended-attributes
-					      filename))))
+					       filename))))
      ;; Neither remote - should not reach this handler, but be safe.
      (t
       (tramp-run-real-handler
@@ -4510,94 +4518,56 @@ Returns t on success, nil on failure."
         (zerop (alist-get 'exit_code result))))))
 
 ;; ============================================================================
-;; Dired operations
-;; ============================================================================
-
-(defun tramp-rpc-handle-dired-compress-file (file)
-  "Like `dired-compress-file' for TRAMP-RPC files.
-FILE is the file name being handled."
-  (tramp-run-real-handler #'dired-compress-file (list file)))
-
-;; ============================================================================
 ;; Process operations
 ;; ============================================================================
 
-(defun tramp-rpc-run-git-commands (directory commands)
-  "Run multiple git COMMANDS in DIRECTORY using pipelined RPC.
-COMMANDS is a list of lists, where each sublist is arguments to git.
-For example: ((\"rev-parse\" \"HEAD\") (\"status\" \"--porcelain\"))
+(defun tramp-rpc--route-process-file-stream (destination output &optional file-p)
+  "Route OUTPUT to DESTINATION.
+When FILE-P is non-nil, a string DESTINATION names a file; otherwise it names
+an Emacs buffer, matching `call-process' and `process-file'."
+  (cond
+   ((null destination) nil)
+   ((eq destination t) (insert output))
+   ((bufferp destination)
+    (with-current-buffer destination (insert output)))
+   ((and (stringp destination) file-p)
+    (with-temp-file destination (insert output)))
+   ((stringp destination)
+    (with-current-buffer (get-buffer-create destination) (insert output)))))
 
-Returns a list of plists, each containing:
-  :exit-code - the exit code of the command
-  :stdout    - standard output as a string
-  :stderr    - standard error as a string
-
-This is much faster than running each command sequentially over TRAMP
-because all commands are sent in a single network round-trip."
-  (with-parsed-tramp-file-name directory nil
-    (setq localname (file-name-unquote localname))
-    (let* ((requests
-            (mapcar (lambda (args)
-                      (cons "process.run"
-                            `((cmd . "git")
-                              (args . ,(vconcat args))
-                              (cwd . ,localname))))
-                    commands))
-           (results (tramp-rpc--call-pipelined v requests)))
-      ;; Convert results to a more convenient format
-      (mapcar (lambda (result)
-                (if (plist-get result :error)
-                    (list :exit-code -1
-                          :stdout ""
-                          :stderr (or (plist-get result :message) "RPC error"))
-                  (list :exit-code (alist-get 'exit_code result)
-                        :stdout (tramp-rpc--decode-output
-                                 (alist-get 'stdout result))
-                        :stderr (tramp-rpc--decode-output
-                                 (alist-get 'stderr result)))))
-              results))))
+(defun tramp-rpc--process-file-merge-output-p (destination)
+  "Return non-nil when DESTINATION requires ordered combined output."
+  (or (not (consp destination))
+      (eq (car destination) :file)
+      (eq (cadr destination) t)))
 
 (defun tramp-rpc--route-process-file-output (destination stdout &optional stderr)
   "Route `process-file' STDOUT and STDERR according to DESTINATION.
-DESTINATION follows the `process-file' convention:
-  nil       - discard
-  t         - insert into current buffer
-  string    - write to file
-  buffer    - insert into buffer
-  (stdout-dest . stderr-dest) - cons for separate handling"
-  (cond
-   ((null destination) nil)
-   ((eq destination t)
-    (insert stdout))
-   ((stringp destination)
-    (with-temp-file destination
-      (insert stdout)))
-   ((bufferp destination)
-    (with-current-buffer destination
-      (insert stdout)))
-   ((consp destination)
-    (let ((stdout-dest (car destination))
-          (stderr-dest (cadr destination)))
-      (when stdout-dest
-        (cond
-         ((eq stdout-dest t) (insert stdout))
-         ((stringp stdout-dest)
-          (with-temp-file stdout-dest (insert stdout)))
-         ((bufferp stdout-dest)
-          (with-current-buffer stdout-dest (insert stdout)))))
-      (when (and stderr-dest stderr)
-        (cond
-         ((stringp stderr-dest)
-          (with-temp-file stderr-dest (insert stderr)))
-         ((bufferp stderr-dest)
-          (with-current-buffer stderr-dest (insert stderr)))))))))
+DESTINATION follows the `process-file' convention: nil discards output; t,
+a buffer, or a buffer name receives combined output; (:file FILE) writes
+combined output to FILE; and (STDOUT-DEST STDERR-DEST) separates the streams.
+A t STDERR-DEST mixes stderr into STDOUT-DEST."
+  (let ((combined (concat stdout (or stderr ""))))
+    (cond
+     ((and (consp destination) (eq (car destination) :file))
+      (tramp-rpc--route-process-file-stream (cadr destination) combined t))
+     ((consp destination)
+      (let ((stdout-destination (car destination))
+            (stderr-destination (cadr destination)))
+        (if (eq stderr-destination t)
+            (tramp-rpc--route-process-file-stream stdout-destination combined)
+          (tramp-rpc--route-process-file-stream stdout-destination stdout)
+          (when stderr
+            (tramp-rpc--route-process-file-stream stderr-destination stderr t)))))
+     (t
+      (tramp-rpc--route-process-file-stream destination combined)))))
 
 (defun tramp-rpc--get-signal-strings (vec)
   "Strings to return by `process-file' in case of signals on VEC.
 Runs `kill -l' on the remote host to get signal names, then maps
 signal numbers to human-readable strings like \"Interrupt\" or
 \"Signal 2\".  The result is cached per connection."
-  (with-tramp-connection-property vec "rpc-signal-strings"
+  (tramp-rpc--with-route-connection-property vec "rpc-signal-strings"
     (let* ((result (tramp-rpc--call vec "process.run"
                                     `((cmd . "/bin/sh")
                                       (args . ["-c" "kill -l"])
@@ -4665,88 +4635,88 @@ ARGS contains the original function arguments."
                (env (tramp-rpc--process-environment
                      v localname (equal program shell-file-name)))
                (stdin-content (when (and infile (not (eq infile t)))
-                                 (with-temp-buffer
-                                   (set-buffer-multibyte nil)
-                                   (insert-file-contents-literally infile)
-                                   (buffer-string))))
-               dispatched)
-          ;; Once dispatch is attempted, clear after every exit when Emacs says
-          ;; the command may have side effects.  This includes decoding,
-          ;; prefetch, and output-routing failures, and prevents metadata cached
-          ;; while the command ran from surviving it.
+                                (with-temp-buffer
+                                  (set-buffer-multibyte nil)
+                                  (insert-file-contents-literally infile)
+                                  (buffer-string)))))
+          ;; Clear after every RPC exit when Emacs says the command may have side
+          ;; effects.  This includes decoding, prefetch, and output-routing
+          ;; failures, and prevents metadata cached while the command ran from
+          ;; surviving it.
           (unwind-protect
-              (progn
-                (setq dispatched t)
-                (let ((result
-                       (condition-case err
-                           (tramp-rpc--call
-                            v "process.run"
-                            `((cmd . ,program)
-                              (args . ,(vconcat args))
-                              (cwd . ,localname)
-                              (env . ,env)
-                              ,@(when stdin-content
-                                  `((stdin . ,stdin-content)))))
-                         ;; The server marks confirmed spawn ENOENT as
-                         ;; `file-missing'.  Shell-based TRAMP returns status
-                         ;; 127 and leaves the diagnostic on stderr, so preserve
-                         ;; both parts of that contract for split destinations.
-                         (file-missing
-                          (tramp-rpc--route-process-file-output
-                           destination "" (concat (error-message-string err) "\n"))
-                          127))))
-                  (if (eq result 127)
-                      127
-                    (if result
-                        (let ((exit-code (alist-get 'exit_code result))
-                              (stdout (tramp-rpc--decode-output
-                                       (alist-get 'stdout result)))
-                              (stderr (tramp-rpc--decode-output
-                                       (alist-get 'stderr result))))
+              (let ((result
+                     (condition-case err
+                         (tramp-rpc--call
+                          v "process.run"
+                          `((cmd . ,program)
+                            (args . ,(vconcat args))
+                            (cwd . ,localname)
+                            (env . ,env)
+                            ,@(when (tramp-rpc--process-file-merge-output-p
+                                     destination)
+                                '((merge_stderr . t)))
+                            ,@(when stdin-content
+                                `((stdin . ,stdin-content)))))
+                       ;; The server marks confirmed spawn ENOENT as
+                       ;; `file-missing'.  Shell-based TRAMP returns status
+                       ;; 127 and leaves the diagnostic on stderr, so preserve
+                       ;; both parts of that contract for split destinations.
+                       (file-missing
+                        (tramp-rpc--route-process-file-output
+                         destination "" (concat (error-message-string err) "\n"))
+                        127))))
+                (if (eq result 127)
+                    127
+                  (if result
+                      (let ((exit-code (alist-get 'exit_code result))
+                            (stdout (tramp-rpc--decode-output
+                                     (alist-get 'stdout result)))
+                            (stderr (tramp-rpc--decode-output
+                                     (alist-get 'stderr result))))
 
-                          ;; Memoize uncached Magit git calls made during lazy
-                          ;; remote status expansion.
-                          (when (null infile)
-                            (tramp-rpc-magit--process-cache-store
-                             program args exit-code stdout))
+                        ;; Memoize uncached Magit git calls made during lazy
+                        ;; remote status expansion.
+                        (when (null infile)
+                          (tramp-rpc-magit--process-cache-store
+                           program args exit-code stdout))
 
-                          ;; Let the real `update-index --refresh' run, then
-                          ;; build the read snapshot used by later Magit calls.
-                          (when (and
-                                 (null infile)
-                                 (bound-and-true-p
-                                  tramp-rpc-magit--allow-process-cache)
-                                 (or (string-suffix-p "/git" program)
-                                     (string= "git" program))
-                                 (= exit-code 0)
-                                 (tramp-rpc-magit--git-cache-safe-environment-p))
-                            (let ((core-args
-                                   (tramp-rpc-magit--strip-git-prefix-args args)))
-                              (when (and
-                                     (equal (car core-args) "update-index")
-                                     (member "--refresh" core-args))
-                                (tramp-rpc-magit--clear-status-cache-for-connection v)
-                                (tramp-rpc-magit--prefetch default-directory))))
-
-                          (tramp-rpc--route-process-file-output
-                           destination stdout stderr)
-
-                          ;; Handle signal strings when requested by Emacs.
-                          (if (and
+                        ;; Let the real `update-index --refresh' run, then
+                        ;; build the read snapshot used by later Magit calls.
+                        (when (and
+                               (null infile)
                                (bound-and-true-p
-                                process-file-return-signal-string)
-                               (natnump exit-code) (>= exit-code 128))
-                              (let ((strings (tramp-rpc--get-signal-strings v)))
-                                (aref strings (- exit-code 128)))
-                            exit-code))
-                      ;; A successful RPC result is always non-nil.
-                      (signal 'remote-file-error
-                              (list "Empty process.run response"))))))
+                                tramp-rpc-magit--allow-process-cache)
+                               (or (string-suffix-p "/git" program)
+                                   (string= "git" program))
+                               (= exit-code 0)
+                               (tramp-rpc-magit--git-cache-safe-environment-p))
+                          (let ((core-args
+                                 (tramp-rpc-magit--strip-git-prefix-args args)))
+                            (when (and
+                                   (equal (car core-args) "update-index")
+                                   (member "--refresh" core-args))
+                              (tramp-rpc-magit--clear-status-cache-for-connection v)
+                              (tramp-rpc-magit--prefetch default-directory))))
+
+                        (tramp-rpc--route-process-file-output
+                         destination stdout stderr)
+
+                        ;; Handle signal strings when requested by Emacs.
+                        (if (and
+                             (bound-and-true-p
+                              process-file-return-signal-string)
+                             (natnump exit-code) (>= exit-code 128))
+                            (let ((strings (tramp-rpc--get-signal-strings v)))
+                              (aref strings (- exit-code 128)))
+                          exit-code))
+                    ;; A successful RPC result is always non-nil.
+                    (signal 'remote-file-error
+                            (list "Empty process.run response")))))
             ;; Any external command may mutate the filesystem, and watcher
             ;; delivery is asynchronous.  Honor Emacs' conservative default;
             ;; callers with a proven read-only scope can bind
             ;; `process-file-side-effects' to nil.
-            (when (and dispatched process-file-side-effects)
+            (when process-file-side-effects
               (tramp-rpc--clear-file-caches-for-connection v))))))))
 
 (defun tramp-rpc-handle-vc-registered (file)
@@ -5363,23 +5333,15 @@ the empty string."
     (when (hash-table-p tramp-rpc--file-notify-descriptors)
       (maphash
        (lambda (_descriptor data)
-         (let* ((watch-key (plist-get data :watch-key))
-                (watch-entry (and watch-key
-                                  (gethash watch-key
-                                           tramp-rpc--file-notify-watch-counts)))
-                (canonical-directory
-                 (or (plist-get watch-entry :canonical-directory)
-                     (plist-get data :canonical-directory)))
-                (directory (plist-get data :directory))
-                (relative (and canonical-directory directory
-                               (tramp-rpc--file-notify-relative-name
-                                canonical-directory file-name))))
-           (when relative
-             (let ((alias (if (string-empty-p relative)
-                              (directory-file-name directory)
-                            (expand-file-name relative directory))))
-               (unless (string= alias file-name)
-                 (cl-pushnew alias aliases :test #'string=))))))
+         (when-let* ((canonical-directory
+                      (tramp-rpc--file-notify-canonical-directory data))
+                     ((tramp-rpc--file-notify-relative-name
+                       canonical-directory file-name))
+                     (alias
+                      (tramp-rpc--file-notify-original-spelling
+                       data file-name))
+                     ((not (string= alias file-name))))
+           (cl-pushnew alias aliases :test #'string=)))
        tramp-rpc--file-notify-descriptors))
     aliases))
 
@@ -5725,7 +5687,7 @@ Also controls process exit detection latency."
     (file-name-all-completions . tramp-rpc-handle-file-name-all-completions)
     (make-directory . tramp-rpc-handle-make-directory)
     (delete-directory . tramp-rpc-handle-delete-directory)
-    (dired-compress-file . tramp-rpc-handle-dired-compress-file)
+
     (insert-directory . tramp-rpc-handle-insert-directory)
     (copy-directory . tramp-rpc-handle-copy-directory)
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -247,7 +247,9 @@ This is called from `tramp-multi-hop-p-hook'."
 ;; autoload-owned functions used by the full implementation below.
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
-(declare-function tramp-sh-handle-copy-file "tramp-sh" (&rest args))
+(declare-function tramp-sh-handle-copy-file "tramp-sh"
+                  (filename newname &optional ok-if-already-exists keep-date
+                            preserve-uid-gid preserve-extended-attributes))
 
 (defvar tramp-rpc--sudo-file-name-p-in-progress nil
   "Non-nil while checking hidden rpc+sudo proxy expansion.")
@@ -1036,10 +1038,21 @@ ARGS contains the remaining arguments of the advised TRAMP property function."
 (defmacro tramp-rpc--with-route-connection-property (vec property &rest body)
   "Evaluate BODY once and cache it under route-aware PROPERTY for VEC."
   (declare (indent 2) (debug t))
-  `(let ((tramp-rpc--route-property-access t))
-     (with-tramp-connection-property
-         ,vec (tramp-rpc--route-property-name ,vec ,property)
-       ,@body)))
+  (let ((cached-vec (make-symbol "vec"))
+        (cached-property (make-symbol "property"))
+        (missing (make-symbol "missing"))
+        (value (make-symbol "value")))
+    `(let* ((,cached-vec ,vec)
+            (,cached-property ,property)
+            (,missing (make-symbol "missing"))
+            (,value (tramp-rpc--get-route-connection-property
+                     ,cached-vec ,cached-property ,missing)))
+       (if (eq ,value ,missing)
+           (let ((,value (progn ,@body)))
+             (tramp-rpc--set-route-connection-property
+              ,cached-vec ,cached-property ,value)
+             ,value)
+         ,value))))
 
 (defun tramp-rpc--get-route-connection-property (vec property default)
   "Return route-aware connection PROPERTY for VEC, or DEFAULT."
@@ -3663,7 +3676,9 @@ PRESERVE-PERMISSIONS non-nil preserves file permissions."
 
 (defun tramp-rpc--copy-directory-fallback
     (dirname newname keep-date parents copy-contents)
-  "Run generic directory copy and invalidate only its source and destination."
+  "Copy DIRNAME to NEWNAME with the generic TRAMP handler.
+KEEP-DATE, PARENTS, and COPY-CONTENTS are passed through unchanged.  Invalidate
+only the source path and destination subtree caches."
   (prog1
       (tramp-handle-copy-directory
        dirname newname keep-date parents copy-contents)
@@ -3829,8 +3844,9 @@ COPY-CONTENTS non-nil copies directory contents."
               (tramp-flush-directory-properties v2 copied-parent-localname)
               (tramp-flush-connection-properties v2)
               (tramp-rpc--invalidate-cache-for-path dirname)
-              (tramp-rpc--invalidate-cache-for-subtree
-               (tramp-make-tramp-file-name v2 (file-name-quote copied-localname)))))))
+              ;; Preserve NEWNAME's quoted or unquoted spelling so custom cache
+              ;; keys and TRAMP properties for that spelling are both cleared.
+              (tramp-rpc--invalidate-cache-for-subtree newname)))))
     (tramp-rpc--copy-directory-fallback
      dirname newname keep-date parents copy-contents)))
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -530,12 +530,25 @@ The value must be a positive number."
   :type 'number
   :group 'tramp-rpc)
 
+(defcustom tramp-rpc-poll-interval 0.1
+  "Seconds between synchronous RPC response polls.
+The value must be a positive number."
+  :type 'number
+  :group 'tramp-rpc)
+
 (defun tramp-rpc--configured-call-timeout ()
   "Return the validated synchronous RPC call timeout."
   (unless (and (numberp tramp-rpc-call-timeout)
                (> tramp-rpc-call-timeout 0))
     (user-error "`tramp-rpc-call-timeout' must be a positive number"))
   tramp-rpc-call-timeout)
+
+(defun tramp-rpc--configured-poll-interval ()
+  "Return the validated synchronous RPC poll interval."
+  (unless (and (numberp tramp-rpc-poll-interval)
+               (> tramp-rpc-poll-interval 0))
+    (user-error "`tramp-rpc-poll-interval' must be a positive number"))
+  tramp-rpc-poll-interval)
 
 (defcustom tramp-rpc-use-controlmaster t
   "Whether to use SSH ControlMaster for connection sharing.
@@ -2195,7 +2208,8 @@ Returns the request ID."
 CONNECTION, when non-nil, is the captured connection generation to use.
 Returns the result or signals an error."
   (tramp-rpc--call-with-timeout
-   vec method params (tramp-rpc--configured-call-timeout) 0.1 connection))
+   vec method params (tramp-rpc--configured-call-timeout)
+   (tramp-rpc--configured-poll-interval) connection))
 
 (defun tramp-rpc--call-fast (vec method params)
   "Call METHOD with PARAMS with shorter timeout for low-latency ops.
@@ -2271,8 +2285,52 @@ connection's filter, and therefore no nested wait, can run inside BODY."
                           (eq timer (plist-get info timer-key))))
                (timer-activate timer))))))))
 
+(defun tramp-rpc--wait-for-response-ids
+    (conn process buffer ids timeout poll-interval label)
+  "Wait for IDS from PROCESS and return response state.
+CONN supplies the SSH stderr stream, BUFFER holds decoded responses, TIMEOUT
+is a wall-clock limit, and POLL-INTERVAL controls output polling.  LABEL is
+used only for debug messages.  The returned plist contains :responses,
+:remaining, :elapsed, and :process-live."
+  (let ((start-time (float-time))
+        (deadline (+ (float-time) timeout))
+        (remaining (copy-sequence ids))
+        (responses (make-hash-table :test 'eql)))
+    (cl-labels
+        ((collect ()
+           (dolist (id (copy-sequence remaining))
+             (when-let* ((response
+                          (tramp-rpc--find-response-by-id id process)))
+               (puthash id response responses)
+               (setq remaining (delete id remaining))))))
+      (with-current-buffer buffer
+        (collect)
+        (while (and remaining
+                    (< (float-time) deadline)
+                    (process-live-p process))
+          (if (not (tramp-rpc--process-accessible-p process))
+              (if non-essential
+                  (progn
+                    (tramp-rpc--debug "LOCKED-%s (non-essential, bailing)" label)
+                    (throw 'non-essential 'non-essential))
+                (sleep-for poll-interval)
+                (collect))
+            (if (tramp-rpc--with-suspended-timers-preserving-process-timers
+                  (with-local-quit
+                    (tramp-rpc--drain-connection-stderr conn)
+                    (accept-process-output process poll-interval nil t)
+                    (tramp-rpc--drain-connection-stderr conn)
+                    t))
+                (collect)
+              (tramp-rpc--debug "QUIT-%s (user interrupted)" label)
+              (keyboard-quit))))))
+    (list :responses responses
+          :remaining remaining
+          :elapsed (- (float-time) start-time)
+          :process-live (process-live-p process))))
+
 (defun tramp-rpc--call-with-timeout (vec method params total-timeout poll-interval
-                                          &optional connection)
+                                         &optional connection)
   "Call METHOD with PARAMS on the RPC server for VEC.
 TOTAL-TIMEOUT is maximum seconds to wait.
 POLL-INTERVAL is seconds between `accept-process-output' checks.
@@ -2296,66 +2354,18 @@ Returns the result or signals an error."
       ;; Send request (binary data with length prefix, no newline)
       (process-send-string process request)
 
-      ;; Wait for response with matching ID using wall-clock deadline.
-    ;; NOTE: We use (float-time) instead of decrementing a counter because
-    ;; accept-process-output can return early (e.g. async process output
-    ;; arrives), and decrementing by poll-interval each iteration would
-    ;; cause premature timeouts when there is concurrent I/O traffic.
-    (with-current-buffer buffer
-      (let ((start-time (float-time))
-            (deadline (+ (float-time) total-timeout))
-            response)
-        ;; A transport sentinel may have injected an error before the loop.
-        (setq response (tramp-rpc--find-response-by-id expected-id process))
-        ;; Wait for a response with the correct ID
-        (while (and (not response)
-                    (< (float-time) deadline)
-                    (process-live-p process))
-          ;; Check if process is locked to another thread before trying to accept
-          (if (not (tramp-rpc--process-accessible-p process))
-              (progn
-                ;; Process locked - if non-essential, bail out; otherwise sleep and retry
-                (if non-essential
-                    (progn
-                      (tramp-rpc--debug "LOCKED id=%s method=%s (non-essential, bailing)"
-                                       expected-id method)
-                      (throw 'non-essential 'non-essential))
-                  ;; Sleep briefly - other thread may receive our response
-                  (sleep-for poll-interval)
-                  ;; Check if other thread already got our response
-                  (setq response (tramp-rpc--find-response-by-id expected-id process))))
-            ;; Process is accessible - proceed with accept-process-output
-            ;; Use same pattern as tramp-accept-process-output:
-            ;; - poll-interval timeout to avoid spinning
-            ;; - JUST-THIS-ONE=t to only accept from this process (Bug#12145)
-            ;; - with-local-quit to allow C-g, returns t on success
-            ;; - Propagate quit if user pressed C-g
-            ;; - suspended timers to prevent deferred process sentinels
-            ;;   (scheduled via run-at-time 0) from firing inside
-            ;;   accept-process-output and blocking this call.  The
-            ;;   sentinels will run when control returns to the command
-            ;;   loop.  (Mirrors tramp-accept-process-output.)  The
-            ;;   wrapper additionally keeps process timers this wait
-            ;;   scheduled, which the plain suspension would discard.
-            (if (tramp-rpc--with-suspended-timers-preserving-process-timers
-                  (with-local-quit
-                    (tramp-rpc--drain-connection-stderr conn)
-                    (accept-process-output process poll-interval nil t)
-                    (tramp-rpc--drain-connection-stderr conn)
-                    t))
-                ;; Check if our response arrived in pending responses
-                (setq response (tramp-rpc--find-response-by-id expected-id process))
-              ;; User quit - propagate it
-              (tramp-rpc--debug "QUIT id=%s (user interrupted)" expected-id)
-              (keyboard-quit))))
+      (let* ((state (tramp-rpc--wait-for-response-ids
+                     conn process buffer (list expected-id) total-timeout
+                     poll-interval "CALL"))
+             (response (gethash expected-id (plist-get state :responses))))
 
         (unless response
           (if (or (process-get process :tramp-rpc-transport-dead)
-                  (not (process-live-p process)))
+                  (not (plist-get state :process-live)))
               (signal 'remote-file-error
                       (list (format "RPC transport disconnected from %s"
                                     (tramp-file-name-host vec))))
-            (let ((elapsed (- (float-time) start-time))
+            (let ((elapsed (plist-get state :elapsed))
                   (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
               (tramp-rpc--debug
                "TIMEOUT id=%s method=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
@@ -2379,9 +2389,9 @@ Returns the result or signals an error."
                   (data (tramp-rpc-protocol-error-data response))
                   (os-errno (tramp-rpc-protocol-error-errno response)))
               (tramp-rpc--debug "ERROR id=%s code=%s msg=%s errno=%s"
-                               expected-id code msg os-errno)
+				expected-id code msg os-errno)
               (tramp-rpc--signal-rpc-error "RPC" msg code os-errno nil data))
-          (plist-get response :result)))))))
+          (plist-get response :result))))))
 
 (defun tramp-rpc--call-batch (vec requests)
   "Execute multiple RPC REQUESTS in a single round-trip for VEC.
@@ -2399,6 +2409,7 @@ Returns:
    ((type . \"file\") ...)    ; file.stat result
    (:error -32001 :message \"...\"))  ; or error plist"
   (let* ((timeout (tramp-rpc--configured-call-timeout))
+         (poll-interval (tramp-rpc--configured-poll-interval))
          (conn (tramp-rpc--ensure-connection vec))
          (process (plist-get conn :process))
          (buffer (plist-get conn :buffer))
@@ -2407,59 +2418,26 @@ Returns:
                             requests)))
          (expected-id (car id-and-request))
          (request (cdr id-and-request)))
-
     (tramp-rpc--debug "SEND-BATCH id=%s count=%d" expected-id (length requests))
     (tramp-rpc--track-pending-request process expected-id)
-
     (tramp-rpc--with-pending-requests
         (process buffer (list expected-id) vec "Batch RPC interrupted\n")
-      ;; Send batch request (binary data with length prefix, no newline)
       (process-send-string process request)
-
-      ;; Wait for response with matching ID using wall-clock deadline
-    (with-current-buffer buffer
-      (let ((start-time (float-time))
-            (deadline (+ (float-time) timeout))
-            response)
-        ;; A transport sentinel may have injected an error before the loop.
-        (setq response (tramp-rpc--find-response-by-id expected-id process))
-        (while (and (not response)
-                    (< (float-time) deadline)
-                    (process-live-p process))
-          ;; Check if process is locked to another thread before trying to accept
-          (if (not (tramp-rpc--process-accessible-p process))
-              ;; Process locked - if non-essential, bail out; otherwise sleep and retry
-              (if non-essential
-                  (progn
-                    (tramp-rpc--debug "LOCKED-BATCH id=%s (non-essential, bailing)" expected-id)
-                    (throw 'non-essential 'non-essential))
-                ;; Sleep briefly - other thread may receive our response
-                (sleep-for 0.1)
-                ;; Check if other thread already got our response
-                (setq response (tramp-rpc--find-response-by-id expected-id process)))
-            ;; Process is accessible
-            (if (tramp-rpc--with-suspended-timers-preserving-process-timers
-                  (with-local-quit
-                    (tramp-rpc--drain-connection-stderr conn)
-                    (accept-process-output process 0.1 nil t)
-                    (tramp-rpc--drain-connection-stderr conn)
-                    t))
-                ;; Check if our response arrived in pending responses
-                (setq response (tramp-rpc--find-response-by-id expected-id process))
-              (tramp-rpc--debug "QUIT-BATCH id=%s (user interrupted)" expected-id)
-              (keyboard-quit))))
-
+      (let* ((state (tramp-rpc--wait-for-response-ids
+                     conn process buffer (list expected-id) timeout
+                     poll-interval "BATCH"))
+             (response (gethash expected-id (plist-get state :responses))))
         (unless response
           (if (or (process-get process :tramp-rpc-transport-dead)
-                  (not (process-live-p process)))
+                  (not (plist-get state :process-live)))
               (signal 'remote-file-error
                       (list (format "RPC transport disconnected from %s"
                                     (tramp-file-name-host vec))))
-            (let ((elapsed (- (float-time) start-time))
+            (let ((elapsed (plist-get state :elapsed))
                   (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
               (tramp-rpc--debug
                "TIMEOUT-BATCH id=%s elapsed=%.1fs buffer-size=%d process-live=%s stderr-tail=%S"
-               expected-id elapsed (buffer-size) (process-live-p process)
+               expected-id elapsed (buffer-size) (plist-get state :process-live)
                stderr-tail)
               (tramp-rpc--invalidate-timed-out-connection
                process vec "Batch RPC timeout\n")
@@ -2471,17 +2449,16 @@ Returns:
                        (tramp-file-name-host vec) expected-id elapsed)
                       (when stderr-tail
                         (format "; SSH stderr: %s" stderr-tail))))))))
-
         (tramp-rpc--debug "RECV-BATCH id=%s (found)" expected-id)
         (if (tramp-rpc-protocol-error-p response)
             (progn
               (tramp-rpc--debug "ERROR-BATCH id=%s msg=%s"
-                               expected-id (tramp-rpc-protocol-error-message response))
-              (signal
-	       'remote-file-error
-	       (list "Batch RPC error"
-                     (tramp-rpc-protocol-error-message response))))
-          (tramp-rpc-protocol-decode-batch-response response)))))))
+                                expected-id
+                                (tramp-rpc-protocol-error-message response))
+              (signal 'remote-file-error
+		      (list "Batch RPC error"
+			    (tramp-rpc-protocol-error-message response))))
+          (tramp-rpc-protocol-decode-batch-response response))))))
 
 ;; ============================================================================
 ;; Request pipelining support
@@ -2530,77 +2507,38 @@ TIMEOUT is the maximum time to wait in seconds.
 When nil, `tramp-rpc-call-timeout' is used.  CONNECTION, when non-nil, is the
 captured connection generation to use."
   (let* ((timeout (or timeout (tramp-rpc--configured-call-timeout)))
+         (poll-interval (tramp-rpc--configured-poll-interval))
          (conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (plist-get conn :process))
-         (buffer (plist-get conn :buffer))
-         (deadline (+ (float-time) timeout))
-         (remaining-ids (copy-sequence ids))
-         (responses (make-hash-table :test 'eql)))
+         (buffer (plist-get conn :buffer)))
     (tramp-rpc--debug "RECV-PIPE waiting for %d responses: %S" (length ids) ids)
     (tramp-rpc--with-pending-requests
         (process buffer ids vec "Pipelined RPC interrupted\n")
-      (progn
-          (with-current-buffer buffer
-            ;; Consume transport-death errors before checking process status.
-            (dolist (id remaining-ids)
-              (let ((response (tramp-rpc--find-response-by-id id process)))
-                (when response
-                  (puthash id response responses)
-                  (setq remaining-ids (delete id remaining-ids)))))
-            (while (and remaining-ids
-                  (< (float-time) deadline)
-                  (process-live-p process))
-        ;; Check if process is locked to another thread before trying to accept
-        (if (not (tramp-rpc--process-accessible-p process))
-            ;; Process locked - if non-essential, bail out; otherwise sleep and retry
-            (if non-essential
-                (progn
-                  (tramp-rpc--debug "LOCKED-PIPE (non-essential, bailing)")
-                  (throw 'non-essential 'non-essential))
-              ;; Sleep briefly - other thread may receive our responses
-              (sleep-for 0.1)
-              ;; Check if other thread already got any of our responses
-              (dolist (id remaining-ids)
-                (let ((response (tramp-rpc--find-response-by-id id process)))
-                  (when response
-                    (tramp-rpc--debug "RECV-PIPE found id=%s (after sleep)" id)
-                    (puthash id response responses)
-                    (setq remaining-ids (delete id remaining-ids))))))
-          ;; Process is accessible
-          (if (tramp-rpc--with-suspended-timers-preserving-process-timers
-                (with-local-quit
-                  (tramp-rpc--drain-connection-stderr conn)
-                  (accept-process-output process 0.1 nil t)
-                  (tramp-rpc--drain-connection-stderr conn)
-                  t))
-              ;; Check for each remaining ID in pending responses
-              (dolist (id remaining-ids)
-                (let ((response (tramp-rpc--find-response-by-id id process)))
-                  (when response
-                    (tramp-rpc--debug "RECV-PIPE found id=%s" id)
-                    ;; Store response by ID
-                    (puthash id response responses)
-                    ;; Remove from remaining
-                    (setq remaining-ids (delete id remaining-ids)))))
-            (tramp-rpc--debug "RECV-PIPE quit (user interrupted)")
-            (keyboard-quit)))))
-          (when remaining-ids
-            (tramp-rpc--debug "RECV-PIPE missing ids: %S" remaining-ids)
-            (let ((process-live (process-live-p process)))
-              (when process-live
-                (tramp-rpc--invalidate-timed-out-connection
-                 process vec "Pipelined RPC timeout\n"))
-              (signal
-               'remote-file-error
-               (list (if process-live
-                         (format "Timeout waiting for pipelined RPC responses from %s (missing ids: %S)"
-                                 (tramp-file-name-host vec) remaining-ids)
-                       (format "RPC process died waiting for pipelined responses from %s (missing ids: %S)"
-                               (tramp-file-name-host vec) remaining-ids))))))
-          ;; Convert hash table to alist in original order
-          (mapcar (lambda (id)
-                    (cons id (gethash id responses)))
-                  ids)))))
+      (let* ((state (tramp-rpc--wait-for-response-ids
+                     conn process buffer ids timeout poll-interval "PIPE"))
+             (remaining-ids (plist-get state :remaining))
+             (responses (plist-get state :responses)))
+        (when remaining-ids
+          (tramp-rpc--debug "RECV-PIPE missing ids: %S" remaining-ids)
+          (let ((process-live (plist-get state :process-live))
+                (stderr-tail (tramp-rpc--connection-stderr-tail conn)))
+            (when process-live
+              (tramp-rpc--invalidate-timed-out-connection
+               process vec "Pipelined RPC timeout\n"))
+            (signal
+             'remote-file-error
+             (list
+              (if process-live
+                  (concat
+                   (format
+                    "Timeout waiting for pipelined RPC responses from %s (missing ids: %S)"
+                    (tramp-file-name-host vec) remaining-ids)
+                   (when stderr-tail
+                     (format "; SSH stderr: %s" stderr-tail)))
+                (format
+                 "RPC process died waiting for pipelined responses from %s (missing ids: %S)"
+                 (tramp-file-name-host vec) remaining-ids))))))
+        (mapcar (lambda (id) (cons id (gethash id responses))) ids)))))
 
 (defun tramp-rpc--call-pipelined (vec requests)
   "Execute multiple REQUESTS in a pipelined fashion for VEC.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,7 +33,7 @@ notify = "8.2"
 ignore = "0.4"
 
 # Safe syscall wrappers.
-rustix = { version = "1", features = ["std", "fs", "process"] }
+rustix = { version = "1", features = ["std", "fs", "pipe", "process"] }
 
 # Linux real-time signal bounds are provided by libc at runtime.
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -11,6 +11,9 @@ use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, tcgetpgrp};
 use rmpv::Value;
 use rustix::io::fcntl_dupfd_cloexec;
+#[cfg(target_vendor = "apple")]
+use rustix::pipe::pipe;
+#[cfg(not(target_vendor = "apple"))]
 use rustix::pipe::{PipeFlags, pipe_with};
 use rustix::process::{Pid as RustixPid, Signal as RustixSignal};
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -44,7 +47,16 @@ pub(crate) fn is_benign_stdin_error(error: &std::io::Error) -> bool {
 }
 
 fn merged_output_fds() -> std::io::Result<(OwnedFd, OwnedFd, OwnedFd)> {
+    #[cfg(target_vendor = "apple")]
+    let (read_fd, write_fd) = {
+        let (read_fd, write_fd) = pipe()?;
+        set_fd_cloexec(read_fd.as_raw_fd())?;
+        set_fd_cloexec(write_fd.as_raw_fd())?;
+        (read_fd, write_fd)
+    };
+    #[cfg(not(target_vendor = "apple"))]
     let (read_fd, write_fd) = pipe_with(PipeFlags::CLOEXEC)?;
+
     let stderr_fd = fcntl_dupfd_cloexec(&write_fd, 0)?;
     Ok((read_fd, write_fd, stderr_fd))
 }

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -10,13 +10,15 @@ use nix::sys::termios::{LocalFlags, OutputFlags, SetArg, tcgetattr, tcsetattr};
 use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{Pid, tcgetpgrp};
 use rmpv::Value;
+use rustix::io::fcntl_dupfd_cloexec;
+use rustix::pipe::{PipeFlags, pipe_with};
 use rustix::process::{Pid as RustixPid, Signal as RustixSignal};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use rustix_libc_wrappers::process::SignalExt;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command as StdCommand, ExitStatus, Stdio};
@@ -39,6 +41,19 @@ pub(crate) fn is_benign_stdin_error(error: &std::io::Error) -> bool {
         error.kind(),
         ErrorKind::BrokenPipe | ErrorKind::WriteZero | ErrorKind::ConnectionReset
     )
+}
+
+fn merged_output_fds() -> std::io::Result<(OwnedFd, OwnedFd, OwnedFd)> {
+    let (read_fd, write_fd) = pipe_with(PipeFlags::CLOEXEC)?;
+    let stderr_fd = fcntl_dupfd_cloexec(&write_fd, 0)?;
+    Ok((read_fd, write_fd, stderr_fd))
+}
+
+fn merged_output_pipe() -> std::io::Result<(Stdio, Stdio, tokio::fs::File)> {
+    let (read_fd, write_fd, stderr_fd) = merged_output_fds()?;
+    let reader = tokio::fs::File::from_std(std::fs::File::from(read_fd));
+
+    Ok((Stdio::from(write_fd), Stdio::from(stderr_fd), reader))
 }
 
 pub(crate) async fn read_sync_output<R>(
@@ -324,6 +339,9 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
         /// Clear environment before setting env vars
         #[serde(default)]
         clear_env: bool,
+        /// Capture stdout and stderr through one ordered pipe
+        #[serde(default)]
+        merge_stderr: bool,
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -353,8 +371,17 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
         Stdio::null()
     });
 
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
+    let merged_reader = if params.merge_stderr {
+        let (stdout, stderr, reader) =
+            merged_output_pipe().map_err(|error| RpcError::process_error(error.to_string()))?;
+        cmd.stdout(stdout);
+        cmd.stderr(stderr);
+        Some(reader)
+    } else {
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        None
+    };
     cmd.kill_on_drop(true);
     configure_process_group(&mut cmd);
 
@@ -371,6 +398,10 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
             return Err(spawn_error(error, executable_missing));
         }
     };
+    // Tokio's Command retains custom Stdio handles after spawn.  Drop it so
+    // the parent does not keep the merged pipe's write ends open and prevent
+    // the reader from observing EOF after the child exits.
+    drop(cmd);
     let child_pid = child
         .id()
         .ok_or_else(|| RpcError::process_error("Spawned process has no PID"))?;
@@ -382,14 +413,20 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
     // early (`head`, `grep -q', ...) is normal and its output must survive.
     let stdin_data = params.stdin;
     let mut stdin = child.stdin.take();
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| RpcError::process_error("Failed to capture process stdout"))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| RpcError::process_error("Failed to capture process stderr"))?;
+    let separate_streams = if merged_reader.is_none() {
+        Some((
+            child
+                .stdout
+                .take()
+                .ok_or_else(|| RpcError::process_error("Failed to capture process stdout"))?,
+            child
+                .stderr
+                .take()
+                .ok_or_else(|| RpcError::process_error("Failed to capture process stderr"))?,
+        ))
+    } else {
+        None
+    };
     let write_stdin = async move {
         if let Some(data) = stdin_data
             && let Some(mut stdin) = stdin.take()
@@ -406,18 +443,40 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
     // intentionally per-run rather than server-wide, so admission permits up
     // to GENERAL_TASK_LIMIT concurrent allocations of this size.
     let remaining = Arc::new(Semaphore::new(output_limit));
-    let result = tokio::try_join!(
-        write_stdin,
-        read_sync_output(stdout, Arc::clone(&remaining), output_limit),
-        read_sync_output(stderr, remaining, output_limit),
-        async {
-            child
-                .wait()
-                .await
-                .map_err(|e| std::io::Error::other(format!("Failed to wait for process: {e}")))
-        }
-    );
-    let ((), stdout, stderr, status) = match result {
+    let result =
+        if let Some(reader) = merged_reader {
+            tokio::try_join!(
+                write_stdin,
+                read_sync_output(reader, remaining, output_limit),
+                async {
+                    child.wait().await.map_err(|e| {
+                        std::io::Error::other(format!("Failed to wait for process: {e}"))
+                    })
+                }
+            )
+            .map(|((), output, status)| (output, Vec::new(), status))
+        } else {
+            let (stdout, stderr) = match separate_streams {
+                Some(streams) => streams,
+                None => {
+                    return Err(RpcError::process_error(
+                        "Separate process streams were not captured",
+                    ));
+                }
+            };
+            tokio::try_join!(
+                write_stdin,
+                read_sync_output(stdout, Arc::clone(&remaining), output_limit),
+                read_sync_output(stderr, remaining, output_limit),
+                async {
+                    child.wait().await.map_err(|e| {
+                        std::io::Error::other(format!("Failed to wait for process: {e}"))
+                    })
+                }
+            )
+            .map(|((), stdout, stderr, status)| (stdout, stderr, status))
+        };
+    let (stdout, stderr, status) = match result {
         Ok(result) => result,
         Err(error) => {
             let _ = child.kill().await;
@@ -1321,7 +1380,6 @@ pub async fn list(_params: Value) -> HandlerResult {
 // PTY (Pseudo-Terminal) Process Management
 // ============================================================================
 
-use std::os::unix::io::{FromRawFd, OwnedFd};
 use std::os::unix::process::CommandExt;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
@@ -2671,6 +2729,40 @@ mod tests {
         assert_eq!(
             map_get(&result, "exit_code").and_then(Value::as_i64),
             Some(3)
+        );
+    }
+
+    #[test]
+    fn merged_output_descriptors_are_close_on_exec() {
+        let (read_fd, stdout_fd, stderr_fd) = merged_output_fds().expect("merged output pipe");
+        for fd in [&read_fd, &stdout_fd, &stderr_fd] {
+            let flags = rustix::io::fcntl_getfd(fd).expect("descriptor flags");
+            assert!(flags.contains(rustix::io::FdFlags::CLOEXEC));
+        }
+    }
+
+    #[tokio::test]
+    async fn process_run_merge_stderr_preserves_stream_order() {
+        let params = Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("/bin/sh".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![
+                    Value::String("-c".into()),
+                    Value::String("printf stderr >&2; printf stdout".into()),
+                ]),
+            ),
+            (Value::String("merge_stderr".into()), Value::Boolean(true)),
+        ]);
+
+        let result = run(params).await.expect("merged process output");
+        assert_eq!(
+            map_get(&result, "stdout").and_then(Value::as_slice),
+            Some(b"stderrstdout".as_slice())
+        );
+        assert_eq!(
+            map_get(&result, "stderr").and_then(Value::as_slice),
+            Some([].as_slice())
         );
     }
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -7703,6 +7703,16 @@ discard it for being unreadable."
       (should (equal (seq-take captured 2) '("/bin/sh" "-c")))
       (should (string-match-p "2>/tmp/stderr\\\\ file" (nth 2 captured))))))
 
+(ert-deftest tramp-rpc-mock-test-make-process-pty-sudo-rejects-stderr-file ()
+  "PTY sudo must not hide an interactive password prompt in a stderr file."
+  (let ((default-directory "/rpc:user@host:/work/"))
+    (should-error
+     (tramp-rpc-handle-make-process
+      :name "sudo-stderr-pty" :buffer nil
+      :command '("sudo" "id") :connection-type 'pty
+      :stderr "/rpc:user@host:/tmp/stderr" :noquery t)
+     :type 'file-error)))
+
 (ert-deftest tramp-rpc-mock-test-make-process-sudo-pipe-uses-stdin-password ()
   "Pipe-mode literal sudo should authenticate in the same stdin context."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
@@ -7996,6 +8006,30 @@ discard it for being unreadable."
       (tramp-flush-connection-properties direct)
       (tramp-flush-connection-properties hopped))))
 
+(ert-deftest tramp-rpc-mock-test-route-property-cache-qualifies-nested-writes ()
+  "Route-aware cache bodies still qualify nested generic property writes."
+  (let ((vec (tramp-dissect-file-name "/rpc:user@target:/"))
+        (evaluations 0))
+    (unwind-protect
+        (progn
+          (should
+           (eq (tramp-rpc--with-route-connection-property vec "test-property"
+                 (setq evaluations (1+ evaluations))
+                 (tramp-set-connection-property vec "uid-integer" 1000)
+                 'cached)
+               'cached))
+          (should
+           (eq (tramp-rpc--with-route-connection-property vec "test-property"
+                 (setq evaluations (1+ evaluations))
+                 'recomputed)
+               'cached))
+          (should (= evaluations 1))
+          (should (= (tramp-get-connection-property vec "uid-integer" nil) 1000))
+          (let ((tramp-rpc--route-property-access t))
+            (should-not
+             (tramp-get-connection-property vec "uid-integer" nil))))
+      (tramp-flush-connection-properties vec))))
+
 (ert-deftest tramp-rpc-mock-test-sudo-route-properties-do-not-collide ()
   "Generic TRAMP properties distinguish separate sudo-via-RPC routes."
   (let* ((first (make-tramp-file-name
@@ -8153,6 +8187,21 @@ discard it for being unreadable."
     (should (string-match-p "shasum -a 256" command))
     (should (string-match-p "mv -f" command))))
 
+(ert-deftest tramp-rpc-mock-test-deploy-debug-log-supports-relative-path ()
+  "Deployment debug logging accepts a file in `default-directory'."
+  (let ((directory (make-temp-file "tramp-rpc-deploy-log" t))
+        (old-log-file (getenv "TRAMP_RPC_DEPLOY_DEBUG_LOG")))
+    (unwind-protect
+        (let ((default-directory (file-name-as-directory directory))
+              (tramp-rpc-deploy-debug t))
+          (setenv "TRAMP_RPC_DEPLOY_DEBUG_LOG" "deploy.log")
+          (tramp-rpc-deploy--log "relative log")
+          (with-temp-buffer
+            (insert-file-contents (expand-file-name "deploy.log" directory))
+            (should (string-match-p "relative log" (buffer-string)))))
+      (setenv "TRAMP_RPC_DEPLOY_DEBUG_LOG" old-log-file)
+      (delete-directory directory t))))
+
 (ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-returns-status-and-output ()
   "The deploy diagnostic SSH helper keeps argv separate and returns status."
   (let (program args)
@@ -8168,6 +8217,48 @@ discard it for being unreadable."
     (should (equal args
                    '("-o" "BatchMode=yes" "-o" "ConnectTimeout=10"
                      "-l" "user name" "--" "-host" "echo ok")))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-handles-missing-program ()
+  "A missing SSH executable is returned as a failed diagnostic result."
+  (cl-letf (((symbol-function 'call-process)
+             (lambda (&rest _args)
+               (signal 'file-missing '("Searching for program" "ssh")))))
+    (let ((result (tramp-rpc-deploy--diagnose-ssh "host" nil "true")))
+      (should (= (car result) 127))
+      (should (string-match-p "ssh" (cdr result))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-normalizes-signal-status ()
+  "A signal-terminated SSH process returns numeric failure and its message."
+  (cl-letf (((symbol-function 'call-process)
+             (lambda (_program _infile destination _display &rest _args)
+               (when destination (insert "partial output"))
+               "killed by signal 15")))
+    (let ((result (tramp-rpc-deploy--diagnose-ssh "host" nil "true")))
+      (should (= (car result) 128))
+      (should (equal (cdr result)
+                     "partial output\nkilled by signal 15")))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-diagnose-includes-failure-output ()
+  "Deployment diagnostics retain output from every failed remote check."
+  (let ((tramp-rpc-deploy-bootstrap-method "rsync")
+        (buffer-name "*tramp-rpc-diagnose*"))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc-deploy--diagnose-ssh)
+                   (lambda (_host _user command &optional _timeout)
+                     (cond
+                      ((string-match-p "SSH_OK" command) '(0 . "SSH_OK"))
+                      ((string-match-p "uname" command) '(1 . "arch failure"))
+                      ((string-match-p "mkdir" command) '(1 . "directory failure"))
+                      ((string-match-p "sha256sum" command) '(0 . "checksum failure NONE"))
+                      ((string-match-p "rsync" command) '(0 . "rsync failure NONE")))))
+                  ((symbol-function 'display-buffer) #'ignore))
+          (tramp-rpc-deploy-diagnose "host" "")
+          (with-current-buffer buffer-name
+            (dolist (message '("arch failure" "directory failure"
+                               "checksum failure NONE" "rsync failure NONE"))
+              (should (string-match-p message (buffer-string))))))
+      (when-let* ((buffer (get-buffer buffer-name)))
+        (kill-buffer buffer)))))
 
 ;;; ============================================================================
 ;;; Test Runner

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -8150,11 +8150,10 @@ discard it for being unreadable."
     (should (equal paths '("/rpc:one:/source")))
     (should (equal subtrees '("/rpc:two:/dest")))))
 
-(ert-deftest tramp-rpc-mock-test-copy-file-preserve-uid-gid-uses-upstream ()
-  "Every remote ownership-preserving combination uses upstream TRAMP."
+(ert-deftest tramp-rpc-mock-test-copy-file-preserve-uid-gid-uses-upstream-cross-boundary ()
+  "Ownership-preserving copies crossing the RPC boundary use upstream TRAMP."
   (should (fboundp 'tramp-sh-handle-copy-file))
-  (dolist (files '(("/rpc:mock:/source" "/rpc:mock:/dest")
-                   ("/rpc:mock:/source" "/tmp/dest")
+  (dolist (files '(("/rpc:mock:/source" "/tmp/dest")
                    ("/tmp/source" "/rpc:mock:/dest")
                    ("/rpc:one:/source" "/rpc:two:/dest")))
     (let (arguments)
@@ -8165,6 +8164,27 @@ discard it for being unreadable."
               (car files) (cadr files) t t t t)
              'upstream)))
       (should (equal (nth 4 arguments) t)))))
+
+(ert-deftest tramp-rpc-mock-test-copy-file-preserve-uid-gid-same-remote-uses-rpc ()
+  "Same-remote ownership preservation copies and changes ownership via RPC."
+  (let (calls)
+    (cl-letf (((symbol-function 'tramp-rpc--call-batch)
+               (lambda (&rest _args)
+                 '(((type . "file") (uid . 42) (gid . 84)) nil)))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (_vec method params)
+                 (push (cons method params) calls)
+                 t))
+              ((symbol-function 'tramp-flush-file-properties) #'ignore)
+              ((symbol-function 'tramp-flush-directory-properties) #'ignore)
+              ((symbol-function 'tramp-rpc--invalidate-cache-for-path) #'ignore))
+      (tramp-rpc--copy-file-same-remote
+       "/rpc:mock:/source" "/rpc:mock:/dest" t t t t))
+    (setq calls (nreverse calls))
+    (should (equal (mapcar #'car calls) '("file.copy" "file.chown")))
+    (should (eq (alist-get 'preserve (cdr (car calls))) t))
+    (should (= (alist-get 'uid (cdr (cadr calls))) 42))
+    (should (= (alist-get 'gid (cdr (cadr calls))) 84))))
 
 (ert-deftest tramp-rpc-mock-test-remote-stderr-command-wrapper-is-argv-safe ()
   "Remote stderr redirection preserves command argv in pipe and PTY paths."
@@ -8226,6 +8246,15 @@ discard it for being unreadable."
     (let ((result (tramp-rpc-deploy--diagnose-ssh "host" nil "true")))
       (should (= (car result) 127))
       (should (string-match-p "ssh" (cdr result))))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-handles-file-errors ()
+  "SSH launch errors such as permission failures are diagnostic results."
+  (cl-letf (((symbol-function 'call-process)
+             (lambda (&rest _args)
+               (signal 'file-error '("Opening process" "Permission denied")))))
+    (let ((result (tramp-rpc-deploy--diagnose-ssh "host" nil "true")))
+      (should (= (car result) 127))
+      (should (string-match-p "Permission denied" (cdr result))))))
 
 (ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-normalizes-signal-status ()
   "A signal-terminated SSH process returns numeric failure and its message."

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1109,7 +1109,18 @@ literally finds nothing."
           ;; stdout is now raw binary
           (let ((stdout (alist-get 'stdout result)))
             (should (msgpack-bin-p stdout))
-            (should (string-match-p "hello world" (msgpack-bin-string stdout))))))
+            (should (string-match-p "hello world" (msgpack-bin-string stdout)))))
+        ;; Combined destinations require the server to preserve cross-stream
+        ;; emission order rather than concatenating independently captured data.
+        (let* ((result (tramp-rpc-mock-test--rpc-call
+                        "process.run"
+                        '((cmd . "/bin/sh")
+                          (args . ["-c" "printf stderr >&2; printf stdout"])
+                          (merge_stderr . t))))
+               (stdout (alist-get 'stdout result))
+               (stderr (alist-get 'stderr result)))
+          (should (equal (msgpack-bin-string stdout) "stderrstdout"))
+          (should (equal (msgpack-bin-string stderr) ""))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-process-spawn-enoent-is-classified ()
@@ -1312,7 +1323,6 @@ This matches the behavior expected by `tramp-test28-process-file'."
 (declare-function tramp-rpc-handle-magit-status-refresh-buffer "tramp-rpc-magit" ())
 (declare-function tramp-rpc-magit--section-show-advice
                   "tramp-rpc-magit" (orig section))
-(declare-function tramp-rpc-handle-dired-compress-file "tramp-rpc" (file))
 (declare-function tramp-rpc--file-notify-dispatch-rescan
                   "tramp-rpc" (connection-process))
 (declare-function tramp-rpc--acl-enabled-p "tramp-rpc" (vec))
@@ -1358,7 +1368,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
   (setq tramp-rpc-magit--allow-process-cache nil))
 
 (ert-deftest tramp-rpc-mock-test-process-write-queues-isolate-connections ()
-  "Queues with the same remote PID remain isolated by RPC connection." 
+  "Queues with the same remote PID remain isolated by RPC connection."
   (let* ((vec-a (tramp-dissect-file-name "/rpc:queue-a:/tmp/"))
          (vec-b (tramp-dissect-file-name "/rpc:queue-b:/tmp/"))
          (buffer-a (generate-new-buffer " *tramp-rpc-queue-a*"))
@@ -1396,7 +1406,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (clrhash tramp-rpc--process-write-queues))))
 
 (ert-deftest tramp-rpc-mock-test-process-write-queue-ordered-callbacks ()
-  "A queue dispatches writes in order, one acknowledgement at a time." 
+  "A queue dispatches writes in order, one acknowledgement at a time."
   (let* ((vec (tramp-dissect-file-name "/rpc:queue-order:/tmp/"))
          (buffer (generate-new-buffer " *tramp-rpc-queue-order*"))
          (connection (start-process "tramp-rpc-queue-order" buffer "sleep" "10"))
@@ -1427,7 +1437,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (clrhash tramp-rpc--process-write-queues)))))
 
 (ert-deftest tramp-rpc-mock-test-process-write-queue-callback-after-cleanup ()
-  "A late write callback cannot recreate a cleaned queue." 
+  "A late write callback cannot recreate a cleaned queue."
   (let* ((vec (tramp-dissect-file-name "/rpc:queue-cleanup:/tmp/"))
          (buffer (generate-new-buffer " *tramp-rpc-queue-cleanup*"))
          (connection (start-process "tramp-rpc-queue-cleanup" buffer "sleep" "10"))
@@ -1450,7 +1460,7 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (clrhash tramp-rpc--process-write-queues))))
 
 (ert-deftest tramp-rpc-mock-test-process-write-queue-timeout-preserves-pending-data ()
-  "Queue drain timeout reports and retains bytes instead of closing stdin." 
+  "Queue drain timeout reports and retains bytes instead of closing stdin."
   (let* ((vec (tramp-dissect-file-name "/rpc:queue-timeout:/tmp/"))
          (buffer (generate-new-buffer " *tramp-rpc-queue-timeout*"))
          (connection (start-process "tramp-rpc-queue-timeout" buffer "sleep" "10"))
@@ -2507,25 +2517,6 @@ This matches the behavior expected by `tramp-test28-process-file'."
                        output)))))
       (delete-directory runner-temp-directory t))))
 
-(ert-deftest tramp-rpc-mock-test-dired-compress-file-registered ()
-  "`dired-compress-file' is handled for TRAMP-RPC files."
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (should (eq (alist-get 'dired-compress-file tramp-rpc-file-name-handler-alist)
-              'tramp-rpc-handle-dired-compress-file)))
-
-(ert-deftest tramp-rpc-mock-test-dired-compress-file-delegates-to-real-handler ()
-  "TRAMP-RPC reuses Emacs' `dired-compress-file' implementation."
-  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
-  (let ((calls nil))
-    (cl-letf (((symbol-function 'tramp-run-real-handler)
-               (lambda (operation args)
-                 (push (list operation args) calls)
-                 "/rpc:mock:/tmp/file.gz")))
-      (should (equal (tramp-rpc-handle-dired-compress-file "/rpc:mock:/tmp/file")
-                     "/rpc:mock:/tmp/file.gz"))
-      (should (equal calls
-                     '((dired-compress-file ("/rpc:mock:/tmp/file"))))))))
-
 (ert-deftest tramp-rpc-mock-test-compatible-path-value-prefers-text ()
   "Valid UTF-8 paths remain compatible with pre-binary-path servers."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
@@ -3344,7 +3335,6 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (setq calls nil)
       (tramp-rpc-unwatch-directory link-directory)
       (should (equal (mapcar #'car (nreverse (copy-sequence calls))) nil))
-      (should (tramp-rpc--directory-watched-p "/tmp/real/" (tramp-dissect-file-name real-directory)))
       (tramp-rpc-unwatch-directory real-directory)
       (should (equal (mapcar #'car (nreverse (copy-sequence calls)))
                      '("watch.remove"))))))
@@ -6139,8 +6129,6 @@ A rejected sudo password must not be reused on the next attempt, otherwise
                (lambda (&rest _) nil))
               ((symbol-function 'tramp-rpc--caller-environment)
                (lambda () nil))
-              ((symbol-function 'tramp-rpc--directory-watched-p)
-               (lambda (&rest _) t))
               ((symbol-function 'tramp-rpc--call)
                (lambda (vec _method params)
                  (setq captured (list vec params))
@@ -6250,7 +6238,7 @@ A rejected sudo password must not be reused on the next attempt, otherwise
   :tags '(:connection-cleanup)
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let ((vec (tramp-dissect-file-name "/rpc:bootstrap-host:/")))
-    (dolist (state '(live-process process-buffer legacy-process-buffer connected))
+    (dolist (state '(live-process private-process-buffer connected))
       (let ((proc (when (eq state 'live-process)
                     (make-process :name "tramp-rpc-bootstrap-cleanup-test"
                                   :command '("cat")
@@ -6265,8 +6253,7 @@ A rejected sudo password must not be reused on the next attempt, otherwise
                       ((symbol-function 'tramp-connection-property-p)
                        (lambda (_vec property)
                          (pcase state
-                           ('process-buffer (equal property "process-buffer"))
-                           ('legacy-process-buffer
+                           ('private-process-buffer
                             (equal property " process-buffer"))
                            ('connected (equal property " connected")))))
                       ((symbol-function 'tramp-cleanup-connection)
@@ -6820,14 +6807,14 @@ background, which can precede the socket becoming visible."
           (should (tramp-rpc--acl-enabled-p vec))
           (should (tramp-rpc--acl-enabled-p vec))
           (should (= acl-calls 2))
-          (should (tramp-get-connection-property
+          (should (tramp-rpc--get-route-connection-property
                    vec " rpc-acl-enabled" nil))
           (should-not (tramp-get-connection-property
-                       vec "rpc-acl-enabled" nil))
+                       vec " rpc-acl-enabled" nil))
           (should-not (tramp-rpc--selinux-enabled-p vec))
           (should-not (tramp-rpc--selinux-enabled-p vec))
           (should (= selinux-calls 1))
-          (should (eq (tramp-get-connection-property
+          (should (eq (tramp-rpc--get-route-connection-property
                        vec " rpc-selinux-enabled" t)
                       nil)))
       (tramp-flush-connection-properties vec))))
@@ -7429,6 +7416,11 @@ discard it for being unreadable."
       (should (= (tramp-rpc-handle-process-file "rg" nil nil nil "pattern") 0))
       (should (equal (alist-get 'cmd captured-params) "rg"))
       (should (equal (alist-get 'args captured-params) ["pattern"]))
+      (should (eq (alist-get 'merge_stderr captured-params) t))
+      (should-not
+       (tramp-rpc--process-file-merge-output-p '(nil "/tmp/stderr")))
+      (should (tramp-rpc--process-file-merge-output-p '(t t)))
+      (should (tramp-rpc--process-file-merge-output-p '(:file "/tmp/output")))
       (should (equal (assoc "PATH" (alist-get 'env captured-params))
                      '("PATH" . "/home/user/.cargo/bin:/usr/bin:/bin"))))))
 
@@ -7447,8 +7439,6 @@ discard it for being unreadable."
                (lambda (&rest _) nil))
               ((symbol-function 'tramp-rpc--decode-output)
                (lambda (output) output))
-              ((symbol-function 'tramp-rpc--directory-watched-p)
-               (lambda (&rest _) nil))
               ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
                (lambda (vec) (push (list 'invalidate vec) calls)))
               ((symbol-function 'tramp-rpc--call)
@@ -7500,7 +7490,7 @@ discard it for being unreadable."
   "Dispatched commands clear once unless side effects are explicitly disabled."
   (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
   (let ((default-directory "/rpc:user@host:/work/")
-        watched invalidated)
+        invalidated)
     (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
                (lambda (_vec) '("/usr/bin")))
               ((symbol-function 'tramp-rpc--get-direnv-environment)
@@ -7511,17 +7501,15 @@ discard it for being unreadable."
                (lambda (&rest _) nil))
               ((symbol-function 'tramp-rpc--decode-output)
                (lambda (output) output))
-              ((symbol-function 'tramp-rpc--directory-watched-p)
-               (lambda (&rest _) watched))
               ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
                (lambda (&rest _) (setq invalidated t)))
               ((symbol-function 'tramp-rpc--call)
                (lambda (&rest _)
                  '((exit_code . 0) (stdout . "") (stderr . "")))))
-      (setq invalidated nil watched t)
+      (setq invalidated nil)
       (should (= (tramp-rpc-handle-process-file "touch" nil nil nil "new") 0))
       (should invalidated)
-      (setq invalidated nil watched nil)
+      (setq invalidated nil)
       (let ((process-file-side-effects nil))
         (should (= (tramp-rpc-handle-process-file
                     "git" nil nil nil "status" "--porcelain")
@@ -7572,8 +7560,6 @@ discard it for being unreadable."
               ((symbol-function 'tramp-rpc--caller-environment)
                (lambda () nil))
               ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
-               (lambda (&rest _) nil))
-              ((symbol-function 'tramp-rpc--directory-watched-p)
                (lambda (&rest _) nil))
               ((symbol-function 'tramp-rpc--clear-file-caches-for-connection)
                (lambda (vec) (setq invalidated-directory vec)))
@@ -7664,6 +7650,58 @@ discard it for being unreadable."
             (should (equal (cadr started) '("-n" "id"))))
         (when (processp proc)
           (delete-process proc))))))
+
+(ert-deftest tramp-rpc-mock-test-make-process-remote-stderr-file-pipe ()
+  "Pipe-mode remote string stderr is wrapped as a remote file redirect."
+  (let ((default-directory "/rpc:user@host:/work/") started proc)
+    (cl-letf (((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--start-remote-process)
+               (lambda (_vec program args _cwd _env)
+                 (setq started (cons program args))
+                 51))
+              ((symbol-function 'tramp-rpc--start-async-read) #'ignore))
+      (unwind-protect
+          (progn
+            (setq proc (tramp-rpc-handle-make-process
+                        :name "remote-stderr-pipe" :buffer nil
+                        :command '("printf" "error")
+                        :connection-type 'pipe
+                        :stderr "/rpc:user@host:/tmp/stderr file"
+                        :noquery t))
+            (should (equal (seq-take started 2) '("/bin/sh" "-c")))
+            (should (string-match-p "2>/tmp/stderr\\\\ file" (nth 2 started))))
+        (when (processp proc) (delete-process proc))))))
+
+(ert-deftest tramp-rpc-mock-test-make-process-remote-stderr-file-pty ()
+  "PTY-mode remote string stderr uses the same remote redirect wrapper."
+  (let ((default-directory "/rpc:user@host:/work/") captured)
+    (cl-letf (((symbol-function 'tramp-rpc--remote-path-environment)
+               (lambda (_vec) nil))
+              ((symbol-function 'tramp-rpc--tramp-remote-process-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc--make-pty-process)
+               (lambda (_vec _name _buffer command &rest _)
+                 (setq captured command)
+                 'pty-process)))
+      (should
+       (eq (tramp-rpc-handle-make-process
+            :name "remote-stderr-pty" :buffer nil
+            :command '("printf" "error") :connection-type 'pty
+            :stderr "/rpc:user@host:/tmp/stderr file" :noquery t)
+           'pty-process))
+      (should (equal (seq-take captured 2) '("/bin/sh" "-c")))
+      (should (string-match-p "2>/tmp/stderr\\\\ file" (nth 2 captured))))))
 
 (ert-deftest tramp-rpc-mock-test-make-process-sudo-pipe-uses-stdin-password ()
   "Pipe-mode literal sudo should authenticate in the same stdin context."
@@ -7835,6 +7873,301 @@ discard it for being unreadable."
       ;; Second access via absolute path - should hit the cache, not fetch again
       (tramp-rpc--get-direnv-environment vec "/home/user/project")
       (should (= fetch-count 1)))))
+
+(ert-deftest tramp-rpc-mock-test-clear-all-caches-clears-route-owned-state ()
+  "The public all-cache command clears explicit caches and route properties."
+  (let* ((vec (tramp-dissect-file-name "/rpc:user@cache-host:/"))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--exec-path-cache (make-hash-table :test 'equal))
+         (tramp-rpc--login-shell-cache (make-hash-table :test 'equal)))
+    (puthash 'connection (list :vec vec) tramp-rpc--connections)
+    (puthash 'key 'value tramp-rpc--exec-path-cache)
+    (puthash 'key 'value tramp-rpc--login-shell-cache)
+    (tramp-set-connection-property vec "~" "/home/user")
+    (tramp-set-connection-property vec "~user" "/home/user")
+    (tramp-rpc--set-route-connection-property vec "rpc-signal-strings" ["HUP"])
+    (cl-letf (((symbol-function 'tramp-rpc-magit--clear-cache) #'ignore)
+              ((symbol-function 'tramp-rpc--clear-file-metadata-caches) #'ignore)
+              ((symbol-function 'tramp-rpc--clear-direnv-cache) #'ignore)
+              ((symbol-function 'tramp-flush-directory-properties) #'ignore))
+      (tramp-rpc-clear-all-caches))
+    (should (= (hash-table-count tramp-rpc--exec-path-cache) 0))
+    (should (= (hash-table-count tramp-rpc--login-shell-cache) 0))
+    (should-not (tramp-get-connection-property vec "~" nil))
+    (should-not (tramp-get-connection-property vec "~user" nil))
+    (should-not
+     (tramp-rpc--get-route-connection-property vec "rpc-signal-strings" nil))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-output-routing ()
+  "Process-file output destinations follow upstream buffer/file semantics."
+  (let ((stdout-buffer (generate-new-buffer " *tramp-rpc-stdout*"))
+        (named-buffer " *tramp-rpc-named-stdout*")
+        (stderr-file (make-temp-file "tramp-rpc-stderr"))
+        (output-file (make-temp-file "tramp-rpc-output")))
+    (unwind-protect
+        (with-temp-buffer
+          (tramp-rpc--route-process-file-output t "current" "-error")
+          (should (equal (buffer-string) "current-error"))
+          (tramp-rpc--route-process-file-output named-buffer "named" "-error")
+          (should (equal (with-current-buffer named-buffer (buffer-string))
+                         "named-error"))
+          (tramp-rpc--route-process-file-output
+           (list stdout-buffer t) "stdout" "stderr")
+          (should (equal (buffer-string) "current-error"))
+          (should (equal (with-current-buffer stdout-buffer (buffer-string))
+                         "stdoutstderr"))
+          (tramp-rpc--route-process-file-output
+           (list nil stderr-file) "" "file-error")
+          (with-temp-buffer
+            (insert-file-contents stderr-file)
+            (should (equal (buffer-string) "file-error")))
+          (tramp-rpc--route-process-file-output
+           (list :file output-file) "file-output" "-error")
+          (with-temp-buffer
+            (insert-file-contents output-file)
+            (should (equal (buffer-string) "file-output-error"))))
+      (kill-buffer stdout-buffer)
+      (when (get-buffer named-buffer) (kill-buffer named-buffer))
+      (delete-file stderr-file)
+      (delete-file output-file))))
+
+(ert-deftest tramp-rpc-mock-test-process-send-region-managed-and-native ()
+  "Send-region shares RPC delivery but preserves native fallback semantics."
+  (let ((process (make-pipe-process :name "tramp-rpc-send-region" :noquery t))
+        written native)
+    (unwind-protect
+        (with-temp-buffer
+          (insert "prefix-PAYLOAD-suffix")
+          (process-put process :tramp-rpc-pid 42)
+          (process-put process :tramp-rpc-vec 'vec)
+          (cl-letf (((symbol-function 'tramp-rpc--encode-process-input)
+                     (lambda (_process string) string))
+                    ((symbol-function 'tramp-rpc--write-remote-process)
+                     (lambda (_vec _pid data _owner) (setq written data))))
+            (tramp-rpc-handle-process-send-region process 8 15))
+          (should (equal written "PAYLOAD"))
+          (process-put process :tramp-rpc-direct-ssh t)
+          (cl-letf (((symbol-function 'tramp-run-real-handler)
+                     (lambda (operation args) (setq native (list operation args)))))
+            (tramp-rpc-handle-process-send-region process 8 15))
+          (should (equal native
+                         (list #'process-send-region (list process 8 15)))))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-route-aware-property-names-do-not-collide ()
+  "Project and generic TRAMP properties distinguish routes to one target."
+  (let* ((direct (tramp-dissect-file-name "/rpc:user@target:/"))
+         (hopped (tramp-dissect-file-name "/ssh:gateway|rpc:user@target:/")))
+    (dolist (property '("rpc-signal-strings" " rpc-acl-enabled"
+                        " rpc-selinux-enabled" "uid-integer" "~user"))
+      (should-not
+       (equal (tramp-rpc--route-property-name direct property)
+              (tramp-rpc--route-property-name hopped property))))
+    (unwind-protect
+        (progn
+          (tramp-rpc--set-route-connection-property
+           direct " rpc-acl-enabled" t)
+          (tramp-rpc--set-route-connection-property
+           hopped " rpc-acl-enabled" nil)
+          (tramp-set-connection-property direct "uid-integer" 1000)
+          (tramp-set-connection-property hopped "uid-integer" 2000)
+          (tramp-set-connection-property direct "~user" "/direct/home")
+          (tramp-set-connection-property hopped "~user" "/hopped/home")
+          (should (tramp-rpc--get-route-connection-property
+                   direct " rpc-acl-enabled" 'missing))
+          (should-not (tramp-rpc--get-route-connection-property
+                       hopped " rpc-acl-enabled" 'missing))
+          (should (= (tramp-get-connection-property
+                      direct "uid-integer" 'missing)
+                     1000))
+          (should (= (tramp-get-connection-property
+                      hopped "uid-integer" 'missing)
+                     2000))
+          (should (equal (tramp-get-connection-property direct "~user" nil)
+                         "/direct/home"))
+          (should (equal (tramp-get-connection-property hopped "~user" nil)
+                         "/hopped/home"))
+          ;; Explicit route-aware cleanup must not pass an already-qualified
+          ;; tilde property through the generic property advice a second time.
+          (tramp-rpc--flush-route-connection-property direct "~user")
+          (should-not (tramp-get-connection-property direct "~user" nil))
+          (should (equal (tramp-get-connection-property hopped "~user" nil)
+                         "/hopped/home")))
+      (tramp-flush-connection-properties direct)
+      (tramp-flush-connection-properties hopped))))
+
+(ert-deftest tramp-rpc-mock-test-sudo-route-properties-do-not-collide ()
+  "Generic TRAMP properties distinguish separate sudo-via-RPC routes."
+  (let* ((first (make-tramp-file-name
+                 :method "sudo" :user "root" :host "target" :localname "/"
+                 :hop "rpc:u@gateway1|rpc:u@target|"))
+         (second (make-tramp-file-name
+                  :method "sudo" :user "root" :host "target" :localname "/"
+                  :hop "rpc:u@gateway2|rpc:u@target|")))
+    (should (tramp-rpc--sudo-file-name-p first))
+    (should (tramp-rpc--sudo-file-name-p second))
+    (unwind-protect
+        (progn
+          (tramp-set-connection-property first "uid-integer" 1001)
+          (tramp-set-connection-property second "uid-integer" 2002)
+          (tramp-set-connection-property first "~root" "/first/root")
+          (tramp-set-connection-property second "~root" "/second/root")
+          (should (= (tramp-get-connection-property
+                      first "uid-integer" 'missing)
+                     1001))
+          (should (= (tramp-get-connection-property
+                      second "uid-integer" 'missing)
+                     2002))
+          (should (equal (tramp-get-connection-property first "~root" nil)
+                         "/first/root"))
+          (should (equal (tramp-get-connection-property second "~root" nil)
+                         "/second/root"))
+          (tramp-rpc--flush-owned-route-connection-properties first)
+          (should-not (tramp-get-connection-property first "~root" nil))
+          (should (equal (tramp-get-connection-property second "~root" nil)
+                         "/second/root")))
+      (tramp-flush-connection-properties first)
+      (tramp-flush-connection-properties second))))
+
+(ert-deftest tramp-rpc-mock-test-system-info-seeds-route-aware-tramp-properties ()
+  "system.info seeds generic TRAMP caches independently for each route."
+  (let* ((direct (tramp-dissect-file-name "/rpc:user@target:/"))
+         (hopped (tramp-dissect-file-name "/ssh:gateway|rpc:user@target:/")))
+    (unwind-protect
+        (progn
+          (tramp-rpc--cache-system-info
+           direct '((uid . 1000) (gid . 100) (home . "/direct") (os . "linux")))
+          (tramp-rpc--cache-system-info
+           hopped '((uid . 2000) (gid . 200) (home . "/hopped") (os . "macos")))
+          (should (= (tramp-get-connection-property direct "uid-integer" nil)
+                     1000))
+          (should (= (tramp-get-connection-property hopped "uid-integer" nil)
+                     2000))
+          (should (equal (tramp-get-connection-property direct "uname" nil)
+                         "Linux"))
+          (should (equal (tramp-get-connection-property hopped "uname" nil)
+                         "Darwin"))
+          (should (equal (tramp-get-connection-property direct "~user" nil)
+                         "/direct"))
+          (should (equal (tramp-get-connection-property hopped "~user" nil)
+                         "/hopped")))
+      (tramp-flush-connection-properties direct)
+      (tramp-flush-connection-properties hopped))))
+
+(ert-deftest tramp-rpc-mock-test-bounded-magit-caches-prune-expired-and-overflow ()
+  "Ancestor, prefetch, and process cache tables remain bounded."
+  (let ((remote-file-name-inhibit-cache nil))
+    (dolist (spec
+             `((ancestor ,(lambda (time) (cons time 'value)) ,#'car)
+               (prefetch ,#'identity ,#'identity)
+               (process ,(lambda (time) (list :time time :cache 'value))
+                        ,(lambda (entry) (plist-get entry :time)))))
+      (let ((table (make-hash-table :test 'equal))
+            (make-entry (nth 1 spec))
+            (timestamp (nth 2 spec)))
+        (puthash 'expired (funcall make-entry 0) table)
+        (dotimes (i 5)
+          (puthash i (funcall make-entry (float-time)) table))
+        (tramp-rpc-magit--bound-table table 3 timestamp)
+        (should-not (gethash 'expired table))
+        (should (<= (hash-table-count table) 3))))))
+
+(ert-deftest tramp-rpc-mock-test-process-cache-pruning-uses-process-ttl ()
+  "Process cache admission uses its TTL, independent of metadata inhibition."
+  (let* ((tramp-rpc-magit--process-caches (make-hash-table :test 'equal))
+         (tramp-rpc-magit-process-cache-ttl 120)
+         (tramp-rpc-magit-process-cache-max-size 10)
+         (remote-file-name-inhibit-cache t)
+         (vec (tramp-dissect-file-name "/rpc:cache-host:/")))
+    (puthash 'stale (list :time 850 :cache 'stale)
+             tramp-rpc-magit--process-caches)
+    (puthash 'fresh (list :time 950 :cache 'fresh)
+             tramp-rpc-magit--process-caches)
+    (cl-letf (((symbol-function 'float-time) (lambda (&optional _) 1000)))
+      (tramp-rpc-magit--set-process-cache
+       vec "/rpc:cache-host:/work/" (make-hash-table :test 'equal)))
+    (should-not (gethash 'stale tramp-rpc-magit--process-caches))
+    (should (gethash 'fresh tramp-rpc-magit--process-caches))
+    (should (= (hash-table-count tramp-rpc-magit--process-caches) 2))))
+
+(ert-deftest tramp-rpc-mock-test-file-exists-inhibition-preserves-entry ()
+  "Full cache inhibition bypasses but does not purge file-exists entries."
+  (let* ((tramp-rpc--file-exists-cache (make-hash-table :test 'equal))
+         (filename "/rpc:mock:/tmp/entry")
+         (expanded (expand-file-name filename)))
+    (puthash expanded (cons (float-time) t) tramp-rpc--file-exists-cache)
+    (let ((remote-file-name-inhibit-cache t))
+      (should (eq (tramp-rpc--file-exists-cache-lookup filename) 'not-cached)))
+    (should (gethash expanded tramp-rpc--file-exists-cache))))
+
+(ert-deftest tramp-rpc-mock-test-copy-directory-fallback-invalidates-targets ()
+  "Generic directory copies invalidate their explicit source and destination."
+  (let (paths subtrees)
+    (cl-letf (((symbol-function 'tramp-handle-copy-directory)
+               (lambda (&rest _) 'copied))
+              ((symbol-function 'tramp-rpc--invalidate-cache-for-path)
+               (lambda (path) (push path paths)))
+              ((symbol-function 'tramp-rpc--invalidate-cache-for-subtree)
+               (lambda (path) (push path subtrees))))
+      (should
+       (eq (tramp-rpc--copy-directory-fallback
+            "/rpc:one:/source" "/rpc:two:/dest" t t nil)
+           'copied)))
+    (should (equal paths '("/rpc:one:/source")))
+    (should (equal subtrees '("/rpc:two:/dest")))))
+
+(ert-deftest tramp-rpc-mock-test-copy-file-preserve-uid-gid-uses-upstream ()
+  "Every remote ownership-preserving combination uses upstream TRAMP."
+  (should (fboundp 'tramp-sh-handle-copy-file))
+  (dolist (files '(("/rpc:mock:/source" "/rpc:mock:/dest")
+                   ("/rpc:mock:/source" "/tmp/dest")
+                   ("/tmp/source" "/rpc:mock:/dest")
+                   ("/rpc:one:/source" "/rpc:two:/dest")))
+    (let (arguments)
+      (cl-letf (((symbol-function 'tramp-sh-handle-copy-file)
+                 (lambda (&rest args) (setq arguments args) 'upstream)))
+        (should
+         (eq (tramp-rpc-handle-copy-file
+              (car files) (cadr files) t t t t)
+             'upstream)))
+      (should (equal (nth 4 arguments) t)))))
+
+(ert-deftest tramp-rpc-mock-test-remote-stderr-command-wrapper-is-argv-safe ()
+  "Remote stderr redirection preserves command argv in pipe and PTY paths."
+  (should
+   (equal (tramp-rpc--redirect-command-stderr
+           '("printf" "%s" "a b") "/tmp/error file")
+          '("/bin/sh" "-c" "exec \"$@\" 2>/tmp/error\\ file"
+            "tramp-rpc-stderr" "printf" "%s" "a b"))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-target-registry-and-shell-builders ()
+  "Deploy targets are centralized and activation retains safety predicates."
+  (should (equal (tramp-rpc-deploy--arch-to-rust-target "armv7-linux")
+                 "armv7-unknown-linux-musleabihf"))
+  (should (equal (tramp-rpc-deploy--normalize-machine "armv6l") "arm"))
+  (let ((command (tramp-rpc-deploy--activation-command
+                  "/tmp/stage file" "/tmp/dest" (make-string 64 ?a))))
+    (should (string-match-p "test ! -e" command))
+    (should (string-match-p "! test -L" command))
+    (should (string-match-p "sha256sum" command))
+    (should (string-match-p "shasum -a 256" command))
+    (should (string-match-p "mv -f" command))))
+
+(ert-deftest tramp-rpc-mock-test-deploy-diagnose-ssh-returns-status-and-output ()
+  "The deploy diagnostic SSH helper keeps argv separate and returns status."
+  (let (program args)
+    (cl-letf (((symbol-function 'call-process)
+               (lambda (called-program _infile destination _display &rest called-args)
+                 (setq program called-program args called-args)
+                 (when destination (insert "failure"))
+                 17)))
+      (should (equal (tramp-rpc-deploy--diagnose-ssh
+                      "-host" "user name" "echo ok" t)
+                     '(17 . "failure"))))
+    (should (equal program "ssh"))
+    (should (equal args
+                   '("-o" "BatchMode=yes" "-o" "ConnectTimeout=10"
+                     "-l" "user name" "--" "-host" "echo ok")))))
 
 ;;; ============================================================================
 ;;; Test Runner

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -162,6 +162,49 @@
       (should (process-live-p process))
       (should-not (process-get process :tramp-rpc-pending-ids)))))
 
+(ert-deftest tramp-rpc-mock-test-request-pipeline-collects-partial-responses ()
+  "Pipelined waiting retains partial completion and original ID order."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let* ((vec (tramp-rpc-mock-test-request--vec))
+           (connection (list :process process :buffer buffer :vec vec))
+           (pending (tramp-rpc--get-pending-responses buffer))
+           (tramp-rpc-poll-interval 0.001)
+           delivered)
+      (process-put process :tramp-rpc-pending-ids '(301 302))
+      (puthash 301 '(:id 301 :result first) pending)
+      (cl-letf (((symbol-function 'accept-process-output)
+                 (lambda (&rest _)
+                   (unless delivered
+                     (setq delivered t)
+                     (puthash 302 '(:id 302 :result second) pending))
+                   t)))
+        (should
+         (equal (tramp-rpc--receive-responses
+                 vec '(301 302) 1 connection)
+                '((301 :id 301 :result first)
+                  (302 :id 302 :result second))))))))
+
+(ert-deftest tramp-rpc-mock-test-request-pipeline-timeout-includes-stderr ()
+  "Pipelined timeout diagnostics include missing IDs and SSH stderr."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let* ((stderr-buffer (generate-new-buffer " *tramp-rpc-request-stderr*"))
+           (vec (tramp-rpc-mock-test-request--vec))
+           (connection (list :process process :buffer buffer :vec vec
+                             :stderr-buffer stderr-buffer))
+           message)
+      (unwind-protect
+          (progn
+            (with-current-buffer stderr-buffer (insert "permission denied"))
+            (cl-letf (((symbol-function 'tramp-rpc--invalidate-timed-out-connection)
+                       #'ignore))
+              (condition-case err
+                  (tramp-rpc--receive-responses vec '(401 402) 0 connection)
+                (remote-file-error
+                 (setq message (error-message-string err)))))
+            (should (string-match-p "missing ids: (401 402)" message))
+            (should (string-match-p "SSH stderr: permission denied" message)))
+        (kill-buffer stderr-buffer)))))
+
 (ert-deftest tramp-rpc-mock-test-request-timeout-invalidates-ssh-generation ()
   "Timeout invalidation removes the transport and its ControlMaster."
   (tramp-rpc-mock-test-request--with-connection (process buffer)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -83,6 +83,8 @@
 (require 'tramp-rpc)
 
 (declare-function tramp-rpc--decode-output "tramp-rpc" (data))
+(declare-function tramp-rpc--get-route-connection-property
+                  "tramp-rpc" (vec property default))
 (declare-function tramp-rpc--handle-async-read-response "tramp-rpc-process")
 (declare-function tramp-rpc--start-cat-relays
                   "tramp-rpc-process" (name buffer stderr-buffer cleanup))
@@ -151,7 +153,7 @@ Value is a cons cell (CHECKED . RESULT).")
          ;; metadata, not a file-operation cache, and refetching it makes call
          ;; counts depend on whether this connection was just replaced.
          (let ((system-info
-                (tramp-get-connection-property
+                (tramp-rpc--get-route-connection-property
                  vec tramp-rpc--system-info-property nil)))
            (tramp-flush-directory-properties vec "/")
            (tramp-flush-connection-properties vec)


### PR DESCRIPTION
Several Elisp paths had accumulated duplicated request waits, cache cleanup, process routing, and deployment logic. The copies had begun to diverge in timeout handling, cache identity, output routing, and documentation.

This consolidates those paths, makes connection state route-aware and bounded, and fixes process output, remote stderr, ownership-preserving copy, and cache invalidation semantics. It also adds ordered stdout/stderr capture to the server for combined `process-file` destinations and expands focused regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable polling intervals for remote operations.
  * Improved capture, merging, and redirection of remote command output.
  * Added route-specific connection handling for multi-route sessions.
  * Added configurable limits for Magit-related caches.

* **Bug Fixes**
  * Improved remote process input/output and file-copy behavior.
  * Strengthened deployment checks, diagnostics, and atomic updates.
  * Improved cache invalidation and cleanup across remote operations.

* **Tests**
  * Expanded coverage for output ordering, timeouts, process handling, cache limits, routing, copying, and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->