### PR TITLE
Fix MELPA warnings and compile modules in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,19 @@ jobs:
             sleep 10
           done
 
+      - name: Byte-compile each module in isolation
+        run: |
+          # package-initialize loads dependency autoloads, and compiling modules
+          # together carries definitions into later files.  Neither should hide
+          # a missing require in the module under test.
+          for file in lisp/*.el; do
+            rm -f lisp/*.elc
+            emacs -Q --batch \
+              --eval '(let ((dir (expand-file-name "elpa" user-emacs-directory))) (dolist (entry (directory-files dir t "^[^.]")) (when (file-directory-p entry) (push entry load-path))))' \
+              --eval '(setq byte-compile-error-on-warn t byte-compile-warnings t load-prefer-newer t)' \
+              -L lisp -f batch-byte-compile "$file"
+          done
+
       - name: Byte-compile
         run: |
           rm -f lisp/*.elc

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -33,4 +33,6 @@ jobs:
              :files (:defaults "Cargo.toml" "Cargo.lock" "server" ".cargo"))
           WARN_IS_ERROR: true
           EXIST_OK: false
+        # Melpazoid's experimental style findings remain advisory.  The elisp
+        # job in ci.yml independently enforces compiler and package-lint warnings.
         run: make -C ~/melpazoid

--- a/lisp/tramp-rpc-cache.el
+++ b/lisp/tramp-rpc-cache.el
@@ -89,7 +89,7 @@ STAT may be nil, which records a missing file.")
 `remote-file-name-inhibit-cache' t disables caching, while a numeric value
 caps the project-specific TTL.  Nil retains the explicit TRAMP-RPC TTL.
 When push notifications are unavailable (`tramp-rpc--watcher-degraded'),
-caches are TTL-only, so cap to `tramp-rpc--watcher-unavailable-ttl'."
+caches are TTL-only, so cap to `tramp-rpc-watcher-unavailable-ttl'."
   (let ((ttl (cond
                 ((eq remote-file-name-inhibit-cache t) 0)
                 ((numberp remote-file-name-inhibit-cache)
@@ -97,7 +97,7 @@ caches are TTL-only, so cap to `tramp-rpc--watcher-unavailable-ttl'."
                 (t tramp-rpc--cache-ttl))))
     (if (and (boundp 'tramp-rpc--watcher-degraded)
              tramp-rpc--watcher-degraded)
-        (min ttl tramp-rpc--watcher-unavailable-ttl)
+        (min ttl tramp-rpc-watcher-unavailable-ttl)
       ttl)))
 
 (defun tramp-rpc--cache-entry-valid-p (timestamp)
@@ -613,7 +613,8 @@ When RECURSIVE is non-nil, watch subdirectories too."
       (message "No directories being watched."))))
 
 ;; Keep the caches and watches consistent with transport generations, and
-;; receive server notifications.
+;; receive server notifications.  These internal callbacks are required when
+;; this module is loaded standalone; they do not enable editor integrations.
 (add-hook 'tramp-rpc-connection-invalidate-functions
           #'tramp-rpc--clear-file-caches-for-connection t)
 (add-hook 'tramp-rpc-transport-cleanup-functions

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -32,16 +32,6 @@
 (require 'tramp-sh)
 (require 'url)
 
-;; Functions from tramp-rpc.el.  `tramp-rpc-deploy' is loaded by
-;; tramp-rpc.el after these helpers have been defined.
-(declare-function tramp-send-command
-                  "tramp-sh" (vec command &optional neveropen nooutput))
-(declare-function tramp-send-command-and-check
-                  "tramp-sh"
-                  (vec command &optional subshell dont-suppress-err exit-status))
-(declare-function tramp-send-command-and-read
-                  "tramp-sh" (vec command &optional noerror marker))
-
 ;; ============================================================================
 ;;; Customization
 ;; ============================================================================

--- a/lisp/tramp-rpc-magit.el
+++ b/lisp/tramp-rpc-magit.el
@@ -252,13 +252,13 @@ Returns the cache hash table, or nil if none."
 (defun tramp-rpc-magit--process-cache-timestamp-valid-p (timestamp)
   "Return non-nil when process cache TIMESTAMP is within its own TTL.
 When push notifications are unavailable, cap to
-`tramp-rpc--watcher-unavailable-ttl' so unwatched changes surface promptly."
+`tramp-rpc-watcher-unavailable-ttl' so unwatched changes surface promptly."
   (or (null tramp-rpc-magit-process-cache-ttl)
       (let ((ttl tramp-rpc-magit-process-cache-ttl))
         (when (and (boundp 'tramp-rpc--watcher-degraded)
                    tramp-rpc--watcher-degraded
-                   (boundp 'tramp-rpc--watcher-unavailable-ttl))
-          (setq ttl (min ttl tramp-rpc--watcher-unavailable-ttl)))
+                   (boundp 'tramp-rpc-watcher-unavailable-ttl))
+          (setq ttl (min ttl tramp-rpc-watcher-unavailable-ttl)))
         (<= (- (float-time) timestamp) ttl))))
 
 (defun tramp-rpc-magit--set-process-cache (vec directory cache)
@@ -1402,7 +1402,8 @@ Removes handlers."
 
 ;; Prefetched status output is keyed by connection and stale as soon as the
 ;; server reports a change or the connection is retired.  Ancestor scans
-;; follow the file metadata they were derived from.
+;; follow the file metadata they were derived from.  These internal callbacks
+;; keep standalone module use correct; they do not enable the Magit integration.
 (add-hook 'tramp-rpc-connection-invalidate-functions
           #'tramp-rpc-magit--clear-status-cache-for-connection t)
 (add-hook 'tramp-rpc-fs-events-functions

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -1690,7 +1690,8 @@ Removes handlers and cleans up async processes."
 
 ;; Relay teardown runs from the transport's generation cleanup: remote
 ;; children are signalled while the transport is still live, local relays
-;; are removed once it is dead.
+;; are removed once it is dead.  Register these internal callbacks even when
+;; this module is loaded standalone, so relays cannot outlive the transport.
 (add-hook 'tramp-rpc-transport-terminate-functions
           #'tramp-rpc--terminate-async-processes t)
 (add-hook 'tramp-rpc-transport-terminate-functions

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -2239,7 +2239,7 @@ actual PATH line, matching the robustness of upstream TRAMP."
 (defconst tramp-rpc--system-info-property "tramp-rpc-system-info"
   "TRAMP connection property storing the cached system.info response.")
 
-(defcustom tramp-rpc--watcher-unavailable-ttl 30
+(defcustom tramp-rpc-watcher-unavailable-ttl 30
   "TTL cap in seconds for caches when push notifications are unavailable.
 When the server reports `watcher_available' as false, `fs.events'
 notifications are not running and caches are TTL-only.  Capping to a short
@@ -2251,7 +2251,7 @@ seconds of stale metadata."
 (defvar tramp-rpc--watcher-degraded nil
   "Non-nil when any known connection lacks push notifications.
 Set from `system.info' `watcher_available'.  Once set, metadata and Magit
-process caches use `tramp-rpc--watcher-unavailable-ttl' as a cap.  This is
+process caches use `tramp-rpc-watcher-unavailable-ttl' as a cap.  This is
 global and conservative, one degraded host shortens TTLs for all, because
 cache validity checks do not carry connection context.")
 

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -226,10 +226,13 @@ This is called from `tramp-multi-hop-p-hook'."
 
 ;; Now the actual implementation
 (require 'cl-lib)
+(require 'cl-extra)
 (require 'json)
 (require 'seq)
 (require 'tramp)
 (require 'tramp-sh)
+(require 'tramp-cache)
+(require 'tramp-compat)
 (require 'tramp-rpc-protocol)
 (require 'tramp-rpc-connection)
 (require 'tramp-rpc-transport)
@@ -248,13 +251,10 @@ This is called from `tramp-multi-hop-p-hook'."
 ;; autoload-owned functions used by the full implementation below.
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
-(declare-function tramp-sh-handle-copy-file "tramp-sh"
-                  (filename newname &optional ok-if-already-exists keep-date
-                            preserve-uid-gid preserve-extended-attributes))
 
 
-;; Helper modules only define functions while the main package is loading.
-;; Runtime integration is installed explicitly after `tramp-rpc' is provided.
+;; Helper modules register internal lifecycle callbacks when loaded.
+;; Editor integrations are installed after `tramp-rpc' is provided.
 (require 'tramp-rpc-deploy)
 (require 'tramp-rpc-process)
 (require 'tramp-rpc-advice)
@@ -3197,6 +3197,8 @@ VEC-OR-FILENAME can be either a tramp-file-name struct or a filename string."
 ;; Connection cleanup support
 ;; ============================================================================
 
+;; Internal transport teardown must always release file-notify watches.
+;; This is backend lifecycle wiring, not an opt-in editor integration.
 (add-hook 'tramp-rpc-transport-cleanup-functions
           #'tramp-rpc--cleanup-file-notify-for-connection t)
 
@@ -3303,7 +3305,7 @@ cleanup of all connections has run."
   "Remove malformed native-comp entries that prevent unloading.
 
 Native compilation can record anonymous compiled functions as
-`(defun . --anonymous-lambda)' in `load-history'.  Emacs bug#80446
+entries for `--anonymous-lambda' in `load-history'.  Emacs bug#80446
 causes `unload-feature' to reject those entries.  Remove them from all
 TRAMP-RPC modules before any of the modules are unloaded."
   (dolist (entry load-history)


### PR DESCRIPTION
The [MELPA review](https://github.com/melpa/melpa/pull/10181#issuecomment-5560494695) found warnings that dependency preloading hid in our byte-compilation job.

Fix the missing runtime requires, redundant declarations, private customization name, and documentation warning. Compile each module in a fresh Emacs process without dependency autoloads, with compiler warnings treated as errors.

Document why the 11 internal cleanup/cache hook registrations are necessary. Keep melpazoid's experimental style findings visible and advisory, without a custom output parser or suppression allowlist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected cache and process-cache expiration handling when the file watcher is unavailable.
  - Improved standalone module behavior and transport cleanup to prevent stale relay resources.
  - Corrected documentation and references for the watcher-unavailable cache setting.

- **Changes**
  - Renamed the watcher-unavailable cache TTL customization to use its public name.

- **Chores**
  - Added stricter isolated byte-compilation checks to detect missing module dependencies.
  - Clarified advisory status for experimental style-check findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->