### PR TITLE
Keep RPC connection alive when a response wait is interrupted

### DIFF
--- a/README.org
+++ b/README.org
@@ -463,6 +463,13 @@ verified mismatch remains an explicit error.
   block for up to the RPC timeout when the remote program stops reading.
   Pipe writes remain queued by default; set
   ~tramp-rpc-synchronous-pipe-writes~ non-nil to make them synchronous too.
+- ~C-g~ while waiting for a synchronous, batch, or pipelined RPC response
+  abandons only that wait.  The connection, its other pending requests, and its
+  remote processes stay alive, and a late reply for the abandoned request is
+  discarded by its ID.  The remote operation itself may still run to
+  completion.  A quit inside a request write still retires the connection
+  because the frame may be incomplete, and RPC timeouts and transport failures
+  keep tearing the connection down.
 
 * Troubleshooting
 

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -1722,8 +1722,11 @@ Returns the request ID."
       (unwind-protect
           (prog1
               (progn
-                ;; Send request (binary data with length prefix, no newline)
-                (process-send-string process request)
+                ;; Send request (binary data with length prefix, no newline).
+                ;; Like the synchronous paths, a quit inside the write
+                ;; leaves framing ambiguous and must retire the generation.
+                (tramp-rpc--send-request-frame
+                 conn vec request "Async RPC interrupted while sending\n")
                 id)
             (setq sent t))
         ;; Cover errors, user quits, and any other non-local exit.

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -681,22 +681,30 @@ This is idempotent so it can run from every synchronous wait exit path."
 
 (defmacro tramp-rpc--with-pending-requests (spec &rest body)
   "Run BODY, releasing unresolved request IDS on every exit.
-SPEC is (CONN IDS [VEC EVENT]).  When it includes VEC and EVENT, retire the
-captured generation on user quit."
+SPEC is (CONN IDS).  Abandoning a wait, including on user quit, leaves the
+transport reusable: `tramp-rpc--connection-filter' discards replies whose ID
+no longer has a waiter, so unrelated requests and processes on CONN survive
+a quit.  Only an ambiguously framed write retires the generation; see
+`tramp-rpc--send-request-frame'."
   (declare (indent 1) (debug t))
   (let ((conn (nth 0 spec))
-        (ids (nth 1 spec))
-        (vec (nth 2 spec))
-        (event (nth 3 spec)))
+        (ids (nth 1 spec)))
     `(unwind-protect
-         (condition-case interrupted
-             (progn ,@body)
-           (quit
-            ,(when vec
-               `(tramp-rpc--invalidate-interrupted-connection
-                 (tramp-rpc-connection-process ,conn) ,vec ,event))
-            (signal (car interrupted) (cdr interrupted))))
+         (progn ,@body)
        (tramp-rpc--release-pending-requests ,conn ,ids))))
