### PR TITLE
Improves TRAMP-RPC resilience, cache freshness, and resource usage under degraded filesystem watchers, hung commands, and NSS outages.

### DIFF
--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -393,11 +393,14 @@ Used during operations that will invalidate caches themselves.")
   "Handle a server-initiated notification.
 PROCESS is the connection, METHOD is the notification method,
 PARAMS is the notification parameters."
-  (cond
-   ((string= method "fs.events")
-    (tramp-rpc--handle-fs-events process params))
-   (t
-    (tramp-rpc--debug "Unknown notification: %s" method))))
+  (condition-case notify-error
+      (cond
+       ((string= method "fs.events")
+        (tramp-rpc--handle-fs-events process params))
+       (t
+        (tramp-rpc--debug "Unknown notification: %s" method)))
+    (error
+     (tramp-rpc--debug "notification %s failed: %S" method notify-error))))
 
 (defun tramp-rpc--fs-event-path (vec event key)
   "Return EVENT's KEY path as a TRAMP file name on VEC, or nil."

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -62,6 +62,8 @@
 (defvar tramp-rpc--connections)
 (defvar tramp-rpc--exec-path-cache)
 (defvar tramp-rpc--login-shell-cache)
+(defvar tramp-rpc--watcher-degraded)
+(defvar tramp-rpc--watcher-unavailable-ttl)
 
 ;; Functions from magit-section.el.
 (autoload 'magit-section-show "magit-section")
@@ -105,27 +107,34 @@ STAT may be nil, which records a missing file.")
 (defun tramp-rpc--effective-cache-ttl ()
   "Return the current TTL for TRAMP-RPC metadata caches.
 `remote-file-name-inhibit-cache' t disables caching, while a numeric value
-caps the project-specific TTL.  Nil retains the explicit TRAMP-RPC TTL."
-  (cond
-   ((eq remote-file-name-inhibit-cache t) 0)
-   ((numberp remote-file-name-inhibit-cache)
-    (min tramp-rpc--cache-ttl (max 0 remote-file-name-inhibit-cache)))
-   (t tramp-rpc--cache-ttl)))
+caps the project-specific TTL.  Nil retains the explicit TRAMP-RPC TTL.
+When push notifications are unavailable (`tramp-rpc--watcher-degraded'),
+caches are TTL-only, so cap to `tramp-rpc--watcher-unavailable-ttl'."
+  (let ((ttl (cond
+                ((eq remote-file-name-inhibit-cache t) 0)
+                ((numberp remote-file-name-inhibit-cache)
+                 (min tramp-rpc--cache-ttl (max 0 remote-file-name-inhibit-cache)))
+                (t tramp-rpc--cache-ttl))))
+    (if (and (boundp 'tramp-rpc--watcher-degraded)
+             tramp-rpc--watcher-degraded)
+        (min ttl tramp-rpc--watcher-unavailable-ttl)
+      ttl)))
 
 (defun tramp-rpc--cache-entry-valid-p (timestamp)
   "Return non-nil when a cache entry created at TIMESTAMP is reusable."
-  (let ((age (- (float-time) timestamp)))
+  (let ((age (- (float-time) timestamp))
+        (ttl (tramp-rpc--effective-cache-ttl)))
     (cond
      ((eq remote-file-name-inhibit-cache t) nil)
      ((numberp remote-file-name-inhibit-cache)
-      (< age (tramp-rpc--effective-cache-ttl)))
+      (< age ttl))
      ;; TRAMP also binds this to `current-time' to invalidate entries older
      ;; than the start of a compound operation.
      ((consp remote-file-name-inhibit-cache)
       (and (not (time-less-p (seconds-to-time timestamp)
                              remote-file-name-inhibit-cache))
-           (< age tramp-rpc--cache-ttl)))
-     (t (< age tramp-rpc--cache-ttl)))))
+           (< age ttl)))
+     (t (< age ttl)))))
 
 (defun tramp-rpc--cache-get (cache key)
   "Get value for KEY from CACHE if not expired.
@@ -794,10 +803,16 @@ Returns the cache hash table, or nil if none."
        (tramp-rpc-magit--get-cache-key v default-directory)))))
 
 (defun tramp-rpc-magit--process-cache-timestamp-valid-p (timestamp)
-  "Return non-nil when process cache TIMESTAMP is within its own TTL."
+  "Return non-nil when process cache TIMESTAMP is within its own TTL.
+When push notifications are unavailable, cap to
+`tramp-rpc--watcher-unavailable-ttl' so unwatched changes surface promptly."
   (or (null tramp-rpc-magit-process-cache-ttl)
-      (<= (- (float-time) timestamp)
-          tramp-rpc-magit-process-cache-ttl)))
+      (let ((ttl tramp-rpc-magit-process-cache-ttl))
+        (when (and (boundp 'tramp-rpc--watcher-degraded)
+                   tramp-rpc--watcher-degraded
+                   (boundp 'tramp-rpc--watcher-unavailable-ttl))
+          (setq ttl (min ttl tramp-rpc--watcher-unavailable-ttl)))
+        (<= (- (float-time) timestamp) ttl))))
 
 (defun tramp-rpc-magit--set-process-cache (vec directory cache)
   "Set the `process-file' CACHE for VEC and DIRECTORY."

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -4975,9 +4975,36 @@ REPLACE non-nil replaces the accessible buffer contents."
 (defconst tramp-rpc--system-info-property "tramp-rpc-system-info"
   "TRAMP connection property storing the cached system.info response.")
 
+(defcustom tramp-rpc--watcher-unavailable-ttl 30
+  "TTL cap in seconds for caches when push notifications are unavailable.
+When the server reports `watcher_available' as false, `fs.events'
+notifications are not running and caches are TTL-only.  Capping to a short
+TTL bounds staleness instead of serving up to `tramp-rpc--cache-ttl'
+seconds of stale metadata."
+  :type 'number
+  :group 'tramp-rpc)
+
+(defvar tramp-rpc--watcher-degraded nil
+  "Non-nil when any known connection lacks push notifications.
+Set from `system.info' `watcher_available'.  Once set, metadata and Magit
+process caches use `tramp-rpc--watcher-unavailable-ttl' as a cap.  Global
+(and conservative: one degraded host shortens TTLs for all) because cache
+validity checks do not carry connection context.")
+
+(defun tramp-rpc--note-watcher-availability (info)
+  "Update `tramp-rpc--watcher-degraded' from system.info INFO.
+INFO is the decoded response alist.  Missing `watcher_available' means an
+old server that predates the field; assume available to preserve behavior.
+An explicit non-t value marks degraded."
+  (when info
+    (let ((cell (assq 'watcher_available info)))
+      (when (and cell (not (eq (cdr cell) t)))
+        (setq tramp-rpc--watcher-degraded t)))))
+
 (defun tramp-rpc--cache-system-info (vec info)
   "Store system.info INFO for VEC and seed related TRAMP properties."
   (when info
+    (tramp-rpc--note-watcher-availability info)
     (tramp-rpc--set-route-connection-property
      vec tramp-rpc--system-info-property info)
     ;; Store remote uname so `tramp-check-remote-uname' works.  The server

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -4995,7 +4995,7 @@ seconds of stale metadata."
   "Non-nil when any known connection lacks push notifications.
 Set from `system.info' `watcher_available'.  Once set, metadata and Magit
 process caches use `tramp-rpc--watcher-unavailable-ttl' as a cap.  Global
-(and conservative: one degraded host shortens TTLs for all) because cache
+\\=(and conservative: one degraded host shortens TTLs for all) because cache
 validity checks do not carry connection context.")
 
 (defun tramp-rpc--note-watcher-availability (info)

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2223,11 +2223,18 @@ Uses length-prefixed binary framing: <4-byte BE length><msgpack payload>."
                 (delete-region (point-min) (mark-marker))
                 (goto-char (point-min))
                 ;; Check for server-initiated notification (no id, has method).
+                ;; Isolated: a throwing notification handler must not strand
+                ;; already-buffered frames behind it in the process filter.
                 (if (plist-get response :notification)
-                    (tramp-rpc--handle-notification
-                     process
-                     (plist-get response :method)
-                     (plist-get response :params))
+                    (condition-case notify-error
+                        (tramp-rpc--handle-notification
+                         process
+                         (plist-get response :method)
+                         (plist-get response :params))
+                      (error
+                       (tramp-rpc--debug
+                        "notification handler failed for %s: %S"
+                        (plist-get response :method) notify-error)))
                   ;; A cleaned generation may still receive buffered output.
                   ;; Its injected transport-death errors belong to live waiters
                   ;; and must not be overwritten by late normal responses.

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -191,6 +191,9 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
                     let mut stdin = child.stdin.take();
                     let stdout = child.stdout.take().expect("piped stdout");
                     let stderr = child.stderr.take().expect("piped stderr");
+                    let output_budget = Arc::new(super::process::RetainedOutputBudget::new(
+                        Arc::clone(&remaining),
+                    ));
                     let write_stdin = async move {
                         if let Some(data) = stdin_data
                             && let Some(mut stdin) = stdin.take()
@@ -215,12 +218,12 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
                             write_stdin,
                             super::process::read_sync_output(
                                 stdout,
-                                Arc::clone(&remaining),
+                                Arc::clone(&output_budget),
                                 crate::MAX_RESPONSE_OUTPUT_BYTES,
                             ),
                             super::process::read_sync_output(
                                 stderr,
-                                remaining,
+                                Arc::clone(&output_budget),
                                 crate::MAX_RESPONSE_OUTPUT_BYTES,
                             ),
                             child.wait()
@@ -239,6 +242,7 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
                     match result {
                         Ok(((), stdout, stderr, status)) => {
                             process_group.disarm();
+                            output_budget.commit();
                             msgpack_map! {
                                 "exit_code" => exit_code_from_status(status),
                                 "stdout" => Value::Binary(stdout),

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -27,6 +27,13 @@ use super::HandlerResult;
 /// Prevents resource exhaustion from excessively large batches.
 const MAX_PARALLEL_COMMANDS: usize = 256;
 
+/// Default per-command timeout for `commands.run_parallel`.  Without it one
+/// hung `git` stalls the whole batch until the Lisp 30s call timeout fires,
+/// discarding completed results and tearing down the connection.
+const DEFAULT_PARALLEL_COMMAND_TIMEOUT_MS: u64 = 25_000;
+/// Hard cap so a client cannot request an unbounded hang.
+const MAX_PARALLEL_COMMAND_TIMEOUT_MS: u64 = 120_000;
+
 /// Global child budget for `commands.run_parallel` requests.  Request-level
 /// admission alone is insufficient because each admitted request can fan out
 /// into hundreds of operating-system processes.
@@ -78,6 +85,17 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
         /// Clear the inherited server environment before applying `env`.
         #[serde(default)]
         clear_env: bool,
+        /// Per-command timeout in milliseconds.  Each hung command fails
+        /// individually instead of stalling the whole batch until the Lisp
+        /// call timeout tears down the connection.  Defaults to
+        /// `DEFAULT_PARALLEL_COMMAND_TIMEOUT_MS`, capped at
+        /// `MAX_PARALLEL_COMMAND_TIMEOUT_MS`.
+        #[serde(default = "default_parallel_timeout_ms")]
+        timeout_ms: u64,
+    }
+
+    fn default_parallel_timeout_ms() -> u64 {
+        DEFAULT_PARALLEL_COMMAND_TIMEOUT_MS
     }
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
@@ -100,16 +118,41 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
     let remaining = Arc::new(Semaphore::new(crate::MAX_RESPONSE_OUTPUT_BYTES));
     let env = params.env.map(Arc::new);
     let clear_env = params.clear_env;
+    let timeout_ms = params.timeout_ms.clamp(1, MAX_PARALLEL_COMMAND_TIMEOUT_MS);
+    let timeout = std::time::Duration::from_millis(timeout_ms);
     let results = futures::future::join_all(params.commands.into_iter().map(|entry| {
         let remaining = Arc::clone(&remaining);
         let env = env.clone();
         async move {
+            // The per-command deadline covers queueing for the global child
+            // permit as well as execution.  All batch entries start their
+            // clocks together, so N hung waves cannot stack into N x timeout
+            // past the Lisp call timeout; the whole batch fails fast.
+            let deadline = tokio::time::Instant::now() + timeout;
+            let timeout_error = |key: String| {
+                (
+                    key,
+                    msgpack_map! {
+                        "exit_code" => -1i32,
+                        "stdout" => Value::Binary(vec![]),
+                        "stderr" => Value::Binary(
+                            format!("Command timed out after {timeout_ms}ms").into_bytes()
+                        ),
+                        "timed_out" => Value::Boolean(true)
+                    },
+                )
+            };
             // Valid batch entries queue behind earlier entries.  Dropping the
             // request future on transport cancellation cancels this wait.
-            let _child_permit = PARALLEL_CHILD_ADMISSIONS
-                .acquire()
-                .await
-                .expect("parallel child admission semaphore is never closed");
+            let _child_permit = match tokio::time::timeout_at(
+                deadline,
+                PARALLEL_CHILD_ADMISSIONS.acquire(),
+            )
+            .await
+            {
+                Ok(permit) => permit.expect("parallel child admission semaphore is never closed"),
+                Err(_) => return timeout_error(entry.key),
+            };
             let mut cmd = Command::new(&entry.cmd);
             cmd.args(&entry.args);
             if let Some(ref cwd) = entry.cwd {
@@ -161,20 +204,38 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
                         }
                         Ok(())
                     };
-                    let result = tokio::try_join!(
-                        write_stdin,
-                        super::process::read_sync_output(
-                            stdout,
-                            Arc::clone(&remaining),
-                            crate::MAX_RESPONSE_OUTPUT_BYTES,
-                        ),
-                        super::process::read_sync_output(
-                            stderr,
-                            remaining,
-                            crate::MAX_RESPONSE_OUTPUT_BYTES,
-                        ),
-                        child.wait()
-                    );
+                    // Isolate hung commands: each command gets its own deadline
+                    // so one stuck `git` fails individually while completed
+                    // results are preserved, instead of stalling `join_all`
+                    // until the Lisp call timeout tears down the connection.
+                    // The deadline was set before queueing, so queue wait
+                    // consumes the same budget.
+                    let run = async {
+                        tokio::try_join!(
+                            write_stdin,
+                            super::process::read_sync_output(
+                                stdout,
+                                Arc::clone(&remaining),
+                                crate::MAX_RESPONSE_OUTPUT_BYTES,
+                            ),
+                            super::process::read_sync_output(
+                                stderr,
+                                remaining,
+                                crate::MAX_RESPONSE_OUTPUT_BYTES,
+                            ),
+                            child.wait()
+                        )
+                    };
+                    let result = match tokio::time::timeout_at(deadline, run).await {
+                        Ok(result) => result,
+                        Err(_) => {
+                            let _ = child.kill().await;
+                            let _ = child.wait().await;
+                            Err(std::io::Error::other(format!(
+                                "Command timed out after {timeout_ms}ms"
+                            )))
+                        }
+                    };
                     match result {
                         Ok(((), stdout, stderr, status)) => {
                             process_group.disarm();
@@ -187,10 +248,13 @@ pub async fn run_parallel(params: Value) -> HandlerResult {
                         Err(error) => {
                             let _ = child.kill().await;
                             let _ = child.wait().await;
+                            let message = error.to_string();
+                            let timed_out = message.starts_with("Command timed out");
                             msgpack_map! {
                                 "exit_code" => -1i32,
                                 "stdout" => Value::Binary(vec![]),
-                                "stderr" => Value::Binary(error.to_string().into_bytes())
+                                "stderr" => Value::Binary(message.into_bytes()),
+                                "timed_out" => Value::Boolean(timed_out)
                             }
                         }
                     }

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -50,11 +50,31 @@ fn path_cstring(bytes: &[u8]) -> Result<CString, std::ffi::NulError> {
     CString::new(bytes)
 }
 
-/// Get FileAttributes using fstatat relative to directory fd
+/// Get FileAttributes using fstatat relative to directory fd.
+/// When `resolve_names` is false, `uname`/`gname` are left as None so the
+/// caller can batch-resolve distinct uid/gids once per listing instead of
+/// once per entry (critical under NSS outage: each miss can cost ~2s).
 fn get_file_attributes_at(
     dir_fd: libc::c_int,
     name: &[u8],
     follow_symlinks: bool,
+) -> Option<FileAttributes> {
+    get_file_attributes_at_inner(dir_fd, name, follow_symlinks, true)
+}
+
+fn get_file_attributes_at_raw(
+    dir_fd: libc::c_int,
+    name: &[u8],
+    follow_symlinks: bool,
+) -> Option<FileAttributes> {
+    get_file_attributes_at_inner(dir_fd, name, follow_symlinks, false)
+}
+
+fn get_file_attributes_at_inner(
+    dir_fd: libc::c_int,
+    name: &[u8],
+    follow_symlinks: bool,
+    resolve_names: bool,
 ) -> Option<FileAttributes> {
     let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
 
@@ -123,14 +143,24 @@ fn get_file_attributes_at(
     let uid = stat_buf.st_uid;
     let gid = stat_buf.st_gid;
     let (atime, mtime, ctime, mode) = extract_stat_fields(&stat_buf);
+    // Batch path (resolve_names=false) defers NSS so the listing can resolve
+    // each distinct uid/gid once instead of once per entry.
+    let (uname, gname) = if resolve_names {
+        (
+            super::file::get_user_name(uid),
+            super::file::get_group_name(gid),
+        )
+    } else {
+        (None, None)
+    };
 
     Some(FileAttributes {
         file_type,
         nlinks: stat_buf.st_nlink as u64,
         uid,
         gid,
-        uname: super::file::get_user_name(uid),
-        gname: super::file::get_group_name(gid),
+        uname,
+        gname,
         atime,
         mtime,
         ctime,
@@ -261,8 +291,10 @@ fn list_dir_sync(
 
         let attrs = if include_attrs {
             // Use lstat (follow_symlinks=false) so symlinks show as symlinks
-            // with their link_target resolved, matching Emacs expectations
-            dir_fd.and_then(|fd| get_file_attributes_at(fd, &name_bytes, false))
+            // with their link_target resolved, matching Emacs expectations.
+            // Defer NSS: resolve each distinct uid/gid once below instead of
+            // once per entry, so an LDAP outage costs per-id, not per-entry.
+            dir_fd.and_then(|fd| get_file_attributes_at_raw(fd, &name_bytes, false))
         } else {
             None
         };
@@ -272,6 +304,35 @@ fn list_dir_sync(
             file_type,
             attrs,
         });
+    }
+
+    // Batch-resolve NSS names for distinct ids only.  With the transient
+    // negative cache in file.rs, an outage yields at most one ~2s miss per
+    // distinct id per TTL window, not one per directory entry.
+    if include_attrs {
+        use std::collections::{HashMap, HashSet};
+        let mut uids = HashSet::new();
+        let mut gids = HashSet::new();
+        for entry in &results {
+            if let Some(attrs) = entry.attrs.as_ref() {
+                uids.insert(attrs.uid);
+                gids.insert(attrs.gid);
+            }
+        }
+        let unames: HashMap<u32, Option<String>> = uids
+            .into_iter()
+            .map(|uid| (uid, super::file::get_user_name(uid)))
+            .collect();
+        let gnames: HashMap<u32, Option<String>> = gids
+            .into_iter()
+            .map(|gid| (gid, super::file::get_group_name(gid)))
+            .collect();
+        for entry in &mut results {
+            if let Some(attrs) = entry.attrs.as_mut() {
+                attrs.uname = unames.get(&attrs.uid).cloned().flatten();
+                attrs.gname = gnames.get(&attrs.gid).cloned().flatten();
+            }
+        }
     }
 
     // Sort by name

--- a/server/src/handlers/file.rs
+++ b/server/src/handlers/file.rs
@@ -151,6 +151,40 @@ static USER_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
 static GROUP_NAMES: std::sync::LazyLock<Mutex<HashMap<u32, Option<String>>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Short negative cache for transient NSS failures (LDAP/SSSD outage).
+/// Without this, every directory entry with the same uid/gid retries libc +
+/// `getent` (~2s each), turning one listing into a per-entry retry storm.
+/// Entries expire after `TRANSIENT_NSS_TTL` so recovery is still prompt.
+const TRANSIENT_NSS_TTL: Duration = Duration::from_secs(10);
+static TRANSIENT_USER_FAILURES: std::sync::LazyLock<Mutex<HashMap<u32, Instant>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+static TRANSIENT_GROUP_FAILURES: std::sync::LazyLock<Mutex<HashMap<u32, Instant>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn transient_failure_recent(cache: &Mutex<HashMap<u32, Instant>>, id: u32) -> bool {
+    let mut cache = cache.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(&at) = cache.get(&id) {
+        if at.elapsed() < TRANSIENT_NSS_TTL {
+            return true;
+        }
+        cache.remove(&id);
+    }
+    false
+}
+
+fn record_transient_failure(cache: &Mutex<HashMap<u32, Instant>>, id: u32) {
+    let mut cache = cache.lock().unwrap_or_else(|e| e.into_inner());
+    cache.insert(id, Instant::now());
+    // Bound growth: outages can touch many distinct ids; drop expired first,
+    // then cap at a generous size to avoid unbounded memory.
+    if cache.len() > 4096 {
+        cache.retain(|_, at| at.elapsed() < TRANSIENT_NSS_TTL);
+    }
+    if cache.len() > 8192 {
+        cache.clear();
+    }
+}
+
 /// Initial buffer size hint from sysconf, or a reasonable default.
 fn sysconf_bufsize(name: libc::c_int, fallback: usize) -> usize {
     let ret = unsafe { libc::sysconf(name) };
@@ -289,8 +323,9 @@ fn nss_name_from_ptr(ptr: *const libc::c_char) -> Option<String> {
 ///
 /// Uses `getpwuid_r` or `getgrgid_r` (selected by `kind`) with a
 /// sysconf-hinted buffer that doubles on `ERANGE`, falls back to `getent`
-/// on libc errors, and caches only definitive results so transient failures
-/// (timeout, backend unavailable) can be retried on a later lookup.
+/// on libc errors, caches definitive results indefinitely, and caches
+/// transient failures (timeout, backend unavailable) for `TRANSIENT_NSS_TTL`
+/// so one listing under outage does not retry per entry.
 fn resolve_nss_name(
     cache: &'static Mutex<HashMap<u32, Option<String>>>,
     kind: NssKind,
@@ -302,6 +337,15 @@ fn resolve_nss_name(
         if let Some(result) = c.get(&id) {
             return result.clone();
         }
+    }
+    // Short negative cache for transient outage: fail fast without hitting
+    // libc/getent again within the TTL window.
+    let transient_cache = match kind {
+        NssKind::User => &*TRANSIENT_USER_FAILURES,
+        NssKind::Group => &*TRANSIENT_GROUP_FAILURES,
+    };
+    if transient_failure_recent(transient_cache, id) {
+        return None;
     }
 
     let (bufsize_hint, database) = match kind {
@@ -377,15 +421,19 @@ fn resolve_nss_name(
         break Ok(name_str);
     };
 
-    // Cache only definitive results. Transient failures (Err) are not
-    // cached so a later lookup can succeed once the service recovers.
+    // Cache definitive results indefinitely; cache transient failures for
+    // TRANSIENT_NSS_TTL so a later lookup can succeed once the service
+    // recovers, without retrying per directory entry during an outage.
     match name_result {
         Ok(name) => {
             let mut c = cache.lock().unwrap_or_else(|e| e.into_inner());
             c.insert(id, name.clone());
             name
         }
-        Err(()) => None,
+        Err(()) => {
+            record_transient_failure(transient_cache, id);
+            None
+        }
     }
 }
 

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -54,6 +54,7 @@ async fn system_info() -> HandlerResult {
         "os" => std::env::consts::OS,
         "arch" => std::env::consts::ARCH,
         "watcher" => watcher_kind(),
+        "watcher_available" => Value::Boolean(crate::watcher::is_active()),
         "max_read_chunk_bytes" => io::MAX_FILE_READ_CHUNK_BYTES as u64,
         "hostname" => hostname(),
         "uid" => getuid().as_raw(),

--- a/server/src/handlers/process.rs
+++ b/server/src/handlers/process.rs
@@ -25,7 +25,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command as StdCommand, ExitStatus, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
@@ -68,9 +68,48 @@ fn merged_output_pipe() -> std::io::Result<(Stdio, Stdio, tokio::fs::File)> {
     Ok((Stdio::from(write_fd), Stdio::from(stderr_fd), reader))
 }
 
+pub(crate) struct RetainedOutputBudget {
+    remaining: Arc<Semaphore>,
+    retained: AtomicUsize,
+    committed: AtomicBool,
+}
+
+impl RetainedOutputBudget {
+    pub(crate) fn new(remaining: Arc<Semaphore>) -> Self {
+        Self {
+            remaining,
+            retained: AtomicUsize::new(0),
+            committed: AtomicBool::new(false),
+        }
+    }
+
+    fn retain(&self, bytes: usize, output_limit: usize) -> std::io::Result<()> {
+        let permits = u32::try_from(bytes).expect("output buffer length fits in u32");
+        let permit = self.remaining.try_acquire_many(permits).map_err(|_| {
+            std::io::Error::other(format!("Process output exceeds {output_limit} byte limit"))
+        })?;
+        permit.forget();
+        self.retained.fetch_add(bytes, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub(crate) fn commit(&self) {
+        self.committed.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for RetainedOutputBudget {
+    fn drop(&mut self) {
+        if !self.committed.load(Ordering::Relaxed) {
+            self.remaining
+                .add_permits(self.retained.load(Ordering::Relaxed));
+        }
+    }
+}
+
 pub(crate) async fn read_sync_output<R>(
     mut reader: R,
-    remaining: Arc<Semaphore>,
+    budget: Arc<RetainedOutputBudget>,
     output_limit: usize,
 ) -> std::io::Result<Vec<u8>>
 where
@@ -83,12 +122,8 @@ where
         if read == 0 {
             return Ok(output);
         }
-        let permits = u32::try_from(read).expect("output buffer length fits in u32");
-        let permit = remaining.try_acquire_many(permits).map_err(|_| {
-            std::io::Error::other(format!("Process output exceeds {output_limit} byte limit"))
-        })?;
         // Consumed permits represent bytes retained in the response buffers.
-        permit.forget();
+        budget.retain(read, output_limit)?;
         output.extend_from_slice(&buffer[..read]);
     }
 }
@@ -455,11 +490,12 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
     // intentionally per-run rather than server-wide, so admission permits up
     // to GENERAL_TASK_LIMIT concurrent allocations of this size.
     let remaining = Arc::new(Semaphore::new(output_limit));
+    let output_budget = Arc::new(RetainedOutputBudget::new(remaining));
     let result =
         if let Some(reader) = merged_reader {
             tokio::try_join!(
                 write_stdin,
-                read_sync_output(reader, remaining, output_limit),
+                read_sync_output(reader, Arc::clone(&output_budget), output_limit),
                 async {
                     child.wait().await.map_err(|e| {
                         std::io::Error::other(format!("Failed to wait for process: {e}"))
@@ -478,8 +514,8 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
             };
             tokio::try_join!(
                 write_stdin,
-                read_sync_output(stdout, Arc::clone(&remaining), output_limit),
-                read_sync_output(stderr, remaining, output_limit),
+                read_sync_output(stdout, Arc::clone(&output_budget), output_limit),
+                read_sync_output(stderr, Arc::clone(&output_budget), output_limit),
                 async {
                     child.wait().await.map_err(|e| {
                         std::io::Error::other(format!("Failed to wait for process: {e}"))
@@ -497,6 +533,7 @@ async fn run_with_output_limit(params: Value, output_limit: usize) -> HandlerRes
         }
     };
     process_group.disarm();
+    output_budget.commit();
 
     // Return binary data directly (no encoding needed!)
     let exit_code = crate::protocol::exit_code_from_status(status);
@@ -2697,10 +2734,27 @@ mod tests {
 
     #[tokio::test]
     async fn synchronous_output_reader_enforces_shared_limit() {
-        let error = read_sync_output(&b"oversized"[..], Arc::new(Semaphore::new(4)), 4)
+        let budget = Arc::new(RetainedOutputBudget::new(Arc::new(Semaphore::new(4))));
+        let error = read_sync_output(&b"oversized"[..], budget, 4)
             .await
             .expect_err("output above the remaining response budget should fail");
         assert!(error.to_string().contains("output exceeds"));
+    }
+
+    #[tokio::test]
+    async fn discarded_output_restores_shared_budget() {
+        let remaining = Arc::new(Semaphore::new(16));
+        let budget = Arc::new(RetainedOutputBudget::new(Arc::clone(&remaining)));
+
+        let output = read_sync_output(&b"12345678"[..], Arc::clone(&budget), 16)
+            .await
+            .expect("output within the budget");
+        assert_eq!(output, b"12345678");
+        assert_eq!(remaining.available_permits(), 8);
+
+        drop(output);
+        drop(budget);
+        assert_eq!(remaining.available_permits(), 16);
     }
 
     #[tokio::test]
@@ -4235,7 +4289,8 @@ mod tests {
 
         let mut output = Vec::new();
         let mut exited = false;
-        for _ in 0..40 {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        while tokio::time::Instant::now() < deadline {
             let read = read_pty(Value::Map(vec![
                 (Value::String("pid".into()), Value::Integer(pid.into())),
                 (
@@ -4252,6 +4307,10 @@ mod tests {
             if exited {
                 break;
             }
+            // Some PTY backends report immediate readability while process
+            // teardown is still in progress; avoid exhausting a fixed poll
+            // count before the exit status becomes observable.
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert!(exited);
         assert!(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -245,6 +245,23 @@ fn deferred_bytes(deferred: &VecDeque<DeferredRequest>) -> usize {
     deferred.iter().map(|r| r.frame_size).sum()
 }
 
+fn enqueue_deferred(
+    deferred: &mut VecDeque<DeferredRequest>,
+    request: Request,
+    frame_size: usize,
+) -> Result<(), Box<Response>> {
+    if frame_size > DEFERRED_BYTE_LIMIT {
+        return Err(Box::new(Response::error(
+            Some(request.id),
+            RpcError::invalid_request(format!(
+                "Request frame exceeds {DEFERRED_BYTE_LIMIT} byte deferred limit"
+            )),
+        )));
+    }
+    deferred.push_back(DeferredRequest::new(request, frame_size));
+    Ok(())
+}
+
 async fn write_response<W>(writer: &Arc<Mutex<W>>, response: &Response)
 where
     W: AsyncWrite + Unpin,
@@ -553,7 +570,9 @@ async fn accept_frame<W>(
         .iter()
         .any(|queued| task_class(&queued.method) == class)
     {
-        deferred.push_back(DeferredRequest::new(request, frame_size));
+        if let Err(response) = enqueue_deferred(deferred, request, frame_size) {
+            let _ = errors.send(*response).await;
+        }
         return;
     }
 
@@ -566,14 +585,20 @@ async fn accept_frame<W>(
             Some(byte_permit) => spawn_request(tasks, request, permit, byte_permit, writer),
             None => {
                 drop(permit);
-                deferred.push_back(DeferredRequest::new(request, frame_size))
+                if let Err(response) = enqueue_deferred(deferred, request, frame_size) {
+                    let _ = errors.send(*response).await;
+                }
             }
         },
-        // Queue rather than reject.  The caller stops reading frames once the
-        // queue is full by count or bytes, so the client is throttled instead
-        // of being handed a synthetic error for a request it was entitled to
-        // make.
-        None => deferred.push_back(DeferredRequest::new(request, frame_size)),
+        // Queue rather than reject when the request fits the deferred byte
+        // limit.  An individual frame larger than the entire queue budget can
+        // never become admissible there, so reject it instead of deadlocking
+        // the connection around an unstartable request.
+        None => {
+            if let Err(response) = enqueue_deferred(deferred, request, frame_size) {
+                let _ = errors.send(*response).await;
+            }
+        }
     }
 }
 
@@ -755,6 +780,19 @@ mod tests {
         let response = errors_rx.recv().await.expect("oversized frame response");
         assert_eq!(response.error.unwrap().code, RpcError::INVALID_REQUEST);
         assert_eq!(frames_rx.recv().await, Some(vec![0xc0]));
+    }
+
+    #[test]
+    fn test_individually_oversized_request_is_not_deferred() {
+        let request = decode_request(&make_request("file.stat", Value::Nil)).unwrap();
+        let mut deferred = VecDeque::new();
+
+        let response = enqueue_deferred(&mut deferred, request, DEFERRED_BYTE_LIMIT + 1)
+            .expect_err("an individually oversized request must be rejected");
+
+        assert!(deferred.is_empty());
+        assert!(matches!(response.id, Some(RequestId::Number(1))));
+        assert_eq!(response.error.unwrap().code, RpcError::INVALID_REQUEST);
     }
 
     #[test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -582,12 +582,15 @@ async fn main() -> std::process::ExitCode {
     let stdout: WriterHandle = Arc::new(Mutex::new(BufWriter::new(tokio::io::stdout())));
 
     // Initialize the filesystem watcher for cache invalidation notifications.
-    // If this fails (e.g. inotify not available), we continue without watching.
+    // If this fails (e.g. inotify not available), we continue without watching
+    // but record the state so `system.info` reports actual availability
+    // instead of just the compiled backend kind.
     // NOTE: Do NOT use eprintln! here or anywhere in the server -- SSH forwards
     // the remote process's stderr over the same pipe to Emacs, where it gets
     // mixed with the binary msgpack protocol on stdout and corrupts framing.
-    if let Ok(manager) = watcher::WatchManager::new(Arc::clone(&stdout)) {
-        watcher::init(manager);
+    match watcher::WatchManager::new(Arc::clone(&stdout)) {
+        Ok(manager) => watcher::init(manager),
+        Err(_) => watcher::set_unavailable(),
     }
 
     match run_connection(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,10 +19,27 @@ use protocol::{Request, RequestId, Response, RpcError};
 use rmpv::Value;
 use std::collections::VecDeque;
 use std::io::Cursor;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio::task::JoinSet;
+
+/// Global byte budget for active request params.  Slot admission alone bounds
+/// task count (16 general), but each active request retains its decoded params
+/// (including stdin blobs up to 100MiB).  Without byte admission, 16 large
+/// active requests could retain ~1.6GiB.  This semaphore bounds retained
+/// active params; permits are held for the task lifetime alongside slot
+/// permits.  Deferred (queued) params are bounded separately by
+/// `DEFERRED_BYTE_LIMIT`; see below.
+static ACTIVE_PARAM_BYTES: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(128 * 1024 * 1024)));
+
+fn try_acquire_param_bytes(size: usize) -> Option<OwnedSemaphorePermit> {
+    let permits = u32::try_from(size).ok()?;
+    Arc::clone(&ACTIVE_PARAM_BYTES)
+        .try_acquire_many_owned(permits)
+        .ok()
+}
 
 pub(crate) const MAX_FRAME_SIZE: usize = 100 * 1024 * 1024;
 pub(crate) const MAX_RESPONSE_OUTPUT_BYTES: usize = MAX_FRAME_SIZE - 1024 * 1024;
@@ -37,6 +54,22 @@ const PTY_WRITE_TASK_LIMIT: usize = 16;
 /// error would just surface as a spurious `remote-file-error' in the middle
 /// of an ordinary file operation.
 const DEFERRED_REQUEST_LIMIT: usize = 64;
+/// Byte budget for decoded-but-not-yet-started requests.  The deferred queue
+/// retains full request params (including `process.run' stdin blobs), so a
+/// count-only bound can retain ~64 x 100MiB ~= 6.4GiB.  Ordinary traffic
+/// (KB-sized requests) stays governed by the count limit; large frames hit
+/// this byte limit first and apply backpressure via the bounded frame channel
+/// and OS pipe.
+///
+/// Bound note: the check runs before receiving the next frame, so the queue
+/// can overshoot by one frame plus up to FRAME_CHANNEL_SIZE in-flight frames.
+/// Worst queued ~= LIMIT + 3 x MAX_FRAME.  With 32MiB this is ~332MiB, far
+/// below the unbounded 6.4GiB.  Active params are separately bounded by
+/// ACTIVE_PARAM_BYTES (128MiB); active response buffers remain per-request
+/// bounded (MAX_RESPONSE_OUTPUT_BYTES each, 16 max) and require the trusted
+/// client to request 16 concurrent large outputs — mitigated by per-command
+/// timeouts and the per-batch shared output budget.
+const DEFERRED_BYTE_LIMIT: usize = 32 * 1024 * 1024;
 const ERROR_RESPONSE_CHANNEL_SIZE: usize = 16;
 const EOF_TASK_JOIN_WAIT: std::time::Duration = std::time::Duration::from_millis(500);
 
@@ -175,6 +208,43 @@ fn request_permit_count(method: &str) -> usize {
     }
 }
 
+/// A decoded request retained in the deferred queue, with its wire size.
+/// `frame_size` approximates retained params (including stdin blobs) so the
+/// queue can be byte-bounded, not just count-bounded.
+struct DeferredRequest {
+    request: Request,
+    frame_size: usize,
+}
+
+impl DeferredRequest {
+    fn new(request: Request, frame_size: usize) -> Self {
+        Self {
+            request,
+            frame_size,
+        }
+    }
+
+    /// Test-only constructor with zero wire size (no byte-budget impact).
+    #[cfg(test)]
+    fn for_test(request: Request) -> Self {
+        Self {
+            request,
+            frame_size: 0,
+        }
+    }
+}
+
+impl std::ops::Deref for DeferredRequest {
+    type Target = Request;
+    fn deref(&self) -> &Self::Target {
+        &self.request
+    }
+}
+
+fn deferred_bytes(deferred: &VecDeque<DeferredRequest>) -> usize {
+    deferred.iter().map(|r| r.frame_size).sum()
+}
+
 async fn write_response<W>(writer: &Arc<Mutex<W>>, response: &Response)
 where
     W: AsyncWrite + Unpin,
@@ -203,13 +273,17 @@ fn spawn_request<W>(
     tasks: &mut JoinSet<()>,
     request: Request,
     permit: OwnedSemaphorePermit,
+    byte_permit: OwnedSemaphorePermit,
     writer: &Arc<Mutex<W>>,
 ) where
     W: AsyncWrite + Unpin + Send + 'static,
 {
     let writer = Arc::clone(writer);
     tasks.spawn(async move {
+        // Hold both the slot permit and the param-byte permit for the task
+        // lifetime, bounding active retained params to ACTIVE_PARAM_BYTES.
         let _permit = permit;
+        let _byte_permit = byte_permit;
         #[cfg(test)]
         let panic_after_response = request.method == "test.panic";
         let response = handlers::dispatch(request).await;
@@ -248,7 +322,7 @@ where
 
     let mut tasks: JoinSet<()> = JoinSet::new();
     let admissions = Admissions::default();
-    let mut deferred: VecDeque<Request> = VecDeque::new();
+    let mut deferred: VecDeque<DeferredRequest> = VecDeque::new();
     let mut general_bypass_budget = None;
 
     loop {
@@ -259,10 +333,11 @@ where
             &admissions,
             &mut general_bypass_budget,
         );
-        // Stop pulling frames while the backlog is full.  The bounded frame
-        // channel then stops draining the pipe, which is the throttle the
-        // client can actually observe.
-        let accepting = deferred.len() < DEFERRED_REQUEST_LIMIT;
+        // Stop pulling frames while the backlog is full by count or bytes.
+        // The bounded frame channel then stops draining the pipe, which is
+        // the throttle the client can actually observe.
+        let accepting = deferred.len() < DEFERRED_REQUEST_LIMIT
+            && deferred_bytes(&deferred) < DEFERRED_BYTE_LIMIT;
 
         if tasks.is_empty() {
             if !accepting {
@@ -341,7 +416,7 @@ async fn drain_tasks_for(tasks: &mut JoinSet<()>, wait: std::time::Duration) {
 /// already-arriving one-permit work once, but are then reserved as they return,
 /// preventing both head-of-line idling and indefinite batch starvation.
 fn start_admissible<W>(
-    deferred: &mut VecDeque<Request>,
+    deferred: &mut VecDeque<DeferredRequest>,
     tasks: &mut JoinSet<()>,
     writer: &Arc<Mutex<W>>,
     admissions: &Admissions,
@@ -353,24 +428,37 @@ fn start_admissible<W>(
     let mut general_waiting = false;
     let mut control_blocked = false;
     let mut pty_write_blocked = false;
-    while let Some(request) = deferred.pop_front() {
+    while let Some(deferred_req) = deferred.pop_front() {
+        let request = deferred_req.request;
         let class = task_class(&request.method);
         let permit_count = request_permit_count(&request.method);
+        // Re-wrap for potential re-queue, preserving the wire size.
+        let rewrap = |request: Request| DeferredRequest::new(request, deferred_req.frame_size);
 
         if class == TaskClass::General && general_waiting {
             let Some(budget) = general_bypass_budget.as_mut() else {
-                still_deferred.push_back(request);
+                still_deferred.push_back(rewrap(request));
                 continue;
             };
             if permit_count > *budget {
-                still_deferred.push_back(request);
+                still_deferred.push_back(rewrap(request));
                 continue;
             }
             if let Some(permit) = admissions.try_acquire_many(class, permit_count) {
-                *budget -= permit_count;
-                spawn_request(tasks, request, permit, writer);
+                match try_acquire_param_bytes(deferred_req.frame_size) {
+                    Some(byte_permit) => {
+                        *budget -= permit_count;
+                        spawn_request(tasks, request, permit, byte_permit, writer);
+                    }
+                    None => {
+                        // Slot released on drop; byte budget is the binding
+                        // constraint.  Requeue and keep waiting.
+                        drop(permit);
+                        still_deferred.push_back(rewrap(request));
+                    }
+                }
             } else {
-                still_deferred.push_back(request);
+                still_deferred.push_back(rewrap(request));
             }
             continue;
         }
@@ -381,16 +469,39 @@ fn start_admissible<W>(
             TaskClass::PtyWrite => pty_write_blocked,
         };
         if blocked {
-            still_deferred.push_back(request);
+            still_deferred.push_back(rewrap(request));
             continue;
         }
 
         match admissions.try_acquire_many(class, permit_count) {
             Some(permit) => {
-                if class == TaskClass::General && permit_count > 1 {
-                    *general_bypass_budget = None;
+                match try_acquire_param_bytes(deferred_req.frame_size) {
+                    Some(byte_permit) => {
+                        if class == TaskClass::General && permit_count > 1 {
+                            *general_bypass_budget = None;
+                        }
+                        spawn_request(tasks, request, permit, byte_permit, writer);
+                    }
+                    None => {
+                        // Byte budget bound active params; release the slot and
+                        // treat like slot exhaustion so backpressure applies.
+                        drop(permit);
+                        if class == TaskClass::General && permit_count > 1 {
+                            if general_bypass_budget.is_none() {
+                                *general_bypass_budget =
+                                    Some(admissions.available_permits(TaskClass::General));
+                            }
+                            general_waiting = true;
+                        } else {
+                            match class {
+                                TaskClass::General => general_waiting = true,
+                                TaskClass::Control => control_blocked = true,
+                                TaskClass::PtyWrite => pty_write_blocked = true,
+                            }
+                        }
+                        still_deferred.push_back(rewrap(request));
+                    }
                 }
-                spawn_request(tasks, request, permit, writer);
             }
             None => {
                 if class == TaskClass::General && permit_count > 1 {
@@ -406,7 +517,7 @@ fn start_admissible<W>(
                         TaskClass::PtyWrite => pty_write_blocked = true,
                     }
                 }
-                still_deferred.push_back(request);
+                still_deferred.push_back(rewrap(request));
             }
         }
     }
@@ -415,7 +526,7 @@ fn start_admissible<W>(
 
 async fn accept_frame<W>(
     payload: Vec<u8>,
-    deferred: &mut VecDeque<Request>,
+    deferred: &mut VecDeque<DeferredRequest>,
     admissions: &Admissions,
     tasks: &mut JoinSet<()>,
     writer: &Arc<Mutex<W>>,
@@ -423,8 +534,10 @@ async fn accept_frame<W>(
 ) where
     W: AsyncWrite + Unpin + Send + 'static,
 {
-    // Decode and validate before spawning.  This lets the frame Vec be freed
-    // before a handler awaits, while retaining the request params it needs.
+    // Decode and validate before spawning.  The frame Vec is freed after
+    // decode, but retained params (e.g. stdin blobs) keep ~payload.len()
+    // bytes alive, so track the wire size for byte-bounded backpressure.
+    let frame_size = payload.len();
     let request = match decode_request(&payload) {
         Ok(request) => request,
         Err(response) => {
@@ -440,18 +553,27 @@ async fn accept_frame<W>(
         .iter()
         .any(|queued| task_class(&queued.method) == class)
     {
-        deferred.push_back(request);
+        deferred.push_back(DeferredRequest::new(request, frame_size));
         return;
     }
 
     // A batch reserves its full subrequest concurrency from the shared general
     // admission bound, so concurrent batches cannot multiply that limit.
+    // Active params are additionally byte-bounded: a slot without byte budget
+    // defers, so 16 large active requests cannot retain ~1.6GiB.
     match admissions.try_acquire_many(class, request_permit_count(&request.method)) {
-        Some(permit) => spawn_request(tasks, request, permit, writer),
+        Some(permit) => match try_acquire_param_bytes(frame_size) {
+            Some(byte_permit) => spawn_request(tasks, request, permit, byte_permit, writer),
+            None => {
+                drop(permit);
+                deferred.push_back(DeferredRequest::new(request, frame_size))
+            }
+        },
         // Queue rather than reject.  The caller stops reading frames once the
-        // queue is full, so the client is throttled instead of being handed a
-        // synthetic error for a request it was entitled to make.
-        None => deferred.push_back(request),
+        // queue is full by count or bytes, so the client is throttled instead
+        // of being handed a synthetic error for a request it was entitled to
+        // make.
+        None => deferred.push_back(DeferredRequest::new(request, frame_size)),
     }
 }
 
@@ -668,36 +790,36 @@ mod tests {
             )
             .expect("hold all but three general permits");
         let mut deferred = VecDeque::from([
-            Request {
+            DeferredRequest::for_test(Request {
                 version: "2.0".into(),
                 id: RequestId::Number(1),
                 method: "batch".into(),
                 params: Value::Nil,
-            },
-            Request {
+            }),
+            DeferredRequest::for_test(Request {
                 version: "2.0".into(),
                 id: RequestId::Number(2),
                 method: "process.status".into(),
                 params: Value::Nil,
-            },
-            Request {
+            }),
+            DeferredRequest::for_test(Request {
                 version: "2.0".into(),
                 id: RequestId::Number(3),
                 method: "process.status".into(),
                 params: Value::Nil,
-            },
-            Request {
+            }),
+            DeferredRequest::for_test(Request {
                 version: "2.0".into(),
                 id: RequestId::Number(4),
                 method: "process.status".into(),
                 params: Value::Nil,
-            },
-            Request {
+            }),
+            DeferredRequest::for_test(Request {
                 version: "2.0".into(),
                 id: RequestId::Number(5),
                 method: "process.status".into(),
                 params: Value::Nil,
-            },
+            }),
         ]);
         let writer = Arc::new(Mutex::new(tokio::io::sink()));
         let mut tasks = JoinSet::new();
@@ -728,12 +850,12 @@ mod tests {
                 GENERAL_TASK_LIMIT - handlers::BATCH_CONCURRENCY + 1,
             )
             .expect("hold all but three general permits");
-        let mut deferred = VecDeque::from([Request {
+        let mut deferred = VecDeque::from([DeferredRequest::for_test(Request {
             version: "2.0".into(),
             id: RequestId::Number(1),
             method: "batch".into(),
             params: Value::Nil,
-        }]);
+        })]);
         let writer = Arc::new(Mutex::new(tokio::io::sink()));
         let mut tasks = JoinSet::new();
         let mut bypass_budget = None;

--- a/server/src/watcher.rs
+++ b/server/src/watcher.rs
@@ -37,14 +37,31 @@ const MAX_DEBOUNCE_EVENTS: usize = 8192;
 /// Global WatchManager instance, initialized in main().
 static WATCH_MANAGER: OnceLock<Arc<WatchManager>> = OnceLock::new();
 
+/// Whether the global watcher actually initialized.  `system.info.watcher`
+/// previously reported `RecommendedWatcher::kind()` even when `init` failed,
+/// so the client could not reliably shorten caches.  This tracks reality.
+static WATCHER_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Get the global WatchManager, if initialized.
 pub fn get() -> Option<&'static Arc<WatchManager>> {
     WATCH_MANAGER.get()
 }
 
+/// Whether filesystem push notifications are actually running.
+pub fn is_active() -> bool {
+    WATCHER_ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Initialize the global WatchManager. Called once from main().
 pub fn init(manager: Arc<WatchManager>) {
     let _ = WATCH_MANAGER.set(manager);
+    WATCHER_ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Record that watcher initialization failed; client should treat caches as
+/// TTL-only without push invalidation.
+pub fn set_unavailable() {
+    WATCHER_ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Helper to lock a std::sync::Mutex, recovering from poisoning.


### PR DESCRIPTION
- Adds watcher availability reporting and caps metadata and Magit cache TTLs when push notifications are unavailable.
- Isolates notification handler failures so buffered RPC frames continue processing.
- Adds per-command timeouts to `commands.run_parallel`, preserving completed results and marking timed-out commands.
- Bounds active and deferred request memory using byte budgets in addition to concurrency limits.
- Batches UID/GID lookups during directory listings and adds a short negative cache for transient NSS failures.
- Tracks actual filesystem watcher initialization state in `system.info`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Parallel commands support configurable timeouts, with timed-out commands reported individually while other results remain available.
  - System status reports whether filesystem monitoring is active.

- **Improvements**
  - Cache lifetimes are reduced automatically when filesystem monitoring is unavailable.
  - Directory listings resolve user and group names more efficiently.
  - Temporary name-resolution failures are retried less aggressively.

- **Bug Fixes**
  - Notification-handler errors no longer interrupt queued RPC responses.
  - Request processing applies memory-based backpressure under heavy load.
  - Oversized deferred requests are rejected clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->