+
+(defun tramp-rpc--send-request-frame (conn vec bytes event)
+  "Write request frame BYTES to generation CONN for VEC.
+EVENT describes the interrupted operation for transport diagnostics.
+A user quit inside the write leaves frame delivery ambiguous, so the
+generation is retired.  Quits before or after a complete write keep the
+transport usable and must not disconnect its other users."
+  (condition-case interrupted
+      (process-send-string (tramp-rpc-connection-process conn) bytes)
+    (quit
+     (tramp-rpc--invalidate-interrupted-connection
+      (tramp-rpc-connection-process conn) vec event)
+     (signal (car interrupted) (cdr interrupted)))))
 
 (defun tramp-rpc--claim-connection-generation (process vec event reason)
   "Claim PROCESS as a dead generation and detach it from VEC's connection table.
@@ -1861,11 +1869,11 @@ Returns the result or signals an error."
     (tramp-rpc--debug "SEND id=%s method=%s" expected-id method)
     (tramp-rpc--track-pending-request conn expected-id)
 
-    (tramp-rpc--with-pending-requests
-        (conn (list expected-id) vec
-              (format "RPC interrupted while waiting for %s\n" method))
+    (tramp-rpc--with-pending-requests (conn (list expected-id))
       ;; Send request (binary data with length prefix, no newline)
-      (process-send-string process request)
+      (tramp-rpc--send-request-frame
+       conn vec request
+       (format "RPC interrupted while sending %s\n" method))
 
       (let* ((state (tramp-rpc--wait-for-response-ids
                      conn (list expected-id) total-timeout
@@ -1933,9 +1941,9 @@ Returns:
          (request (cdr id-and-request)))
     (tramp-rpc--debug "SEND-BATCH id=%s count=%d" expected-id (length requests))
     (tramp-rpc--track-pending-request conn expected-id)
-    (tramp-rpc--with-pending-requests
-        (conn (list expected-id) vec "Batch RPC interrupted\n")
-      (process-send-string process request)
+    (tramp-rpc--with-pending-requests (conn (list expected-id))
+      (tramp-rpc--send-request-frame
+       conn vec request "Batch RPC interrupted while sending\n")
       (let* ((state (tramp-rpc--wait-for-response-ids
                      conn (list expected-id) timeout poll-interval "BATCH"))
              (response (gethash expected-id (plist-get state :responses))))
@@ -1984,31 +1992,25 @@ CONNECTION, when non-nil, is the captured connection generation to use.
 Returns a list of request IDs in the same order."
   (let* ((conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (tramp-rpc-connection-process conn))
-         ids completed dispatch-attempted)
+         ids completed)
     (unwind-protect
-        (condition-case interrupted
-            (progn
-              (dolist (req requests)
-                (let* ((id-and-bytes
-                        (let ((tramp-rpc-protocol--message-target process))
-                          (tramp-rpc-protocol-encode-request-with-id
-                           (car req) (cdr req))))
-                       (id (car id-and-bytes))
-                       (bytes (cdr id-and-bytes)))
-                  (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
-                  (push id ids)
-                  (tramp-rpc--track-pending-request conn id)
-                  ;; Once a transport write is attempted, a quit leaves frame
-                  ;; delivery ambiguous and this generation cannot be reused.
-                  (setq dispatch-attempted t)
-                  (process-send-string process bytes)))
-              (setq completed t)
-              (nreverse ids))
-          (quit
-           (when dispatch-attempted
-             (tramp-rpc--invalidate-interrupted-connection
-              process vec "Pipelined RPC interrupted while sending\n"))
-           (signal (car interrupted) (cdr interrupted))))
+        (progn
+          (dolist (req requests)
+            (let* ((id-and-bytes
+                    (let ((tramp-rpc-protocol--message-target process))
+                      (tramp-rpc-protocol-encode-request-with-id
+                       (car req) (cdr req))))
+                   (id (car id-and-bytes))
+                   (bytes (cdr id-and-bytes)))
+              (tramp-rpc--debug "SEND-PIPE id=%s method=%s" id (car req))
+              (push id ids)
+              (tramp-rpc--track-pending-request conn id)
+              ;; Only a quit inside the write makes frame delivery ambiguous.
+              ;; A quit between two complete frames leaves the stream intact.
+              (tramp-rpc--send-request-frame
+               conn vec bytes "Pipelined RPC interrupted while sending\n")))
+          (setq completed t)
+          (nreverse ids))
       (unless completed
         (tramp-rpc--release-pending-requests conn ids)))))
 
@@ -2023,8 +2025,7 @@ captured connection generation to use."
          (conn (or connection (tramp-rpc--ensure-connection vec)))
          (process (tramp-rpc-connection-process conn)))
     (tramp-rpc--debug "RECV-PIPE waiting for %d responses: %S" (length ids) ids)
-    (tramp-rpc--with-pending-requests
-        (conn ids vec "Pipelined RPC interrupted\n")
+    (tramp-rpc--with-pending-requests (conn ids)
       (let* ((state (tramp-rpc--wait-for-response-ids
                      conn ids timeout poll-interval "PIPE"))
              (remaining-ids (plist-get state :remaining))

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -254,6 +254,31 @@ SPEC is (PROCESS BUFFER [CONNECTION]); CONNECTION defaults to `connection'."
       (should-not (tramp-rpc--get-connection vec))
       (should-not (tramp-rpc-connection-pending-ids connection)))))
 
+(ert-deftest tramp-rpc-mock-test-request-async-send-quit-retires-generation ()
+  "Quit inside an async frame write retires its generation and callback."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let* ((vec (tramp-rpc-mock-test-request--vec))
+           (connection connection)
+           (tramp-rpc--connections (make-hash-table :test 'equal)))
+      (puthash (tramp-rpc--connection-key vec) connection tramp-rpc--connections)
+      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                   (lambda (_vec) connection))
+                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _) '(301 . "request")))
+                ((symbol-function 'process-send-string)
+                 (lambda (&rest _) (signal 'quit nil)))
+                ((symbol-function 'tramp-rpc--cleanup-controlmaster-unlocked) #'ignore))
+        (should
+         (eq 'quit
+             (condition-case nil
+                 (progn
+                   (tramp-rpc--call-async vec "test" nil #'ignore)
+                   'returned)
+               (quit 'quit)))))
+      (should-not (process-live-p process))
+      (should-not (tramp-rpc--get-connection vec))
+      (should-not (gethash 301 (tramp-rpc-connection-async-callbacks connection))))))
+
 (ert-deftest tramp-rpc-mock-test-request-pipeline-encode-error-preserves-generation ()
   "Failure before a pipelined transport write leaves the generation reusable."
   (tramp-rpc-mock-test-request--with-connection (process buffer)

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -78,36 +78,142 @@ SPEC is (PROCESS BUFFER [CONNECTION]); CONNECTION defaults to `connection'."
         (should (zerop (hash-table-count
                         (tramp-rpc-connection-pending-responses connection))))))))
 
-(ert-deftest tramp-rpc-mock-test-request-user-quit-retires-generation ()
-  "User quit detaches and closes the synchronous request generation."
+(defun tramp-rpc-mock-test-request--check-wait-quit (kind)
+  "Abandon a KIND wait without disrupting other users of its transport."
   (tramp-rpc-mock-test-request--with-connection (process buffer)
     (let* ((vec (tramp-rpc-mock-test-request--vec))
-           (connection connection)
-           (tramp-rpc--connections (make-hash-table :test 'equal)))
-      (puthash (tramp-rpc--connection-key vec) connection tramp-rpc--connections)
-      (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
-                 (lambda (_vec) connection))
-                ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
-                 (lambda (&rest _) '(102 . "request")))
-                ((symbol-function 'process-send-string) (lambda (&rest _) nil))
-                ((symbol-function 'accept-process-output)
-                 (lambda (&rest _) (signal 'quit nil)))
-                ((symbol-function 'tramp-rpc--cleanup-async-processes) #'ignore)
-                ((symbol-function 'tramp-rpc--cleanup-pty-processes) #'ignore)
-                ((symbol-function 'tramp-rpc--cleanup-watches-for-connection) #'ignore)
-                ((symbol-function 'tramp-rpc--cleanup-file-notify-for-connection) #'ignore)
-                ((symbol-function 'tramp-rpc--clear-direnv-cache) #'ignore)
-                ((symbol-function 'tramp-rpc--clear-file-caches-for-connection) #'ignore)
-                ((symbol-function 'tramp-rpc-magit--clear-status-cache-for-connection) #'ignore)
+           (tramp-rpc--connections (make-hash-table :test 'equal))
+           (tramp-rpc--async-processes (make-hash-table :test 'eq))
+           (relay (make-pipe-process :name "request-quit-relay" :noquery t))
+           (pending (tramp-rpc-connection-pending-responses connection))
+           callback-response)
+      (unwind-protect
+          (progn
+            (puthash (tramp-rpc--connection-key vec) connection tramp-rpc--connections)
+            (puthash relay (list :vec vec :pid 42 :connection-process process)
+                     tramp-rpc--async-processes)
+            ;; A different synchronous waiter and an async reader share this
+            ;; transport.  Cancelling our request must not release either.
+            (tramp-rpc--track-pending-request connection 900)
+            (puthash 901 (lambda (response) (setq callback-response response))
+                     (tramp-rpc-connection-async-callbacks connection))
+            (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                       (lambda (_vec) connection))
+                      ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                       (lambda (&rest _) '(102 . "request")))
+                      ((symbol-function 'tramp-rpc-protocol-encode-batch-request-with-id)
+                       (lambda (&rest _) '(102 . "batch")))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'accept-process-output)
+                       (lambda (&rest _) (signal 'quit nil)))
+                      ;; A regression must never attempt SSH cleanup in tests.
+                      ((symbol-function 'tramp-rpc--cleanup-controlmaster-unlocked) #'ignore))
+              (should
+               (eq 'quit
+                   (condition-case nil
+                       (progn
+                         (pcase kind
+                           ('sync (tramp-rpc--call-with-timeout vec "test" nil 1 0))
+                           ('batch (tramp-rpc--call-batch vec '(("test"))))
+                           ('pipeline
+                            (tramp-rpc--track-pending-request connection 102)
+                            (tramp-rpc--track-pending-request connection 103)
+                            (puthash 102 '(:id 102 :result completed) pending)
+                            (tramp-rpc--receive-responses vec '(102 103) 1 connection)))
+                         'returned)
+                     (quit 'quit)))))
+            (should (process-live-p process))
+            (should (eq connection (tramp-rpc--get-connection vec)))
+            (should (process-live-p relay))
+            (should (gethash relay tramp-rpc--async-processes))
+            (should (equal '(900) (tramp-rpc-connection-pending-ids connection)))
+            (should (zerop (hash-table-count pending)))
+            ;; Deliver late and unrelated replies together through the filter.
+            (let ((messages (list '(:id 102 :result abandoned)
+                                  '(:id 103 :result abandoned)
+                                  '(:id 900 :result other-waiter)
+                                  '(:id 901 :result async-output))))
+              (cl-letf (((symbol-function 'tramp-rpc-protocol-try-read-message)
+                         (lambda (_buffer)
+                           (set-marker (mark-marker) (point-max))
+                           (pop messages))))
+                (tramp-rpc--connection-filter process "responses")))
+            (should (= 1 (hash-table-count pending)))
+            (should (equal '(:id 900 :result other-waiter) (gethash 900 pending)))
+            (should (equal '(:id 901 :result async-output) callback-response))
+            ;; A new call must still complete on this exact connection.
+            (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                       (lambda (_vec) (tramp-rpc--get-connection vec)))
+                      ((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                       (lambda (&rest _) '(104 . "next")))
+                      ((symbol-function 'process-send-string)
+                       (lambda (target _bytes)
+                         (should (eq process target))
+                         (puthash 104 '(:id 104 :result next-result) pending))))
+              (should (eq 'next-result
+                          (tramp-rpc--call-with-timeout vec "next" nil 1 0)))))
+        (remhash relay tramp-rpc--async-processes)
+        (when (process-live-p relay) (delete-process relay))))))
+
+(ert-deftest tramp-rpc-mock-test-request-sync-wait-quit-preserves-generation ()
+  "Quitting a synchronous wait preserves unrelated work and late reply routing."
+  (tramp-rpc-mock-test-request--check-wait-quit 'sync))
+
+(ert-deftest tramp-rpc-mock-test-request-batch-wait-quit-preserves-generation ()
+  "Quitting a batch wait preserves unrelated work and late reply routing."
+  (tramp-rpc-mock-test-request--check-wait-quit 'batch))
+
+(ert-deftest tramp-rpc-mock-test-request-pipeline-wait-quit-preserves-generation ()
+  "Quitting a partially completed pipeline preserves other transport users."
+  (tramp-rpc-mock-test-request--check-wait-quit 'pipeline))
+
+(ert-deftest tramp-rpc-mock-test-request-send-quit-retires-generation ()
+  "An interrupted single or batch frame write still retires its transport."
+  (dolist (kind '(sync batch))
+    (tramp-rpc-mock-test-request--with-connection (process buffer)
+      (let* ((vec (tramp-rpc-mock-test-request--vec))
+             (tramp-rpc--connections (make-hash-table :test 'equal)))
+        (puthash (tramp-rpc--connection-key vec) connection tramp-rpc--connections)
+        (cl-letf (((symbol-function 'tramp-rpc--ensure-connection)
+                   (lambda (_vec) connection))
+                  ((symbol-function 'process-send-string)
+                   (lambda (&rest _) (signal 'quit nil)))
+                  ((symbol-function 'tramp-rpc--cleanup-controlmaster-unlocked) #'ignore))
+          (should
+           (eq 'quit
+               (condition-case nil
+                   (progn
+                     (if (eq kind 'sync)
+                         (tramp-rpc--call-with-timeout vec "test" nil 1 0)
+                       (tramp-rpc--call-batch vec '(("test"))))
+                     'returned)
+                 (quit 'quit)))))
+        (should-not (process-live-p process))
+        (should-not (tramp-rpc--get-connection vec))
+        (should-not (tramp-rpc-connection-pending-ids connection))))))
+
+(ert-deftest tramp-rpc-mock-test-request-between-pipeline-frames-quit-preserves-generation ()
+  "Quit while encoding a later request leaves earlier complete frames safe."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((vec (tramp-rpc-mock-test-request--vec))
+          (encodes 0)
+          (sends 0))
+      (cl-letf (((symbol-function 'tramp-rpc-protocol-encode-request-with-id)
+                 (lambda (&rest _)
+                   (if (= (cl-incf encodes) 2)
+                       (signal 'quit nil)
+                     '(201 . "request"))))
+                ((symbol-function 'process-send-string)
+                 (lambda (&rest _) (cl-incf sends)))
                 ((symbol-function 'tramp-rpc--cleanup-controlmaster-unlocked) #'ignore))
-        (should (eq (condition-case nil
-                        (progn
-                          (tramp-rpc--call-with-timeout vec "test" nil 1 0)
-                          nil)
-                      (quit 'quit))
-                    'quit)))
-      (should-not (process-live-p process))
-      (should-not (tramp-rpc--get-connection vec))
+        (should
+         (eq 'quit
+             (condition-case nil
+                 (progn (tramp-rpc--send-requests vec '(("one") ("two")) connection)
+                        'returned)
+               (quit 'quit)))))
+      (should (= sends 1))
+      (should (process-live-p process))
       (should-not (tramp-rpc-connection-pending-ids connection)))))
 
 (ert-deftest tramp-rpc-mock-test-request-partial-pipeline-send-quit-retires-generation ()

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -2309,6 +2309,57 @@ This matches the upstream `tramp-test28-process-file' test."
       (when (and (bufferp buf) (buffer-live-p buf))
         (kill-buffer buf)))))
 
+(ert-deftest tramp-rpc-test14-quit-preserves-concurrent-process ()
+  "A quit inside a synchronous wait must not kill a concurrent remote process.
+Long-running remote processes such as an ACP agent share the connection with
+ordinary synchronous file and process operations.  Interrupting one of those
+waits used to retire the whole transport and take the agent down with it."
+  :tags '(:process :expensive-test)
+  (skip-unless (tramp-rpc-test-enabled))
+
+  (let* ((default-directory (tramp-rpc-test--remote-directory))
+         (buffer (generate-new-buffer "*tramp-rpc-quit-longrun*"))
+         (armed nil)
+         (waits 0)
+         (probe (lambda (&rest _)
+                  (when (and armed (> (cl-incf waits) 2))
+                    (setq armed nil)
+                    (signal 'quit nil))))
+         proc)
+    (unwind-protect
+        (progn
+          (setq proc (start-file-process
+                      "tramp-rpc-quit-longrun" buffer
+                      "sh" "-c"
+                      "i=0; while [ $i -lt 30 ]; do echo tick $i; i=$((i+1)); sleep 1; done"))
+          (with-timeout (10 (error "Remote process produced no output"))
+            (while (zerop (buffer-size buffer))
+              (accept-process-output proc 0.1)))
+          (should (process-live-p proc))
+          (advice-add 'accept-process-output :before probe
+                      '((name . tramp-rpc-test-quit-probe)))
+          (setq armed t
+                waits 0)
+          (should (eq 'quit
+                      (condition-case nil
+                          (progn (process-file "sh" nil nil nil "-c" "sleep 6")
+                                 'returned)
+                        (quit 'quit))))
+          (setq quit-flag nil)
+          (advice-remove 'accept-process-output 'tramp-rpc-test-quit-probe)
+          ;; The interrupted wait must not have taken the agent down.
+          (should (process-live-p proc))
+          (let ((before (buffer-size buffer)))
+            (accept-process-output proc 3)
+            (should (> (buffer-size buffer) before)))
+          ;; The transport must still serve new requests.
+          (should (file-exists-p default-directory))
+          (should (eq 7 (process-file "sh" nil nil nil "-c" "exit 7"))))
+      (advice-remove 'accept-process-output 'tramp-rpc-test-quit-probe)
+      (setq quit-flag nil)
+      (when (processp proc) (ignore-errors (delete-process proc)))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
 ;;; ============================================================================
 ;;; Test 15: Copy/Rename Between Local and Remote
 ;;; ============================================================================


### PR DESCRIPTION
Closes #306.

Since 0d641d0, C-g inside a synchronous response wait retired the whole transport generation, killing unrelated remote processes sharing the connection.

The first two commits are cherry-picks of @liaowang11's proposed fix and tests from #306, preserving authorship. They scope teardown to an interrupted request write via a new tramp-rpc--send-request-frame helper; an abandoned wait only releases its own request IDs since the filter already drops late replies by ID.

On top: route tramp-rpc--call-async through the same helper, since a quit inside an async write leaves framing equally ambiguous, with a mock test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interrupting a synchronous, batch, or pipelined RPC wait no longer unnecessarily disconnects the transport.
  - Other pending requests, callbacks, and remote processes continue operating after an interrupted wait.
  - Late replies for interrupted requests are safely ignored.
  - Interruptions during request transmission still retire the connection when the message may be incomplete.
  - RPC timeouts and transport failures continue to disconnect as expected.

- **Documentation**
  - Added compatibility notes describing interruption behavior during RPC operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->