### PR TITLE
Fix process lifecycle races, deployment trust, and CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install Nix
         if: ${{ steps.cache-binary.outputs.cache-hit != 'true' && !contains(inputs.target, 'apple-darwin') }}
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Cache Nix store
         if: ${{ steps.cache-binary.outputs.cache-hit != 'true' && !contains(inputs.target, 'apple-darwin') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,8 @@ jobs:
       - name: Run autoload tests
         run: ./test/run-autoload-tests.sh
 
-  test-protocol:
-    name: Protocol Tests (${{ matrix.emacs_label }})
+  test-mock:
+    name: Mock Tests (${{ matrix.emacs_label }})
     runs-on: ubuntu-latest
     needs: elisp
     strategy:
@@ -320,7 +320,7 @@ jobs:
             sleep 10
           done
 
-      - name: Run protocol tests
+      - name: Run mock tests
         run: |
           emacs -Q --batch \
             --eval "(require 'package)" \
@@ -328,17 +328,7 @@ jobs:
             --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             -l test/tramp-rpc-mock-tests.el \
-            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-protocol\")"
-
-      - name: Run request lifecycle tests
-        run: |
-          emacs -Q --batch \
-            --eval "(require 'package)" \
-            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
-            --eval "(package-initialize)" \
-            --eval "(setq debug-on-error t)" \
-            -l test/tramp-rpc-mock-tests.el \
-            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-mock-test-request\")"
+            --eval "(tramp-rpc-mock-test--run-guarded '(and \"^tramp-rpc-mock-test\" (not (tag :multi-hop)) (not (tag :server))))"
 
   test-multi-hop:
     name: Multi-Hop Tests (${{ matrix.emacs_label }})
@@ -396,7 +386,7 @@ jobs:
             --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             -l test/tramp-rpc-mock-tests.el \
-            --eval "(ert-run-tests-batch-and-exit '(tag :multi-hop))"
+            --eval "(tramp-rpc-mock-test--run-guarded '(tag :multi-hop))"
 
   test-server:
     name: Server Integration Tests (${{ matrix.emacs_label }})
@@ -456,7 +446,7 @@ jobs:
             --eval "(package-initialize)" \
             --eval "(setq debug-on-error t)" \
             -l test/tramp-rpc-mock-tests.el \
-            --eval "(ert-run-tests-batch-and-exit '(tag :server))"
+            --eval "(tramp-rpc-mock-test--run-guarded '(tag :server))"
 
   test-full-suite:
     name: Full Test Suite (with SSH) (${{ matrix.emacs_label }})
@@ -546,7 +536,7 @@ jobs:
             --eval "(setq debug-on-error t)" \
             --eval "(setq tramp-verbose 0)" \
             -l test/tramp-rpc-tests.el \
-            --eval "(ert-run-tests-batch-and-exit \"^tramp-rpc-test\")"
+            --eval "(tramp-rpc-test--run-guarded \"^tramp-rpc-test\")"
 
   test-upstream-tramp:
     name: Upstream Tramp Tests (${{ matrix.emacs_label }})
@@ -719,7 +709,7 @@ jobs:
         rust-extra,
         elisp,
         test-autoload,
-        test-protocol,
+        test-mock,
         test-multi-hop,
         test-server,
         test-full-suite,
@@ -736,7 +726,7 @@ jobs:
           echo "Rust Extra: ${{ needs.rust-extra.result }}"
           echo "Elisp: ${{ needs.elisp.result }}"
           echo "Autoload Tests: ${{ needs.test-autoload.result }}"
-          echo "Protocol Tests: ${{ needs.test-protocol.result }}"
+          echo "Mock Tests: ${{ needs.test-mock.result }}"
           echo "Multi-Hop Tests: ${{ needs.test-multi-hop.result }}"
           echo "Server Tests: ${{ needs.test-server.result }}"
           echo "Full Test Suite: ${{ needs.test-full-suite.result }}"
@@ -747,7 +737,7 @@ jobs:
              [[ "${{ needs.rust-extra.result }}" != "success" ]] || \
              [[ "${{ needs.elisp.result }}" != "success" ]] || \
              [[ "${{ needs.test-autoload.result }}" != "success" ]] || \
-             [[ "${{ needs.test-protocol.result }}" != "success" ]] || \
+             [[ "${{ needs.test-mock.result }}" != "success" ]] || \
              [[ "${{ needs.test-multi-hop.result }}" != "success" ]] || \
              [[ "${{ needs.test-server.result }}" != "success" ]] || \
              [[ "${{ needs.test-full-suite.result }}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Check version consistency
+        run: |
+          CARGO_VERSION=$(grep -oP '^version = "\K[^"]+' Cargo.toml)
+          ELISP_VERSION=$(grep -oP '^;; Version: \K.*' lisp/tramp-rpc.el)
+          DEPLOY_VERSION=$(grep -oP 'tramp-rpc-deploy-version "\K[^"]+' lisp/tramp-rpc-deploy.el)
+          echo "Cargo.toml:           $CARGO_VERSION"
+          echo "lisp/tramp-rpc.el:    $ELISP_VERSION"
+          echo "tramp-rpc-deploy.el:  $DEPLOY_VERSION"
+          if [ "$CARGO_VERSION" != "$ELISP_VERSION" ] || [ "$CARGO_VERSION" != "$DEPLOY_VERSION" ]; then
+            echo "::error::Version mismatch between Cargo.toml, lisp/tramp-rpc.el and lisp/tramp-rpc-deploy.el"
+            exit 1
+          fi
+
   elisp:
     name: Emacs Lisp (${{ matrix.emacs_label }})
     runs-on: ubuntu-latest
@@ -708,6 +721,7 @@ jobs:
         rust-linux,
         rust-macos,
         rust-extra,
+        format,
         elisp,
         test-autoload,
         test-mock,
@@ -725,6 +739,7 @@ jobs:
           echo "Rust Linux: ${{ needs.rust-linux.result }}"
           echo "Rust macOS: ${{ needs.rust-macos.result }}"
           echo "Rust Extra: ${{ needs.rust-extra.result }}"
+          echo "Rust Format: ${{ needs.format.result }}"
           echo "Elisp: ${{ needs.elisp.result }}"
           echo "Autoload Tests: ${{ needs.test-autoload.result }}"
           echo "Mock Tests: ${{ needs.test-mock.result }}"
@@ -736,6 +751,7 @@ jobs:
           if [[ "${{ needs.rust-linux.result }}" != "success" ]] || \
              [[ "${{ needs.rust-macos.result }}" != "success" ]] || \
              [[ "${{ needs.rust-extra.result }}" != "success" ]] || \
+             [[ "${{ needs.format.result }}" != "success" ]] || \
              [[ "${{ needs.elisp.result }}" != "success" ]] || \
              [[ "${{ needs.test-autoload.result }}" != "success" ]] || \
              [[ "${{ needs.test-mock.result }}" != "success" ]] || \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,6 +536,7 @@ jobs:
             --eval "(setq debug-on-error t)" \
             --eval "(setq tramp-verbose 0)" \
             -l test/tramp-rpc-tests.el \
+            --eval "(setq tramp-rpc-deploy-git-build-policy 'release)" \
             --eval "(tramp-rpc-test--run-guarded \"^tramp-rpc-test\")"
 
   test-upstream-tramp:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v7

--- a/benchmark/benchmark.el
+++ b/benchmark/benchmark.el
@@ -382,10 +382,13 @@ Same operations as batch-mixed-ops but done one at a time."
     ("batch-mixed-ops"    . tramp-rpc-benchmark--batch-mixed-ops))
   "Alist of RPC-only benchmark tests for batch operations.")
 
-(defun tramp-rpc-benchmark--resolve-test-selection (selected tests)
+(defun tramp-rpc-benchmark--resolve-test-selection (selected tests &optional allow-missing)
   "Resolve SELECTED benchmark names from TESTS.
 SELECTED accepts nil (all), :all, or a list of strings/symbols.
-Return filtered tests as an alist in the same shape as TESTS."
+Return filtered tests as an alist in the same shape as TESTS.
+When ALLOW-MISSING is non-nil, names that are not in TESTS are ignored
+instead of signalling; callers use this to combine the regular and
+RPC-only test tables."
   (cond
    ((or (null selected) (eq selected :all))
     tests)
@@ -399,9 +402,10 @@ Return filtered tests as an alist in the same shape as TESTS."
            (missing (seq-remove (lambda (name)
                                   (assoc name tests))
                                 names)))
-      (when missing
-        (error "Unknown benchmark(s): %s"
-               (mapconcat #'identity missing ", ")))
+      (unless allow-missing
+        (when missing
+          (error "Unknown benchmark(s): %s"
+                 (mapconcat #'identity missing ", "))))
       filtered))
    (t
     (error "SELECTED benchmarks must be nil, :all, or a list"))))
@@ -569,11 +573,20 @@ Batch mode example:
     --eval '(setq tramp-rpc-benchmark-host \"server\" tramp-rpc-benchmark-iterations 5)' \\
     --eval '(tramp-rpc-benchmark-run-subset (quote (\"file-exists\" \"file-read\")) (quote (\"rpc\")))'"
   (interactive)
-  (let* ((selected-tests
-          (tramp-rpc-benchmark--resolve-test-selection
-           benchmark-names tramp-rpc-benchmark--tests))
-         (selected-methods
-          (tramp-rpc-benchmark--resolve-method-selection methods)))
+  (let* ((selected-methods
+          (tramp-rpc-benchmark--resolve-method-selection methods))
+         ;; The RPC-only batch tests do not take a method argument and only
+         ;; make sense for the rpc method, but they must be resolvable by name
+         ;; and included in the rpc run.  Resolve against the combined table so
+         ;; an unknown name is still an error.
+         (all-tests (append tramp-rpc-benchmark--tests
+                            tramp-rpc-benchmark--rpc-only-tests))
+         (selected-tests
+          (tramp-rpc-benchmark--resolve-test-selection benchmark-names all-tests))
+         (regular-names (mapcar #'car tramp-rpc-benchmark--tests))
+         (regular-tests (seq-filter (lambda (test)
+                                      (member (car test) regular-names))
+                                    selected-tests)))
     (when (null selected-tests)
       (error "No benchmarks selected"))
     (setq tramp-rpc-benchmark-results nil)
@@ -582,11 +595,15 @@ Batch mode example:
     (message "Tests: %s" (mapconcat #'car selected-tests ", "))
     (message "This may take a few minutes...\n")
     (dolist (method selected-methods)
-      (message "\n=== Benchmarking %s ===\n" method)
-      (condition-case err
-          (tramp-rpc-benchmark--run-method method selected-tests)
-        (error
-         (message "Error running benchmarks for %s: %s" method err))))
+      (let ((tests (if (string= method "rpc")
+                       selected-tests
+                     regular-tests)))
+        (when tests
+          (message "\n=== Benchmarking %s ===\n" method)
+          (condition-case err
+              (tramp-rpc-benchmark--run-method method tests)
+            (error
+             (message "Error running benchmarks for %s: %s" method err))))))
     (tramp-rpc-benchmark--report)
     (message "\nBenchmarks complete! See *TRAMP Benchmark Results* buffer.")))
 

--- a/lisp/tramp-rpc-advice.el
+++ b/lisp/tramp-rpc-advice.el
@@ -249,6 +249,9 @@ PROCESS is a PID."
 PROCESS is the process being handled."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
       (cond
+       ;; A remote signal death is reported as `signal', matching local
+       ;; processes.  Callers such as LSP and compile branch on this.
+       ((integerp (process-get process :tramp-rpc-exit-signal)) 'signal)
        ((process-get process :tramp-rpc-exited) 'exit)
        ;; Use the real handler to check local relay liveness, not
        ;; `process-live-p' (which would recurse).  Do not perform synchronous
@@ -265,7 +268,9 @@ PROCESS is the process being handled."
   "Handler for `process-exit-status' for TRAMP-RPC processes.
 PROCESS is the process being handled."
   (if (and (processp process) (process-get process :tramp-rpc-pid))
-      (or (process-get process :tramp-rpc-exit-code) 0)
+      (or (process-get process :tramp-rpc-exit-signal)
+          (process-get process :tramp-rpc-exit-code)
+          0)
     (tramp-run-real-handler #'process-exit-status (list process))))
 
 (defun tramp-rpc-handle-process-command (process)

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -876,7 +876,11 @@ Returns the path to the binary on success, nil on failure."
                         (format "target/%s/release/%s"
                                 target tramp-rpc-deploy-binary-name)
                         tramp-rpc-deploy-source-directory))
-         (build-buffer (get-buffer-create "*tramp-rpc-build*")))
+         (build-buffer (get-buffer-create "*tramp-rpc-build*"))
+         ;; Capture the identity of the build inputs before `cargo build' runs.
+         ;; A change during the build would make a later id describe a source
+         ;; state the artifact was not built from.
+         (source-id-before (tramp-rpc-deploy--source-binary-id)))
 
     (message "Building tramp-rpc-server for %s (this may take a minute)..." arch)
 
@@ -891,6 +895,11 @@ Returns the path to the binary on success, nil on failure."
                          (expand-file-name "Cargo.toml" tramp-rpc-deploy-source-directory))))
       (if (zerop exit-code)
           (progn
+            (unless (equal source-id-before
+                           (tramp-rpc-deploy--source-binary-id))
+              (signal
+               'remote-file-error
+               (list "Source tree changed during the build; refusing to cache the artifact")))
             ;; Record the source id this artifact was built from before any
             ;; reuse decision can consult it.
             (tramp-rpc-deploy--record-source-build-id build-output)

--- a/lisp/tramp-rpc-deploy.el
+++ b/lisp/tramp-rpc-deploy.el
@@ -542,11 +542,41 @@ This is useful for development - run scripts/build-all.sh to populate."
                           (file-attribute-modification-time
                            (file-attributes source)))))))
 
+(defun tramp-rpc-deploy--source-build-id-path (build-output)
+  "Return the provenance sidecar path for BUILD-OUTPUT."
+  (concat build-output ".source-id"))
+
+(defun tramp-rpc-deploy--record-source-build-id (build-output)
+  "Record the current source id beside BUILD-OUTPUT.
+Returns the recorded id, or nil when this is not a source-id build.  The
+sidecar lets `tramp-rpc-deploy--source-build-output-path' accept a target
+artifact only when it was produced from the current checkout, instead of
+trusting file modification times that any tool can set."
+  (when-let* ((id (and (tramp-rpc-deploy--use-source-binary-id-p)
+                       (tramp-rpc-deploy--source-binary-id))))
+    (condition-case nil
+        (tramp-rpc-deploy--write-file-atomically
+         (tramp-rpc-deploy--source-build-id-path build-output)
+         (concat id "\n"))
+      (error nil))
+    id))
+
+(defun tramp-rpc-deploy--recorded-source-build-id (build-output)
+  "Return the source id recorded beside BUILD-OUTPUT, or nil."
+  (let ((sidecar (tramp-rpc-deploy--source-build-id-path build-output)))
+    (when (file-exists-p sidecar)
+      (with-temp-buffer
+        (insert-file-contents-literally sidecar)
+        (string-trim (buffer-string))))))
+
 (defun tramp-rpc-deploy--source-build-output-path (arch)
   "Return an existing source-tree build output for ARCH, or nil.
 This lets CI and developers reuse an already-built/downloaded artifact in
-TARGET/release without requiring a rebuild, while skipping obviously stale
-outputs whose mtime predates the source files."
+TARGET/release without requiring a rebuild.  In source-id mode the artifact
+is trusted only when a provenance sidecar records the current source id:
+mtime alone cannot distinguish a current build from a stale artifact whose
+timestamps were preserved or forged.  Outside source-id mode the mtime
+heuristic remains, because there is no source id to compare against."
   (when (and (tramp-rpc-deploy--source-root)
              (tramp-rpc-deploy--source-has-server-p))
     (let* ((target (tramp-rpc-deploy--arch-to-rust-target arch))
@@ -555,9 +585,15 @@ outputs whose mtime predates the source files."
                           target tramp-rpc-deploy-binary-name)
                   (tramp-rpc-deploy--source-root))))
       (when (and (file-exists-p path)
-                 (file-executable-p path)
-                 (tramp-rpc-deploy--newer-than-source-p path))
-        path))))
+                 (file-executable-p path))
+        (let ((expected (and (tramp-rpc-deploy--use-source-binary-id-p)
+                             (tramp-rpc-deploy--source-binary-id))))
+          (cond
+           (expected
+            (when (equal (tramp-rpc-deploy--recorded-source-build-id path)
+                         expected)
+              path))
+           ((tramp-rpc-deploy--newer-than-source-p path) path)))))))
 
 (defun tramp-rpc-deploy--remote-binary-path (vec)
   "Return the remote path where the binary should be installed for VEC."
@@ -855,6 +891,9 @@ Returns the path to the binary on success, nil on failure."
                          (expand-file-name "Cargo.toml" tramp-rpc-deploy-source-directory))))
       (if (zerop exit-code)
           (progn
+            ;; Record the source id this artifact was built from before any
+            ;; reuse decision can consult it.
+            (tramp-rpc-deploy--record-source-build-id build-output)
             ;; Promote only a complete binary with its recorded digest.
             (tramp-rpc-deploy--promote-cached-binary
              build-output cache-path "source-build")

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -557,14 +557,20 @@ EVENT is the process event string."
       (when-let* ((stderr-process (plist-get info :stderr-process)))
         (when (process-live-p stderr-process)
           (tramp-rpc--best-effort (delete-process stderr-process))))
-      (let ((remote-exit (process-get proc :tramp-rpc-exit-code)))
+      (let ((remote-exit (process-get proc :tramp-rpc-exit-code))
+            (remote-signal (process-get proc :tramp-rpc-exit-signal)))
         (tramp-rpc--call-user-sentinel-once
          proc user-sentinel
-         (if remote-exit
-             (if (= remote-exit 0)
-                 "finished\n"
-               (format "exited abnormally with code %d\n" remote-exit))
-           event)))
+         (cond
+          ((integerp remote-signal)
+           (format "%s\n"
+                   (downcase (tramp-rpc-protocol-signal-description
+                              remote-signal))))
+          (remote-exit
+           (if (= remote-exit 0)
+               "finished\n"
+             (format "exited abnormally with code %d\n" remote-exit)))
+          (t event))))
       (remhash proc tramp-rpc--async-processes))))
 
 (defun tramp-rpc--handle-async-read-response (local-process response)
@@ -589,7 +595,8 @@ RESPONSE is the decoded RPC response plist."
                  (stderr (when-let* ((s (alist-get 'stderr result)))
                            (tramp-rpc--binary-bytes s)))
                  (exited (alist-get 'exited result))
-                 (exit-code (alist-get 'exit_code result)))
+                 (exit-code (alist-get 'exit_code result))
+                 (exit-signal (alist-get 'signal result)))
 
             (tramp-rpc--debug "ASYNC-READ response: stdout=%s stderr=%s exited=%s"
                              (if stdout (length stdout) "nil")
@@ -620,7 +627,8 @@ RESPONSE is the decoded RPC response plist."
                 ;; Deferring this via `run-at-time 0' leaves a small window where
                 ;; loops that poll `process-live-p' can observe a stale live
                 ;; process and run one extra iteration.
-                (tramp-rpc--handle-process-exit local-process exit-code)
+                (tramp-rpc--handle-process-exit local-process exit-code
+                                               exit-signal)
               ;; Chain another read - use run-at-time to avoid stack overflow
               (tramp-rpc--schedule-process-timer
                tramp-rpc--async-processes local-process :poll-timer
@@ -632,9 +640,10 @@ RESPONSE is the decoded RPC response plist."
           tramp-rpc--async-processes local-process :poll-timer
           #'tramp-rpc--handle-process-exit local-process -1))))))
 
-(defun tramp-rpc--handle-process-exit (local-process exit-code)
+(defun tramp-rpc--handle-process-exit (local-process exit-code &optional exit-signal)
   "Handle exit of remote process associated with LOCAL-PROCESS.
-Stores the remote exit code and sends EOF to the local cat relay so
+Stores the remote exit code and, when EXIT-SIGNAL is a signal number,
+the signal that terminated it.  Sends EOF to the local cat relay so
 it flushes remaining output and exits naturally.  The process sentinel
 \(`tramp-rpc--pipe-process-sentinel') fires when cat exits, handles
 cleanup, and calls the user's sentinel with the correct event string.
@@ -675,7 +684,13 @@ EXIT-CODE is the process exit status."
       (when (process-live-p local-process)
         (let ((tramp-rpc--closing-local-relay t))
           (tramp-rpc--best-effort (process-send-eof local-process))))
-      ;; Now mark as exited so process-status handler returns 'exit.
+      ;; Mark the process terminal only after the relay EOF.  Both
+      ;; `:tramp-rpc-exit-signal' and `:tramp-rpc-exited' make the advised
+      ;; `process-status' non-live, which would skip the EOF above and leave
+      ;; the relay (and its sentinel) alive forever.
+      (process-put local-process :tramp-rpc-exit-signal
+                   (and (integerp exit-signal) (>= exit-signal 0)
+                        exit-signal))
       (process-put local-process :tramp-rpc-exited t))))
 
 ;; ============================================================================
@@ -1330,7 +1345,8 @@ RESPONSE is the decoded RPC response plist."
                    (output (when-let* ((o (alist-get 'output result)))
                              (tramp-rpc--binary-bytes o)))
                    (exited (alist-get 'exited result))
-                   (exit-code (alist-get 'exit_code result)))
+                   (exit-code (alist-get 'exit_code result))
+                   (exit-signal (alist-get 'signal result)))
 
               ;; Feed raw bytes to the relay.  Its read-side decoder is
             ;; incremental, so a character split across RPC responses is kept
@@ -1341,7 +1357,8 @@ RESPONSE is the decoded RPC response plist."
 
             ;; Handle process exit or chain next read
             (if exited
-                (tramp-rpc--handle-pty-exit local-process exit-code)
+                (tramp-rpc--handle-pty-exit local-process exit-code
+                                            exit-signal)
               ;; Chain via a tracked timer so cleanup can cancel it.
               (tramp-rpc--schedule-process-timer
                tramp-rpc--pty-processes local-process :poll-timer
@@ -1351,9 +1368,10 @@ RESPONSE is the decoded RPC response plist."
        (tramp-rpc--debug "PTY read response error: %S" err)
        (tramp-rpc--handle-pty-exit local-process -1)))))
 
-(defun tramp-rpc--handle-pty-exit (local-process exit-code)
+(defun tramp-rpc--handle-pty-exit (local-process exit-code &optional exit-signal)
   "Handle exit of PTY process associated with LOCAL-PROCESS.
-EXIT-CODE is the process exit status."
+EXIT-CODE is the process exit status.  EXIT-SIGNAL, when non-nil, is the
+signal number that terminated the remote process."
   (when (gethash local-process tramp-rpc--pty-processes)
     (tramp-rpc--cancel-process-timers tramp-rpc--pty-processes local-process)
     ;; Close the remote PTY while the transport is still available.  Keep the
@@ -1367,14 +1385,20 @@ EXIT-CODE is the process exit status."
     ;; particular, do not translate a killed remote PTY into local success.
     (process-put local-process :tramp-rpc-exit-code
                  (if (integerp exit-code) exit-code -1))
-    (process-put local-process :tramp-rpc-exited t)
     ;; Close the relay's local stdin and let cat flush the final PTY bytes
     ;; before exiting naturally.  A zero-timeout `accept-process-output' after
     ;; `process-send-string' does not wait for the relay round trip, while
     ;; deleting it here discards the final output returned with EXITED.
     (when (process-live-p local-process)
       (let ((tramp-rpc--closing-local-relay t))
-        (tramp-rpc--best-effort (process-send-eof local-process))))))
+        (tramp-rpc--best-effort (process-send-eof local-process))))
+    ;; Mark the process terminal only after the relay EOF, for the same reason
+    ;; as the pipe path: either flag makes the advised `process-status'
+    ;; non-live and would skip the EOF, leaving the relay alive.
+    (process-put local-process :tramp-rpc-exit-signal
+                 (and (integerp exit-signal) (>= exit-signal 0)
+                      exit-signal))
+    (process-put local-process :tramp-rpc-exited t)))
 
 (defun tramp-rpc--pty-sentinel (process event)
   "Sentinel for PTY relay PROCESS, preserving its user sentinel once.
@@ -1393,14 +1417,20 @@ EVENT is the process event string."
             (tramp-rpc--call vec "process.kill_pty"
                              `((pid . ,pid) (signal . 9))
                              (process-get process :tramp-rpc-connection)))))
-      (let ((exit-code (process-get process :tramp-rpc-exit-code)))
+      (let ((exit-code (process-get process :tramp-rpc-exit-code))
+            (exit-signal (process-get process :tramp-rpc-exit-signal)))
         (tramp-rpc--call-user-sentinel-once
          process (process-get process :tramp-rpc-user-sentinel)
-         (if exit-code
-             (if (= exit-code 0)
-                 "finished\n"
-               (format "exited abnormally with code %d\n" exit-code))
-           event)))
+         (cond
+          ((integerp exit-signal)
+           (format "%s\n"
+                   (downcase (tramp-rpc-protocol-signal-description
+                              exit-signal))))
+          (exit-code
+           (if (= exit-code 0)
+               "finished\n"
+             (format "exited abnormally with code %d\n" exit-code)))
+          (t event))))
       ;; Run after the wrapped/user sentinel has observed the exit.
       (remhash process tramp-rpc--pty-processes))))
 

--- a/lisp/tramp-rpc-process.el
+++ b/lisp/tramp-rpc-process.el
@@ -41,6 +41,8 @@
 
 ;; Emitted inside the autoload form in tramp-rpc.el.
 (declare-function tramp-rpc-file-name-p "tramp-rpc")
+(declare-function tramp-rpc-protocol-signal-description "tramp-rpc-protocol"
+                  (signal))
 
 ;; ============================================================================
 ;; Process tracking state

--- a/lisp/tramp-rpc-protocol.el
+++ b/lisp/tramp-rpc-protocol.el
@@ -115,6 +115,41 @@ Each value is a cons cell containing the target connection and request.")
   "Return non-nil when METHOD is a long-polling process read method."
   (member method '("process.read" "process.read_pty")))
 
+(defconst tramp-rpc-protocol--signal-descriptions
+  '((1 . "Hangup")
+    (2 . "Interrupt")
+    (3 . "Quit")
+    (4 . "Illegal instruction")
+    (5 . "Trace/breakpoint trap")
+    (6 . "Aborted")
+    (7 . "Bus error")
+    (8 . "Floating point exception")
+    (9 . "Killed")
+    (10 . "User defined signal 1")
+    (11 . "Segmentation fault")
+    (12 . "User defined signal 2")
+    (13 . "Broken pipe")
+    (14 . "Alarm clock")
+    (15 . "Terminated")
+    (24 . "CPU time limit exceeded")
+    (25 . "File size limit exceeded")
+    (26 . "Virtual timer expired")
+    (27 . "Profiling timer expired")
+    (28 . "Window changed")
+    (29 . "I/O possible")
+    (30 . "Power failure")
+    (31 . "Bad system call"))
+  "Signal descriptions matching local Emacs strings for the common signals.")
+
+(defun tramp-rpc-protocol-signal-description (signal)
+  "Return the human-readable description of SIGNAL number.
+Used where no connection is available for the remote `kill -l' mapping,
+such as a process sentinel."
+  (if (integerp signal)
+      (or (alist-get signal tramp-rpc-protocol--signal-descriptions)
+          (format "Signal %d" signal))
+    "Unknown signal"))
+
 (defun tramp-rpc-protocol--empty-poll-response-p (method response)
   "Return non-nil when RESPONSE is an uneventful poll for METHOD."
   (let ((result (plist-get response :result)))

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -1796,6 +1796,12 @@ Returns nil if the process is locked to a different thread."
     (or (null locked-thread)
         (eq locked-thread (current-thread)))))
 
+(defconst tramp-rpc-stderr-buffer-limit 65536
+  "Maximum bytes retained in a connection's SSH stderr buffer.
+Only the tail is used for diagnostics, so the buffer is truncated to this
+many bytes after draining to bound growth over a long-lived connection
+with `-v' or a chatty ProxyJump.")
+
 (defun tramp-rpc--drain-connection-stderr (conn)
   "Drain pending stderr output for CONN's SSH process.
 `make-process' with `:stderr' creates a separate stderr process.  The RPC
@@ -1806,7 +1812,14 @@ and blocking SSH or the remote server."
               ((buffer-live-p stderr-buffer))
               (stderr-process (get-buffer-process stderr-buffer))
               ((tramp-rpc--process-accessible-p stderr-process)))
-    (while (accept-process-output stderr-process 0 nil t))))
+    (while (accept-process-output stderr-process 0 nil t))
+    ;; Keep the diagnostic tail only; an unbounded stderr buffer grows for the
+    ;; whole lifetime of the connection.  Deleting before the process mark
+    ;; leaves the mark at the end, so later appends stay in order.
+    (with-current-buffer stderr-buffer
+      (when (> (buffer-size) tramp-rpc-stderr-buffer-limit)
+        (delete-region (point-min)
+                       (- (point-max) tramp-rpc-stderr-buffer-limit))))))
 
 (defun tramp-rpc--connection-stderr-tail (conn &optional max-bytes)
   "Return a diagnostic tail from CONN's stderr buffer, or nil.

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -746,9 +746,15 @@ instead of invoking the callbacks.  EVENT is the process event string."
         callbacks)
     ;; Kill acknowledgements must still be accepted by the live transport.
     ;; Mark it dead only after these captured-generation calls complete.
+    ;; Teardown is best effort: the hooks issue synchronous RPCs, so a hook
+    ;; error or user quit here must not leave the generation half-cleaned and
+    ;; permanently unclaimable (`cleanup-started' was already set).
     (when (and remote-cleanup (process-live-p process))
-      (run-hook-with-args 'tramp-rpc-transport-terminate-functions
-                          vec process conn))
+      (condition-case hook-error
+          (run-hook-with-args 'tramp-rpc-transport-terminate-functions
+                              vec process conn)
+        ((error quit)
+         (tramp-rpc--debug "transport terminate hook failed: %S" hook-error))))
     (setf (tramp-rpc-connection-transport-cleaned conn) t
           (tramp-rpc-connection-transport-dead conn) t)
     ;; Wake synchronous callers after remote cleanup.  The injected errors
@@ -761,13 +767,18 @@ instead of invoking the callbacks.  EVENT is the process event string."
     (clrhash callback-table)
     ;; Cleanup functions keep local relays tracked through delete-process so
     ;; their wrapped sentinels can preserve the user's sentinel.  Remote
-    ;; termination was completed above using the captured connection.
-    (run-hook-with-args 'tramp-rpc-transport-cleanup-functions vec process)
+    ;; termination was completed above using the captured connection.  The
+    ;; dead/cleaned flags and the transport deletion below must still run when
+    ;; one hook fails, otherwise local relays leak for the session.
+    (condition-case hook-error
+        (run-hook-with-args 'tramp-rpc-transport-cleanup-functions vec process)
+      ((error quit)
+       (tramp-rpc--debug "transport cleanup hook failed: %S" hook-error)))
     (unless defer-callbacks
       (dolist (callback callbacks)
         (condition-case callback-error
             (funcall callback error-response)
-          (error
+          ((error quit)
            (tramp-rpc--debug "transport cleanup callback failed: %S"
                              callback-error)))))
     ;; Explicit disconnect owns transport deletion; unexpected death is

--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -1705,12 +1705,33 @@ Uses length-prefixed binary framing: <4-byte BE length><msgpack payload>."
                         ;; Store only responses for this generation's live
                         ;; waiters.  Late responses from an abandoned
                         ;; generation are discarded.
-                        (when (memql id (tramp-rpc-connection-pending-ids conn))
+                        (cond
+                         ((memql id (tramp-rpc-connection-pending-ids conn))
                           (tramp-rpc--debug
                            "FILTER storing sync response id=%s" id)
                           (puthash id response
                                    (tramp-rpc-connection-pending-responses
-                                    conn)))))))))))))
+                                    conn)))
+                         ;; The server answers oversized frames and parse
+                         ;; errors with an id-less error response.  Deliver it
+                         ;; to the oldest waiter instead of discarding it:
+                         ;; otherwise that waiter burns the full call timeout
+                         ;; and tears the connection down with no diagnosis.
+                         ((and (null id) (plist-get response :error))
+                          (when-let* ((oldest
+                                       (car (last
+                                             (tramp-rpc-connection-pending-ids
+                                              conn)))))
+                            (tramp-rpc--debug
+                             "FILTER delivering id-less error to id=%s: %S"
+                             oldest (plist-get response :error))
+                            (puthash oldest response
+                                     (tramp-rpc-connection-pending-responses
+                                      conn))))
+                         ((plist-get response :error)
+                          (tramp-rpc--debug
+                           "FILTER dropping unmatched error response: %S"
+                           response)))))))))))))
 
 (defun tramp-rpc--call-async (vec method params callback &optional connection)
   "Call METHOD with PARAMS asynchronously on the RPC server for VEC.

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -2165,21 +2165,32 @@ signal numbers to human-readable strings like \"Interrupt\" or
       ;; Sanity: remove duplicate leading "0" entry if kill -l included one
       (when (and (stringp (cadr signals)) (string-equal (cadr signals) "0"))
         (setcdr signals (cddr signals)))
-      ;; Map signal names to human-readable strings
+      ;; Map signal names to human-readable strings matching local Emacs.
       (dotimes (i 128)
         (let ((sig (nth i signals)))
           (aset vec-strings i
                 (cond
                  ((zerop i) 0)
-                 ((null sig) (format "Signal %d" i))
+                 ((null sig) (tramp-rpc-protocol-signal-description i))
                  ((string-equal sig "HUP") "Hangup")
                  ((string-equal sig "INT") "Interrupt")
                  ((string-equal sig "QUIT") "Quit")
+                 ((string-equal sig "ILL") "Illegal instruction")
+                 ((string-equal sig "TRAP") "Trace/breakpoint trap")
+                 ((string-equal sig "ABRT") "Aborted")
+                 ((string-equal sig "IOT") "Aborted")
+                 ((string-equal sig "BUS") "Bus error")
+                 ((string-equal sig "FPE") "Floating point exception")
+                 ((string-equal sig "KILL") "Killed")
+                 ((string-equal sig "SEGV") "Segmentation fault")
+                 ((string-equal sig "PIPE") "Broken pipe")
+                 ((string-equal sig "ALRM") "Alarm clock")
+                 ((string-equal sig "TERM") "Terminated")
                  ((string-equal sig "STOP") "Stopped (signal)")
                  ((string-equal sig "TSTP") "Stopped")
                  ((string-equal sig "TTIN") "Stopped (tty input)")
                  ((string-equal sig "TTOU") "Stopped (tty output)")
-                 (t (format "Signal %d" i))))))
+                 (t (tramp-rpc-protocol-signal-description i))))))
       vec-strings)))
 
 (defun tramp-rpc-handle-process-file
@@ -2250,6 +2261,7 @@ ARGS contains the original function arguments."
                     127
                   (if result
                       (let ((exit-code (alist-get 'exit_code result))
+                            (exit-signal (alist-get 'signal result))
                             (stdout (tramp-rpc--decode-output
                                      (alist-get 'stdout result)))
                             (stderr (tramp-rpc--decode-output
@@ -2282,14 +2294,21 @@ ARGS contains the original function arguments."
                         (tramp-rpc--route-process-file-output
                          destination stdout stderr)
 
-                        ;; Handle signal strings when requested by Emacs.
-                        (if (and
-                             (bound-and-true-p
-                              process-file-return-signal-string)
-                             (natnump exit-code) (>= exit-code 128))
-                            (let ((strings (tramp-rpc--get-signal-strings v)))
-                              (aref strings (- exit-code 128)))
-                          exit-code))
+                        ;; `process-file' returns the raw exit code unless the
+                        ;; caller opts into signal descriptions via
+                        ;; `process-file-return-signal-string'.  This matches
+                        ;; tramp-sh and upstream `tramp-test28-process-file',
+                        ;; which requires the integer 128 + signal by default.
+                        (cond
+                         ((not (bound-and-true-p
+                                process-file-return-signal-string))
+                          exit-code)
+                         ((and (integerp exit-signal) (>= exit-signal 0))
+                          (aref (tramp-rpc--get-signal-strings v) exit-signal))
+                         ((and (natnump exit-code) (> exit-code 128))
+                          (aref (tramp-rpc--get-signal-strings v)
+                                (- exit-code 128)))
+                         (t exit-code)))
                     ;; A successful RPC result is always non-nil.
                     (signal 'remote-file-error
                             (list "Empty process.run response")))))

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -251,6 +251,8 @@ This is called from `tramp-multi-hop-p-hook'."
 ;; autoload-owned functions used by the full implementation below.
 (declare-function tramp-rpc--sudo-file-name-p "tramp-rpc")
 (declare-function tramp-rpc-multi-hop-p "tramp-rpc")
+(declare-function tramp-rpc-protocol-signal-description "tramp-rpc-protocol"
+                  (signal))
 
 
 ;; Helper modules register internal lifecycle callbacks when loaded.

--- a/server/src/handlers/commands.rs
+++ b/server/src/handlers/commands.rs
@@ -317,10 +317,12 @@ fn as_search_dir(path: &Path) -> Option<PathBuf> {
 
 const MAX_DOMINATING_DEPTH: usize = 100;
 
-fn find_dominating_dir(
-    start_dir: &Path,
-    names: &[String],
-) -> Result<Option<(PathBuf, Vec<String>)>, RpcError> {
+/// Walk upward from START_DIR looking for any of NAMES.
+///
+/// The depth bound protects against pathological paths, but hitting it means
+/// "not found": a deep path must degrade like a missing marker rather than
+/// make `locate-dominating-file' and dir-locals signal a remote error.
+fn find_dominating_dir(start_dir: &Path, names: &[String]) -> Option<(PathBuf, Vec<String>)> {
     let mut current = start_dir.to_path_buf();
     let mut depth = 0usize;
     loop {
@@ -331,20 +333,15 @@ fn find_dominating_dir(
             .collect();
 
         if !found.is_empty() {
-            return Ok(Some((current, found)));
+            return Some((current, found));
         }
 
         match current.parent() {
-            Some(parent) if parent != current => {
-                if depth >= MAX_DOMINATING_DEPTH {
-                    return Err(RpcError::invalid_params(format!(
-                        "Maximum ancestor traversal depth ({MAX_DOMINATING_DEPTH}) exceeded"
-                    )));
-                }
+            Some(parent) if parent != current && depth < MAX_DOMINATING_DEPTH => {
                 current = parent.to_path_buf();
                 depth += 1;
             }
-            _ => return Ok(None),
+            _ => return None,
         }
     }
 }
@@ -421,7 +418,7 @@ pub async fn highlevel_locate_dominating_file_multi(params: Value) -> HandlerRes
             return Ok(Value::Array(vec![]));
         };
 
-        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names)? else {
+        let Some((dir, found_names)) = find_dominating_dir(&start_dir, &params.names) else {
             return Ok(Value::Array(vec![]));
         };
 
@@ -469,7 +466,7 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
         };
 
         let locals_value =
-            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names)? {
+            if let Some((locals_dir, _)) = find_dominating_dir(&start_dir, &params.names) {
                 let locals_dir = remap_to_lexical_ancestor(&start_dir, &locals_dir);
                 let local_files: Vec<Value> = params
                     .names
@@ -549,6 +546,21 @@ pub async fn highlevel_dir_locals_find_file_cache_update(params: Value) -> Handl
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dominating_search_depth_limit_is_not_found() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let mut deep = tmp.path().to_path_buf();
+        for index in 0..MAX_DOMINATING_DEPTH + 10 {
+            deep.push(format!("d{index:03}"));
+        }
+        std::fs::create_dir_all(&deep).expect("create deep tree");
+
+        // The marker sits above the bound, so the walk must report not-found
+        // instead of making dir-locals signal a remote error.
+        std::fs::write(tmp.path().join(".git"), b"").expect("write marker");
+        assert!(find_dominating_dir(&deep, &[".git".to_string()]).is_none());
+    }
 
     #[test]
     fn ancestor_paths_use_text_when_compatible_and_binary_when_required() {

--- a/server/src/handlers/dir.rs
+++ b/server/src/handlers/dir.rs
@@ -21,6 +21,20 @@ use super::file::{bytes_to_path, file_type_from_metadata_ft, map_io_error};
 
 use crate::protocol::path_or_bytes;
 
+/// Upper bound on one `dir.list` payload.  The response is checked against the
+/// frame limit only after it is fully serialized, so an unbounded entry list
+/// could allocate far more than the transport can send.  Failing at a
+/// deterministic byte budget keeps the peak bounded and reports a clear error
+/// instead of an opaque oversized-frame rejection.
+const MAX_DIR_LISTING_BYTES: usize = 64 * 1024 * 1024;
+/// Per-entry accounting overhead.  Attribute maps dominate the payload; names
+/// and link targets are added separately.
+const DIR_ENTRY_BUDGET_BYTES: usize = 256;
+/// Overhead for a completion listing, whose entries carry only a name and a
+/// type.  Using the attribute estimate here would reject large flat
+/// directories whose real payload is far smaller than the budget.
+const DIR_ENTRY_BUDGET_BYTES_NO_ATTRS: usize = 32;
+
 /// Extract time and mode fields from `stat` in a cross-platform way
 /// Returns (atime, mtime, ctime, mode)
 /// - On Linux: st_mode is u32; time fields are i32 on 32-bit, i64 on 64-bit
@@ -165,22 +179,27 @@ pub async fn list(params: Value) -> HandlerResult {
     let include_hidden = params.include_hidden;
 
     // Do all I/O in a single blocking task for efficiency
-    let results =
-        tokio::task::spawn_blocking(move || list_dir_sync(&path, include_attrs, include_hidden))
-            .await
-            .map_err(|e| RpcError::internal_error(format!("Task join error: {e}")))?
-            .map_err(|e| map_io_error(e, &path_str))?;
+    let results = tokio::task::spawn_blocking(move || {
+        list_dir_sync(&path, include_attrs, include_hidden, MAX_DIR_LISTING_BYTES)
+    })
+    .await
+    .map_err(|e| RpcError::internal_error(format!("Task join error: {e}")))?
+    .map_err(|e| map_io_error(e, &path_str))?;
 
     // Convert to array of map values with named fields
     let values: Vec<Value> = results.iter().map(|e| e.to_value()).collect();
     Ok(Value::Array(values))
 }
 
-/// Synchronous directory listing with d_type and fstatat optimizations
+/// Synchronous directory listing with d_type and fstatat optimizations.
+///
+/// BUDGET_BYTES bounds the accounted payload so a directory with millions of
+/// entries cannot allocate unbounded memory before the frame-size check.
 fn list_dir_sync(
     path: &Path,
     include_attrs: bool,
     include_hidden: bool,
+    budget_bytes: usize,
 ) -> Result<Vec<DirEntry>, std::io::Error> {
     // Open directory fd for fstatat.  The `OwnedFd` closes it on all exit paths.
     let dir_handle: Option<OwnedFd> = if include_attrs {
@@ -195,6 +214,7 @@ fn list_dir_sync(
     let dir_fd = dir_handle.as_ref().map(AsFd::as_fd);
 
     let mut results: Vec<DirEntry> = Vec::new();
+    let mut budget_used: usize = 0;
 
     // Add . and .. entries
     if include_hidden {
@@ -249,6 +269,24 @@ fn list_dir_sync(
         } else {
             None
         };
+
+        let per_entry_bytes = if include_attrs {
+            DIR_ENTRY_BUDGET_BYTES
+        } else {
+            DIR_ENTRY_BUDGET_BYTES_NO_ATTRS
+        };
+        budget_used += per_entry_bytes
+            + name_bytes.len()
+            + attrs
+                .as_ref()
+                .and_then(|attrs| attrs.link_target.as_ref())
+                .map_or(0, Vec::len);
+        if budget_used > budget_bytes {
+            return Err(std::io::Error::other(format!(
+                "Directory listing for {} exceeds {budget_bytes} bytes",
+                path.display()
+            )));
+        }
 
         results.push(DirEntry {
             name: name_bytes,
@@ -391,4 +429,28 @@ pub async fn remove(params: Value) -> HandlerResult {
     result.map_err(|e| map_io_error(e, &path_str))?;
 
     Ok(Value::Boolean(true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listing_over_budget_is_rejected_instead_of_allocated() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        for index in 0..8 {
+            std::fs::write(tmp.path().join(format!("entry-{index}")), b"x").unwrap();
+        }
+
+        let error = list_dir_sync(tmp.path(), false, true, 64)
+            .expect_err("a tiny budget must stop the listing");
+        assert!(
+            error.to_string().contains("exceeds 64 bytes"),
+            "unexpected error: {error}"
+        );
+
+        let listed = list_dir_sync(tmp.path(), false, true, 64 * 1024)
+            .expect("a normal budget lists the directory");
+        assert!(listed.len() >= 8);
+    }
 }

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -285,18 +285,12 @@ pub async fn copy(params: Value) -> HandlerResult {
             .await
             .map_err(|e| map_io_error(e, &src_str))?
     } else {
-        // Copy regular file (or symlink target)
-        prepare_regular_destination(&dest_path, options.overwrite)
+        // Copy regular file (or symlink target) atomically: a plain
+        // `fs::copy' would open the destination with create+truncate and could
+        // clobber a file created after the overwrite check.
+        copy_file_atomically(&src_path, &dest_path, options)
             .await
-            .map_err(|e| map_io_error(e, &src_str))?;
-        let n = fs::copy(&src_path, &dest_path)
-            .await
-            .map_err(|e| map_io_error(e, &src_str))?;
-
-        apply_copied_metadata(&src_metadata, &dest_path, options)
-            .await
-            .map_err(|e| map_io_error(e, &src_str))?;
-        n
+            .map_err(|e| map_io_error(e, &src_str))?
     };
 
     Ok(msgpack_map! {
@@ -347,12 +341,7 @@ async fn copy_dir_recursive(
             prepare_symlink_destination(&dest_child, options.overwrite).await?;
             tokio::fs::symlink(&link_target, &dest_child).await?;
         } else {
-            prepare_regular_destination(&dest_child, options.overwrite).await?;
-            let n = fs::copy(&entry_path, &dest_child).await?;
-            total += n;
-
-            let meta = fs::metadata(&entry_path).await?;
-            apply_copied_metadata(&meta, &dest_child, options).await?;
+            total += copy_file_atomically(&entry_path, &dest_child, options).await?;
         }
     }
 
@@ -421,16 +410,64 @@ async fn canonicalize_existing_ancestor(path: &Path) -> std::io::Result<PathBuf>
     }
 }
 
-async fn prepare_regular_destination(path: &Path, overwrite: bool) -> std::io::Result<()> {
-    if overwrite {
-        return Ok(());
+/// Copy SRC to DEST through a temporary file in DEST's directory.
+///
+/// `fs::copy' opens the destination with create+truncate, so checking the
+/// destination first and then copying is a TOCTOU: a file created in between
+/// is silently clobbered even when the caller asked not to overwrite.  Copy
+/// to a sibling temp file, apply metadata there, then rename it into place
+/// (atomically replacing or atomically refusing, depending on OVERWRITE).
+///
+/// Overwriting deliberately keeps `fs::copy' semantics: it follows a
+/// destination symlink and truncates the link target, matching Emacs
+/// `copy-file' and the previous server behavior.  There is no refusal
+/// decision to race in that case.  Only the no-overwrite path needs the
+/// staged rename, because a destination created after the caller's check
+/// must not be truncated.
+async fn copy_file_atomically(
+    src: &Path,
+    dest: &Path,
+    options: CopyOptions,
+) -> std::io::Result<u64> {
+    if options.overwrite {
+        let copied = fs::copy(src, dest).await?;
+        let metadata = fs::metadata(src).await?;
+        apply_copied_metadata(&metadata, dest, options).await?;
+        return Ok(copied);
     }
 
-    match fs::symlink_metadata(path).await {
-        Ok(_) => Err(already_exists(path)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
+    let parent = dest
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let temp = temporary_copy_path(parent, dest);
+    let result = async {
+        let copied = fs::copy(src, &temp).await?;
+        let metadata = fs::metadata(src).await?;
+        apply_copied_metadata(&metadata, &temp, options).await?;
+        rename_no_overwrite(&temp, dest).await?;
+        Ok(copied)
     }
+    .await;
+    if result.is_err() {
+        let _ = fs::remove_file(&temp).await;
+    }
+    result
+}
+
+fn temporary_copy_path(parent: &Path, dest: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let name = dest
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "copy".to_string());
+    parent.join(format!(
+        ".{name}.tramp-rpc-copy-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ))
 }
 
 async fn prepare_symlink_destination(path: &Path, overwrite: bool) -> std::io::Result<()> {
@@ -1220,6 +1257,75 @@ mod tests {
 
         assert!(err.message.contains("exists"));
         assert_eq!(fs::read(&dest).await.unwrap(), b"old");
+    }
+
+    #[tokio::test]
+    async fn copy_overwrite_follows_destination_symlink() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src.txt");
+        let target = tmp.path().join("target.txt");
+        let dest = tmp.path().join("dest-link");
+        fs::write(&src, b"new").await.unwrap();
+        fs::write(&target, b"old").await.unwrap();
+        tokio::fs::symlink(&target, &dest).await.unwrap();
+
+        // Emacs `copy-file' with overwrite follows an existing destination
+        // symlink and writes through it; the atomic no-overwrite path must not
+        // change that, so overwriting keeps `fs::copy' semantics.
+        copy(msgpack_map! {
+            "src" => path_value(&src),
+            "dest" => path_value(&dest),
+            "overwrite" => true,
+        })
+        .await
+        .expect("overwrite copy should succeed");
+
+        assert!(
+            fs::symlink_metadata(&dest)
+                .await
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the destination symlink must be preserved"
+        );
+        assert_eq!(fs::read(&target).await.unwrap(), b"new");
+    }
+
+    #[tokio::test]
+    async fn atomic_copy_never_truncates_a_rejected_destination() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src.txt");
+        let dest = tmp.path().join("dest.txt");
+        fs::write(&src, b"new").await.unwrap();
+        fs::write(&dest, b"old").await.unwrap();
+
+        let options = CopyOptions {
+            preserve_permissions: false,
+            preserve_times: false,
+            overwrite: false,
+            merge_existing_directories: false,
+        };
+        let error = copy_file_atomically(&src, &dest, options)
+            .await
+            .expect_err("an existing destination must be refused");
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        // The refusal must not have truncated the destination first.
+        assert_eq!(fs::read(&dest).await.unwrap(), b"old");
+
+        let options = CopyOptions {
+            overwrite: true,
+            ..options
+        };
+        assert_eq!(copy_file_atomically(&src, &dest, options).await.unwrap(), 3);
+        assert_eq!(fs::read(&dest).await.unwrap(), b"new");
+
+        let leftovers: Vec<String> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains("tramp-rpc-copy"))
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
     }
 
     #[tokio::test]

--- a/server/src/handlers/io.rs
+++ b/server/src/handlers/io.rs
@@ -418,12 +418,11 @@ async fn canonicalize_existing_ancestor(path: &Path) -> std::io::Result<PathBuf>
 /// to a sibling temp file, apply metadata there, then rename it into place
 /// (atomically replacing or atomically refusing, depending on OVERWRITE).
 ///
-/// Overwriting deliberately keeps `fs::copy' semantics: it follows a
-/// destination symlink and truncates the link target, matching Emacs
-/// `copy-file' and the previous server behavior.  There is no refusal
-/// decision to race in that case.  Only the no-overwrite path needs the
-/// staged rename, because a destination created after the caller's check
-/// must not be truncated.
+/// Overwriting keeps `fs::copy' semantics: it follows a destination symlink
+/// and truncates the link target, matching Emacs `copy-file' and the previous
+/// behavior.  The no-overwrite path creates the destination exclusively, so a
+/// concurrent create cannot be clobbered and no staging name is ever visible
+/// to directory watchers.
 async fn copy_file_atomically(
     src: &Path,
     dest: &Path,
@@ -436,38 +435,45 @@ async fn copy_file_atomically(
         return Ok(copied);
     }
 
-    let parent = dest
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let temp = temporary_copy_path(parent, dest);
-    let result = async {
-        let copied = fs::copy(src, &temp).await?;
-        let metadata = fs::metadata(src).await?;
-        apply_copied_metadata(&metadata, &temp, options).await?;
-        rename_no_overwrite(&temp, dest).await?;
-        Ok(copied)
-    }
-    .await;
-    if result.is_err() {
-        let _ = fs::remove_file(&temp).await;
-    }
-    result
-}
-
-fn temporary_copy_path(parent: &Path, dest: &Path) -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let name = dest
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "copy".to_string());
-    parent.join(format!(
-        ".{name}.tramp-rpc-copy-{}-{}",
-        std::process::id(),
-        COUNTER.fetch_add(1, Ordering::Relaxed)
-    ))
+    // `O_CREAT|O_EXCL' refuses an existing destination atomically, so a file
+    // created after the caller's check cannot be truncated.  Open the source
+    // first so a missing source does not leave an empty destination behind,
+    // then write and apply metadata through the returned handle, so replacing
+    // DEST with a symlink cannot redirect the chmod/utimes.
+    let metadata = fs::metadata(src).await?;
+    let mut source = fs::File::open(src).await?;
+    let dest_for_open = dest.to_path_buf();
+    let file = tokio::task::spawn_blocking(move || {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&dest_for_open)
+    })
+    .await
+    .map_err(std::io::Error::other)?
+    .map_err(|error| {
+        if error.kind() == std::io::ErrorKind::AlreadyExists {
+            already_exists(dest)
+        } else {
+            error
+        }
+    })?;
+    let mut target = fs::File::from_std(file);
+    let copied = match tokio::io::copy(&mut source, &mut target).await {
+        Ok(copied) => copied,
+        Err(error) => {
+            drop(target);
+            let _ = fs::remove_file(dest).await;
+            return Err(error);
+        }
+    };
+    target.flush().await?;
+    let std_target = target.into_std().await;
+    apply_copied_metadata_fd(&metadata, &std_target, options).await?;
+    drop(std_target);
+    Ok(copied)
 }
 
 async fn prepare_symlink_destination(path: &Path, overwrite: bool) -> std::io::Result<()> {
@@ -523,6 +529,51 @@ async fn apply_copied_metadata(
     Ok(())
 }
 
+/// Apply copied permissions and times through an open handle.
+///
+/// Resolving DEST again for `set_permissions'/`utimensat' would let a caller
+/// that can write the destination directory swap in a symlink and have the
+/// source-controlled metadata applied to its target.  `fchmod'/`futimens' on
+/// the handle created by the copy cannot be redirected.
+async fn apply_copied_metadata_fd(
+    src_meta: &std::fs::Metadata,
+    file: &std::fs::File,
+    options: CopyOptions,
+) -> std::io::Result<()> {
+    let file = file.try_clone()?;
+    // `fs::copy' always copies the permission bits; mirror that.
+    let permissions = src_meta.permissions();
+    let (atime, atime_nsec, mtime, mtime_nsec) = {
+        use std::os::unix::fs::MetadataExt;
+        (
+            src_meta.atime(),
+            src_meta.atime_nsec(),
+            src_meta.mtime(),
+            src_meta.mtime_nsec(),
+        )
+    };
+    tokio::task::spawn_blocking(move || {
+        file.set_permissions(permissions)?;
+        if options.preserve_times {
+            use rustix::fs::{Timespec, Timestamps};
+            let times = Timestamps {
+                last_access: Timespec {
+                    tv_sec: atime,
+                    tv_nsec: atime_nsec,
+                },
+                last_modification: Timespec {
+                    tv_sec: mtime,
+                    tv_nsec: mtime_nsec,
+                },
+            };
+            rustix::fs::futimens(&file, &times).map_err(std::io::Error::from)?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
 async fn remove_path_for_overwrite(path: &Path) -> std::io::Result<()> {
     let meta = fs::symlink_metadata(path).await?;
     if meta.is_dir() && !meta.file_type().is_symlink() {
@@ -532,17 +583,32 @@ async fn remove_path_for_overwrite(path: &Path) -> std::io::Result<()> {
     }
 }
 
-/// Portable check-then-rename for kernels and filesystems without
-/// `RENAME_NOREPLACE`.  `symlink_metadata` does not follow symlinks, so a
-/// dangling symlink still counts as an existing destination.  This is racy by
-/// construction, which is why it is only a fallback.
+/// Atomic no-replace for kernels and filesystems without `RENAME_NOREPLACE`.
+///
+/// Hard-linking the source is atomic and works for non-directory sources on
+/// filesystems that support hard links.  When that is unavailable there is no
+/// atomic no-replace primitive, so fail instead of falling back to a
+/// check-then-rename that can overwrite a concurrently created destination.
 async fn rename_no_overwrite_fallback(src: &Path, dest: &Path) -> std::io::Result<()> {
-    match fs::symlink_metadata(dest).await {
-        Ok(_) => return Err(already_exists(dest)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e),
+    if !fs::symlink_metadata(src).await.map(|meta| meta.is_dir())? {
+        match fs::hard_link(src, dest).await {
+            Ok(()) => {
+                fs::remove_file(src).await?;
+                return Ok(());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(already_exists(dest));
+            }
+            Err(error) => return Err(error),
+        }
     }
-    fs::rename(src, dest).await
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!(
+            "Atomic no-replace rename is not supported for {} on this filesystem",
+            src.display()
+        ),
+    ))
 }
 
 #[cfg(target_os = "linux")]

--- a/server/src/handlers/process/pipe.rs
+++ b/server/src/handlers/process/pipe.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::{Mutex, Notify, Semaphore};
 
 use super::super::HandlerResult;
 use super::super::system::expand_tilde;
@@ -225,6 +225,9 @@ pub(super) struct ManagedProcess {
     pub(super) exit_status: Option<ExitStatus>,
     pub(super) shared_exit_status: Arc<StdMutex<Option<ExitStatus>>>,
     pub(super) stdin: Arc<Mutex<Option<ChildStdin>>>,
+    /// Wakes a `process.write' blocked on a full pipe when stdin is closed.
+    pub(super) stdin_close: Arc<Notify>,
+    pub(super) stdin_close_requested: Arc<AtomicBool>,
     pub(super) stdout: Arc<Mutex<Option<ChildStdout>>>,
     pub(super) stderr: Arc<Mutex<Option<ChildStderr>>>,
     pub(super) cmd: String,
@@ -567,6 +570,8 @@ pub async fn start(params: Value) -> HandlerResult {
         exit_status: None,
         shared_exit_status: Arc::new(StdMutex::new(None)),
         stdin: Arc::new(Mutex::new(child.stdin.take())),
+        stdin_close: Arc::new(Notify::new()),
+        stdin_close_requested: Arc::new(AtomicBool::new(false)),
         stdout: Arc::new(Mutex::new(child.stdout.take())),
         stderr: Arc::new(Mutex::new(child.stderr.take())),
         child,
@@ -599,7 +604,7 @@ pub async fn write(params: Value) -> HandlerResult {
     // Data is already binary, no decoding needed!
     let data = params.data;
 
-    let stdin = {
+    let (stdin, stdin_close, stdin_close_requested) = {
         let processes = get_process_map().lock().await;
         processes
             .get(&params.pid)
@@ -608,9 +613,14 @@ pub async fn write(params: Value) -> HandlerResult {
                     format!("Process not found: {}", params.pid),
                     "not_found",
                 )
+            })
+            .map(|managed| {
+                (
+                    Arc::clone(&managed.stdin),
+                    Arc::clone(&managed.stdin_close),
+                    Arc::clone(&managed.stdin_close_requested),
+                )
             })?
-            .stdin
-            .clone()
     };
 
     let mut stdin_guard = stdin.lock().await;
@@ -620,10 +630,29 @@ pub async fn write(params: Value) -> HandlerResult {
             "stdin_closed",
         ));
     };
-    stdin
-        .write_all(&data)
-        .await
-        .map_err(|e| RpcError::process_error(format!("Failed to write to stdin: {e}")))?;
+    // A close that raced the lock acquisition stores a `notify_one' permit,
+    // so the select below returns immediately even if the write has not
+    // started yet.
+    if stdin_close_requested.load(Ordering::SeqCst) {
+        return Err(RpcError::process_error_with_kind(
+            format!("Process stdin is closed: {}", params.pid),
+            "stdin_closed",
+        ));
+    }
+    tokio::select! {
+        result = stdin.write_all(&data) => result
+            .map_err(|e| RpcError::process_error(format!("Failed to write to stdin: {e}")))?,
+        // `close_stdin' cannot take the handle while this task holds the lock,
+        // so it cancels the blocked write first.  Without this a full pipe
+        // wedges `close_stdin' and the client's close times out, tearing down
+        // the whole connection.
+        _ = stdin_close.notified() => {
+            return Err(RpcError::process_error_with_kind(
+                format!("Process stdin is closed: {}", params.pid),
+                "stdin_closed",
+            ));
+        }
+    }
 
     Ok(msgpack_map! {
         "written" => data.len()
@@ -914,7 +943,7 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
 
     let params: Params = from_value(params).map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
-    let stdin = {
+    let (stdin, stdin_close, stdin_close_requested) = {
         let processes = get_process_map().lock().await;
         processes
             .get(&params.pid)
@@ -923,10 +952,21 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
                     format!("Process not found: {}", params.pid),
                     "not_found",
                 )
+            })
+            .map(|managed| {
+                (
+                    Arc::clone(&managed.stdin),
+                    Arc::clone(&managed.stdin_close),
+                    Arc::clone(&managed.stdin_close_requested),
+                )
             })?
-            .stdin
-            .clone()
     };
+
+    // Cancel any `process.write' blocked on a full pipe before waiting for the
+    // lock it holds.  `notify_one' leaves a permit when no writer is waiting,
+    // and the flag covers a writer that has not reached its select yet.
+    stdin_close_requested.store(true, Ordering::SeqCst);
+    stdin_close.notify_one();
 
     // Flush any buffered data before closing stdin, then drop to close the pipe.
     // This is a defensive measure: the client should drain its write queue before

--- a/server/src/handlers/process/pipe.rs
+++ b/server/src/handlers/process/pipe.rs
@@ -5,8 +5,6 @@
 
 use crate::msgpack_map;
 use crate::protocol::{ProcessResult, RpcError, from_value};
-use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
-use nix::unistd::Pid;
 use rmpv::Value;
 use rustix::io::fcntl_dupfd_cloexec;
 #[cfg(target_vendor = "apple")]
@@ -17,7 +15,6 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::os::fd::OwnedFd;
-use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -944,33 +941,28 @@ pub async fn close_stdin(params: Value) -> HandlerResult {
     Ok(Value::Boolean(true))
 }
 
-pub(super) async fn wait_pipe_child(os_pid: u32) -> Result<Option<ExitStatus>, nix::errno::Errno> {
+/// Wait until the managed child behind registry PID is reaped.
+///
+/// This polls tokio's own `try_wait' so the child's `kill_on_drop' state stays
+/// consistent.  Reaping the same child with a second reaper (nix `waitpid')
+/// hides the reap from tokio, which then still believes the process is running
+/// and can send `SIGKILL' to an already-reaped, potentially recycled PID when
+/// the registry entry is dropped.
+pub(super) async fn wait_pipe_child(pid: u32) -> Result<Option<ExitStatus>, RpcError> {
     loop {
-        match waitpid(Pid::from_raw(os_pid as i32), Some(WaitPidFlag::WNOHANG)) {
-            Ok(status @ (WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _))) => {
-                return Ok(Some(exit_status_from_wait_status(status)));
+        {
+            let mut processes = get_process_map().lock().await;
+            let Some(managed) = processes.get_mut(&pid) else {
+                // Another poll consumed the status and removed the entry.
+                return Ok(None);
+            };
+            if let Some(status) = poll_exit_status(managed).map_err(|error| {
+                RpcError::process_error(format!("Failed to reap process {pid}: {error}"))
+            })? {
+                return Ok(Some(status));
             }
-            Ok(WaitStatus::StillAlive) => {
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            }
-            // Another status poll can only have consumed the status while the
-            // lifecycle lock is not held.  The map entry remains until its
-            // streams reach EOF, even in that case.
-            Err(nix::errno::Errno::ECHILD) => return Ok(None),
-            Err(nix::errno::Errno::EINTR) => continue,
-            Err(error) => return Err(error),
-            Ok(_) => return Err(nix::errno::Errno::EINVAL),
         }
-    }
-}
-
-pub(super) fn exit_status_from_wait_status(status: WaitStatus) -> ExitStatus {
-    match status {
-        WaitStatus::Exited(_, code) => ExitStatus::from_raw(code << 8),
-        WaitStatus::Signaled(_, signal, core_dumped) => {
-            ExitStatus::from_raw(signal as i32 | if core_dumped { 0x80 } else { 0 })
-        }
-        _ => ExitStatus::from_raw(0),
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
     }
 }
 
@@ -1029,7 +1021,7 @@ pub(super) async fn terminate_pipe_process(
     let mut reap = if cached.is_some() {
         cached
     } else {
-        tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(os_pid))
+        tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(pid))
             .await
             .ok()
             .and_then(Result::ok)
@@ -1048,14 +1040,11 @@ pub(super) async fn terminate_pipe_process(
         require_process_group_signal(signal_process_group(os_pid, libc::SIGKILL), "send SIGKILL")?;
     }
     if reap.is_none() && escalate {
-        reap = tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(os_pid))
+        reap = tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(pid))
             .await
             .map_err(|_| {
                 RpcError::process_error(format!("Timed out reaping process {pid} after SIGKILL"))
-            })?
-            .map_err(|error| {
-                RpcError::process_error(format!("Failed to reap process {pid}: {error}"))
-            })?;
+            })??;
     }
     if let Some(exit_status) = reap {
         // Publish before any destructive cleanup so a read which captured the

--- a/server/src/handlers/process/pipe.rs
+++ b/server/src/handlers/process/pipe.rs
@@ -1107,11 +1107,22 @@ pub(super) async fn terminate_pipe_process(
         require_process_group_signal(signal_process_group(os_pid, libc::SIGKILL), "send SIGKILL")?;
     }
     if reap.is_none() && escalate {
-        reap = tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(pid))
-            .await
-            .map_err(|_| {
-                RpcError::process_error(format!("Timed out reaping process {pid} after SIGKILL"))
-            })??;
+        // The escalation reap is the last chance to observe the child.  Retire
+        // it on failure too, so the background reaper owns an unreaped child
+        // instead of leaving the entry registered forever.
+        reap = match tokio::time::timeout(MANAGED_CHILD_WAIT, wait_pipe_child(pid)).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(error)) => {
+                retire_pipe_process(pid).await;
+                return Err(error);
+            }
+            Err(_) => {
+                retire_pipe_process(pid).await;
+                return Err(RpcError::process_error(format!(
+                    "Timed out reaping process {pid} after SIGKILL"
+                )));
+            }
+        };
     }
     if let Some(exit_status) = reap {
         // Publish before any destructive cleanup so a read which captured the

--- a/server/src/handlers/process/pipe.rs
+++ b/server/src/handlers/process/pipe.rs
@@ -1016,6 +1016,23 @@ pub(super) async fn wait_pipe_child(pid: u32) -> Result<Option<ExitStatus>, RpcE
     }
 }
 
+/// Remove PID from the registry, reaping the direct child in the background
+/// when it was not confirmed dead.
+///
+/// Dropping an unreaped tokio `Child' leaves a zombie and keeps
+/// `kill_on_drop' armed, so a bounded-wait timeout (for example, a child in
+/// uninterruptible sleep) must not simply discard the entry.
+pub(super) async fn retire_pipe_process(pid: u32) {
+    let removed = get_process_map().lock().await.remove(&pid);
+    if let Some(mut managed) = removed
+        && managed.exit_status.is_none()
+    {
+        tokio::spawn(async move {
+            let _ = managed.child.wait().await;
+        });
+    }
+}
+
 pub(super) async fn terminate_pipe_process(
     pid: u32,
     signal: i32,
@@ -1053,7 +1070,7 @@ pub(super) async fn terminate_pipe_process(
             *shared_exit_status
                 .lock()
                 .expect("shared pipe exit status lock") = cached;
-            get_process_map().lock().await.remove(&pid);
+            retire_pipe_process(pid).await;
         }
         return Ok(true);
     }
@@ -1107,7 +1124,7 @@ pub(super) async fn terminate_pipe_process(
         }
         if signal == libc::SIGKILL {
             // Explicit SIGKILL is the caller's opt-out from output draining.
-            get_process_map().lock().await.remove(&pid);
+            retire_pipe_process(pid).await;
         }
         return Ok(true);
     }
@@ -1115,7 +1132,7 @@ pub(super) async fn terminate_pipe_process(
         // Explicit SIGKILL is the caller's opt-out from drain-preserving
         // ownership.  Always remove it, whether status() won the reap race or
         // this call did; already in-flight reads retain the shared state.
-        get_process_map().lock().await.remove(&pid);
+        retire_pipe_process(pid).await;
     }
 
     // Signal delivery is the success criterion, matching local

--- a/server/src/handlers/process/pipe.rs
+++ b/server/src/handlers/process/pipe.rs
@@ -423,6 +423,7 @@ pub(crate) async fn run_child(
     // Return binary data directly (no encoding needed!)
     Ok(ProcessResult {
         exit_code: crate::protocol::exit_code_from_status(status),
+        signal: crate::protocol::exit_signal_from_status(status),
         stdout,
         stderr,
     })
@@ -797,12 +798,21 @@ pub async fn read(params: Value) -> HandlerResult {
     } else {
         Value::Nil
     };
+    let exit_signal = if exited {
+        exit_status
+            .and_then(crate::protocol::exit_signal_from_status)
+            .map(|signal| Value::Integer(signal.into()))
+            .unwrap_or(Value::Nil)
+    } else {
+        Value::Nil
+    };
 
     Ok(msgpack_map! {
         "stdout" => stdout_val,
         "stderr" => stderr_val,
         "exited" => exited,
-        "exit_code" => exit_code
+        "exit_code" => exit_code,
+        "signal" => exit_signal
     })
 }
 
@@ -1188,7 +1198,8 @@ pub async fn status(params: Value) -> HandlerResult {
 
     Ok(msgpack_map! {
         "exited" => exit_status.is_some(),
-        "exit_code" => exit_status.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        "exit_code" => exit_status.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil),
+        "signal" => exit_status.and_then(crate::protocol::exit_signal_from_status).map(|s| Value::Integer(s.into())).unwrap_or(Value::Nil)
     })
 }
 
@@ -1215,7 +1226,8 @@ pub async fn list(_params: Value) -> HandlerResult {
             "os_pid" => Value::Integer((managed.child_pid as i64).into()),
             "cmd" => managed.cmd.clone(),
             "exited" => exited.is_some(),
-            "exit_code" => exited.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+            "exit_code" => exited.map(crate::protocol::exit_code_from_status).map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil),
+            "signal" => exited.and_then(crate::protocol::exit_signal_from_status).map(|s| Value::Integer(s.into())).unwrap_or(Value::Nil)
         });
     }
 

--- a/server/src/handlers/process/pty.rs
+++ b/server/src/handlers/process/pty.rs
@@ -104,6 +104,14 @@ impl PtyIoState {
     pub(super) fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire)
     }
+
+    /// Withdraw a cancellation whose motivating signal was not delivered.
+    /// A writer already woken by `cancel' may still observe the error once;
+    /// the `is_closed' re-check in `write_pty' lets later writes proceed.
+    pub(super) fn reopen(&self) {
+        let _syscall_guard = self.syscall_lock.lock().expect("PTY syscall lock");
+        self.closed.store(false, Ordering::Release);
+    }
 }
 
 pub(super) struct ManagedPtyProcess {
@@ -743,9 +751,14 @@ pub async fn write_pty(params: Value) -> HandlerResult {
             result = async_fd.ready(Interest::WRITABLE) => result
                 .map_err(|e| RpcError::process_error(format!("Failed to wait for writable: {e}")))?,
             _ = cancelled => {
-                return Err(RpcError::process_error(format!(
-                    "PTY write cancelled: {}", params.pid
-                )));
+                if io.is_closed() {
+                    return Err(RpcError::process_error(format!(
+                        "PTY write cancelled: {}", params.pid
+                    )));
+                }
+                // The cancellation was withdrawn (a signal that motivated it
+                // failed); ignore the stale notification and retry.
+                continue;
             }
         };
 
@@ -818,14 +831,25 @@ pub(super) async fn terminate_pty_process(
         };
     };
     // Explicit teardown and SIGKILL must wake a writer blocked on readiness
-    // immediately.  Other forwarded signals (notably SIGINT) are survivable
-    // for an interactive shell, so leave the PTY I/O state usable until a
-    // terminal exit has actually been confirmed.
-    if remove || signal == libc::SIGKILL {
+    // immediately, before waiting for the lifecycle lock, so a reader or
+    // writer can be released while the signal is still being delivered.
+    // Other forwarded signals (notably SIGINT) are survivable for an
+    // interactive shell, so leave the PTY I/O state usable until a terminal
+    // exit has actually been confirmed.
+    let cancelled_early = remove || signal == libc::SIGKILL;
+    if cancelled_early {
         io.cancel();
     }
     let _lifecycle_guard = lifecycle.lock().await;
-    signal_pty_process_group(os_pid, signal, "send signal")?;
+    if let Err(error) = signal_pty_process_group(os_pid, signal, "send signal") {
+        // A failed signal (EPERM from a surviving credential-changing
+        // descendant) must leave the PTY usable; otherwise the entry stays
+        // registered with every later write rejected.
+        if cancelled_early {
+            io.reopen();
+        }
+        return Err(error);
+    }
 
     if matches!(signal, 0 | libc::SIGSTOP | libc::SIGCONT) {
         return Ok(true);

--- a/server/src/handlers/process/pty.rs
+++ b/server/src/handlers/process/pty.rs
@@ -804,6 +804,22 @@ pub(super) async fn wait_pty_pid(child_pid: Pid) -> Result<Option<i32>, nix::err
     }
 }
 
+/// Remove PID from the PTY registry, reaping the direct child in the
+/// background when it was not confirmed dead.
+///
+/// Dropping the entry closes the PTY master (which sends SIGHUP), but an
+/// unreaped child would still remain a zombie for the life of the server.
+pub(super) async fn retire_pty_process(pid: u32, os_pid: u32) {
+    let removed = get_pty_process_map().lock().await.remove(&pid);
+    if let Some(managed) = removed
+        && managed.exit_status.is_none()
+    {
+        tokio::spawn(async move {
+            let _ = wait_pty_pid(Pid::from_raw(os_pid as i32)).await;
+        });
+    }
+}
+
 pub(super) async fn terminate_pty_process(
     pid: u32,
     signal: i32,
@@ -961,7 +977,7 @@ pub(super) async fn terminate_pty_process(
         if retain_removed_status {
             record_terminated_pty_status(pid, exit_code);
         }
-        get_pty_process_map().lock().await.remove(&pid);
+        retire_pty_process(pid, os_pid).await;
         return Ok(true);
     }
 

--- a/server/src/handlers/process/pty.rs
+++ b/server/src/handlers/process/pty.rs
@@ -29,29 +29,58 @@ use super::super::system::expand_tilde;
 #[cfg(target_os = "macos")]
 use super::signal_process;
 use super::{
-    MANAGED_CHILD_WAIT, MANAGED_PTY_CHILD_WAIT, MAX_PROCESS_READ_BYTES, SignalCode, dup_cloexec,
+    MANAGED_PTY_CHILD_WAIT, MAX_PROCESS_READ_BYTES, SignalCode, dup_cloexec,
     require_process_group_signal, set_fd_cloexec, set_fd_nonblocking, signal_process_group,
     wait_for_process_group_exit,
 };
 
 pub(super) static PTY_PROCESS_MAP: OnceLock<Mutex<HashMap<u32, ManagedPtyProcess>>> =
     OnceLock::new();
-pub(super) static TERMINATED_PTY_STATUSES: OnceLock<StdMutex<HashMap<u32, i32>>> = OnceLock::new();
+/// Terminal status of a PTY child: the historical 128 + signal code plus the
+/// signal itself when the child was killed by one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PtyExit {
+    pub code: i32,
+    pub signal: Option<i32>,
+}
+
+impl PtyExit {
+    pub(super) fn from_wait_status(status: WaitStatus) -> Option<Self> {
+        match status {
+            WaitStatus::Exited(_, code) => Some(Self { code, signal: None }),
+            WaitStatus::Signaled(_, signal, _) => Some(Self {
+                code: 128 + signal as i32,
+                signal: Some(signal as i32),
+            }),
+            _ => None,
+        }
+    }
+
+    pub(super) fn from_signal(signal: i32) -> Self {
+        Self {
+            code: 128 + signal,
+            signal: Some(signal),
+        }
+    }
+}
+
+pub(super) static TERMINATED_PTY_STATUSES: OnceLock<StdMutex<HashMap<u32, PtyExit>>> =
+    OnceLock::new();
 pub(super) static PTY_PID_COUNTER: OnceLock<Mutex<u32>> = OnceLock::new();
 
 pub(super) fn get_pty_process_map() -> &'static Mutex<HashMap<u32, ManagedPtyProcess>> {
     PTY_PROCESS_MAP.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub(super) fn record_terminated_pty_status(pid: u32, exit_code: i32) {
+pub(super) fn record_terminated_pty_status(pid: u32, exit: PtyExit) {
     TERMINATED_PTY_STATUSES
         .get_or_init(|| StdMutex::new(HashMap::new()))
         .lock()
         .expect("terminated PTY status lock")
-        .insert(pid, exit_code);
+        .insert(pid, exit);
 }
 
-pub(super) fn take_terminated_pty_status(pid: u32) -> Option<i32> {
+pub(super) fn take_terminated_pty_status(pid: u32) -> Option<PtyExit> {
     TERMINATED_PTY_STATUSES
         .get_or_init(|| StdMutex::new(HashMap::new()))
         .lock()
@@ -120,10 +149,10 @@ pub(super) struct ManagedPtyProcess {
     pub(super) io: Arc<PtyIoState>,
     pub(super) child_pid: Pid,
     pub(super) cmd: String,
-    pub(super) exit_status: Option<i32>,
+    pub(super) exit_status: Option<PtyExit>,
     // Retain an observed terminal status for a read that captured the PTY
     // before explicit SIGKILL removes its registry entry.
-    pub(super) shared_exit_status: Arc<StdMutex<Option<i32>>>,
+    pub(super) shared_exit_status: Arc<StdMutex<Option<PtyExit>>>,
     pub(super) output_eof: bool,
 }
 
@@ -526,7 +555,8 @@ pub async fn read_pty(params: Value) -> HandlerResult {
     Ok(msgpack_map! {
         "output" => output,
         "exited" => result.exited,
-        "exit_code" => result.exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+        "exit_code" => result.exit.map(|exit| Value::Integer(exit.code.into())).unwrap_or(Value::Nil),
+        "signal" => result.exit.and_then(|exit| exit.signal).map(|signal| Value::Integer(signal.into())).unwrap_or(Value::Nil)
     })
 }
 
@@ -534,7 +564,7 @@ pub(super) struct PtyReadResult {
     pub(super) output: Vec<u8>,
     pub(super) pending: bool,
     pub(super) exited: bool,
-    pub(super) exit_code: Option<i32>,
+    pub(super) exit: Option<PtyExit>,
 }
 
 pub(super) async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadResult, RpcError> {
@@ -549,7 +579,7 @@ pub(super) async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadRe
                 output: Vec::new(),
                 pending: false,
                 exited: true,
-                exit_code: take_terminated_pty_status(pid),
+                exit: take_terminated_pty_status(pid),
             });
         };
         let fd = dup_cloexec(managed.async_fd.get_ref())
@@ -576,7 +606,7 @@ pub(super) async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadRe
             output: Vec::new(),
             pending: false,
             exited: true,
-            exit_code: shared_status.or(retained_status),
+            exit: shared_status.or(retained_status),
         });
     };
 
@@ -610,7 +640,7 @@ pub(super) async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadRe
         managed.output_eof = true;
     }
 
-    let (child_exited, exit_code) = check_exit_status(managed);
+    let (child_exited, exit) = check_exit_status(managed);
     let exited = child_exited && managed.output_eof;
     drop(processes);
     if exited {
@@ -624,35 +654,26 @@ pub(super) async fn read_pty_now(pid: u32, max_bytes: usize) -> Result<PtyReadRe
         output,
         pending,
         exited,
-        exit_code: exited.then_some(exit_code).flatten(),
+        exit: exited.then_some(exit).flatten(),
     })
 }
 
-pub(super) fn check_exit_status(managed: &mut ManagedPtyProcess) -> (bool, Option<i32>) {
+pub(super) fn check_exit_status(managed: &mut ManagedPtyProcess) -> (bool, Option<PtyExit>) {
     if managed.exit_status.is_some() {
         (true, managed.exit_status)
     } else {
-        match waitpid(managed.child_pid, Some(WaitPidFlag::WNOHANG)) {
-            Ok(WaitStatus::Exited(_, code)) => {
-                managed.exit_status = Some(code);
-                *managed
-                    .shared_exit_status
-                    .lock()
-                    .expect("shared PTY exit status lock") = Some(code);
-                (true, Some(code))
-            }
-            Ok(WaitStatus::Signaled(_, signal, _)) => {
-                let code = 128 + signal as i32;
-                managed.exit_status = Some(code);
-                *managed
-                    .shared_exit_status
-                    .lock()
-                    .expect("shared PTY exit status lock") = Some(code);
-                (true, Some(code))
-            }
-            Ok(WaitStatus::StillAlive) => (false, None),
-            _ => (false, None),
+        let exit = match waitpid(managed.child_pid, Some(WaitPidFlag::WNOHANG)) {
+            Ok(status) => PtyExit::from_wait_status(status),
+            Err(_) => None,
+        };
+        if let Some(exit) = exit {
+            managed.exit_status = Some(exit);
+            *managed
+                .shared_exit_status
+                .lock()
+                .expect("shared PTY exit status lock") = Some(exit);
         }
+        (managed.exit_status.is_some(), managed.exit_status)
     }
 }
 
@@ -788,11 +809,12 @@ pub async fn write_pty(params: Value) -> HandlerResult {
     })
 }
 
-pub(super) async fn wait_pty_pid(child_pid: Pid) -> Result<Option<i32>, nix::errno::Errno> {
+pub(super) async fn wait_pty_pid(child_pid: Pid) -> Result<Option<PtyExit>, nix::errno::Errno> {
     loop {
         match waitpid(child_pid, Some(WaitPidFlag::WNOHANG)) {
-            Ok(WaitStatus::Exited(_, code)) => return Ok(Some(code)),
-            Ok(WaitStatus::Signaled(_, signal, _)) => return Ok(Some(128 + signal as i32)),
+            Ok(status @ (WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _))) => {
+                return Ok(PtyExit::from_wait_status(status));
+            }
             Ok(WaitStatus::StillAlive) => {
                 tokio::time::sleep(std::time::Duration::from_millis(5)).await;
             }
@@ -927,17 +949,30 @@ pub(super) async fn terminate_pty_process(
         signal_pty_process_group(os_pid, libc::SIGKILL, "send SIGKILL")?;
     }
     if reap.is_none() && escalate {
-        reap = tokio::time::timeout(
-            MANAGED_CHILD_WAIT,
+        // The escalation reap is the last chance to observe the child.  Use the
+        // PTY budget for it as well, and retire the entry on failure so a
+        // single unreaped child cannot poison the shared registry for every
+        // later test or connection.
+        reap = match tokio::time::timeout(
+            MANAGED_PTY_CHILD_WAIT,
             wait_pty_pid(Pid::from_raw(os_pid as i32)),
         )
         .await
-        .map_err(|_| {
-            RpcError::process_error(format!("Timed out reaping PTY process {pid} after SIGKILL"))
-        })?
-        .map_err(|error| {
-            RpcError::process_error(format!("Failed to reap PTY process {pid}: {error}"))
-        })?;
+        {
+            Ok(Ok(status)) => status,
+            Ok(Err(error)) => {
+                retire_pty_process(pid, os_pid).await;
+                return Err(RpcError::process_error(format!(
+                    "Failed to reap PTY process {pid}: {error}"
+                )));
+            }
+            Err(_) => {
+                retire_pty_process(pid, os_pid).await;
+                return Err(RpcError::process_error(format!(
+                    "Timed out reaping PTY process {pid} after SIGKILL"
+                )));
+            }
+        };
     }
     if let Some(exit_code) = reap {
         // Reaping confirms terminal death, so no further PTY input can be
@@ -968,14 +1003,14 @@ pub(super) async fn terminate_pty_process(
         // SIGKILL was delivered but the bounded reap did not observe a status
         // (for example, another waiter consumed it).  The explicit kill still
         // has deterministic abnormal process semantics for an in-flight read.
-        let exit_code = {
+        let exit = {
             let mut status = shared_exit_status
                 .lock()
                 .expect("shared PTY exit status lock");
-            *status.get_or_insert(128 + libc::SIGKILL)
+            *status.get_or_insert(PtyExit::from_signal(libc::SIGKILL))
         };
         if retain_removed_status {
-            record_terminated_pty_status(pid, exit_code);
+            record_terminated_pty_status(pid, exit);
         }
         retire_pty_process(pid, os_pid).await;
         return Ok(true);
@@ -1055,13 +1090,14 @@ pub async fn list_pty(_params: Value) -> HandlerResult {
         let Some(managed) = processes.get_mut(&pid) else {
             continue;
         };
-        let (exited, exit_code) = check_exit_status(managed);
+        let (exited, exit) = check_exit_status(managed);
         list.push(msgpack_map! {
             "pid" => pid,
             "os_pid" => managed.child_pid.as_raw(),
             "cmd" => managed.cmd.clone(),
             "exited" => exited,
-            "exit_code" => exit_code.map(|c| Value::Integer(c.into())).unwrap_or(Value::Nil)
+            "exit_code" => exit.map(|exit| Value::Integer(exit.code.into())).unwrap_or(Value::Nil),
+            "signal" => exit.and_then(|exit| exit.signal).map(|signal| Value::Integer(signal.into())).unwrap_or(Value::Nil)
         });
     }
 

--- a/server/src/handlers/process/tests.rs
+++ b/server/src/handlers/process/tests.rs
@@ -200,6 +200,31 @@ async fn cleanup_reports_signal_failure_and_retains_managed_process() {
 }
 
 #[tokio::test]
+async fn removed_unreaped_pipe_process_is_reaped_in_background() {
+    let _test_lock = test_process_map_lock().await;
+    let pid = start_pipe_process("sleep 30").await;
+    let os_pid = pipe_os_pid(pid).await;
+
+    // Remove before the child is reaped, which is what an explicit SIGKILL
+    // whose bounded wait times out does.  The background reaper must wait the
+    // child so it does not become a zombie.
+    retire_pipe_process(pid).await;
+    assert!(!get_process_map().lock().await.contains_key(&pid));
+
+    signal_process_group(os_pid as u32, libc::SIGKILL).expect("kill process group");
+
+    for _ in 0..200 {
+        if waitpid(Pid::from_raw(os_pid as i32), Some(WaitPidFlag::WNOHANG))
+            == Err(nix::errno::Errno::ECHILD)
+        {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("removed child was not reaped in the background");
+}
+
+#[tokio::test]
 async fn failed_pty_signal_leaves_io_usable() {
     let _test_lock = test_process_map_lock().await;
     let start_result = start_pty(Value::Map(vec![

--- a/server/src/handlers/process/tests.rs
+++ b/server/src/handlers/process/tests.rs
@@ -224,6 +224,36 @@ async fn removed_unreaped_pipe_process_is_reaped_in_background() {
     panic!("removed child was not reaped in the background");
 }
 
+#[test]
+fn pty_exit_reports_the_terminating_signal() {
+    use nix::sys::signal::Signal;
+    use nix::sys::wait::WaitStatus;
+
+    let pid = Pid::from_raw(1);
+    assert_eq!(
+        PtyExit::from_wait_status(WaitStatus::Signaled(pid, Signal::SIGKILL, false)),
+        Some(PtyExit {
+            code: 137,
+            signal: Some(9)
+        })
+    );
+    assert_eq!(
+        PtyExit::from_wait_status(WaitStatus::Exited(pid, 42)),
+        Some(PtyExit {
+            code: 42,
+            signal: None
+        })
+    );
+    assert_eq!(
+        PtyExit::from_signal(libc::SIGTERM),
+        PtyExit {
+            code: 143,
+            signal: Some(15)
+        }
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
 #[tokio::test]
 async fn failed_pty_signal_leaves_io_usable() {
     let _test_lock = test_process_map_lock().await;

--- a/server/src/handlers/process/tests.rs
+++ b/server/src/handlers/process/tests.rs
@@ -200,6 +200,51 @@ async fn cleanup_reports_signal_failure_and_retains_managed_process() {
 }
 
 #[tokio::test]
+async fn failed_pty_signal_leaves_io_usable() {
+    let _test_lock = test_process_map_lock().await;
+    let start_result = start_pty(Value::Map(vec![
+        (Value::String("cmd".into()), Value::String("/bin/sh".into())),
+        (
+            Value::String("args".into()),
+            Value::Array(vec![
+                Value::String("-c".into()),
+                Value::String("sleep 30".into()),
+            ]),
+        ),
+    ]))
+    .await
+    .expect("start PTY");
+    let pid = map_get(&start_result, "pid")
+        .and_then(Value::as_u64)
+        .expect("PTY pid") as u32;
+
+    set_test_process_group_signal_error(Some(libc::EPERM));
+    let result = kill_pty(Value::Map(vec![
+        (Value::String("pid".into()), Value::Integer(pid.into())),
+        (Value::String("signal".into()), Value::Integer(9.into())),
+    ]))
+    .await;
+    set_test_process_group_signal_error(None);
+
+    assert!(result.is_err(), "EPERM must be reported");
+    // Cancelling before a signal that can fail would permanently disable PTY
+    // writes while leaving the entry registered.  The client must still be
+    // able to write or close the terminal after a failed signal.
+    let write = write_pty(Value::Map(vec![
+        (Value::String("pid".into()), Value::Integer(pid.into())),
+        (Value::String("data".into()), Value::Binary(b"x".to_vec())),
+    ]))
+    .await;
+    assert!(
+        write.is_ok(),
+        "PTY must remain writable after a failed signal: {:?}",
+        write.err()
+    );
+
+    cleanup_managed_processes().await.expect("cleanup PTY");
+}
+
+#[tokio::test]
 async fn synchronous_output_reader_enforces_shared_limit() {
     let budget = Arc::new(RetainedOutputBudget::new(Arc::new(Semaphore::new(4))));
     let error = read_sync_output(&b"oversized"[..], budget, 4)

--- a/server/src/handlers/process/tests.rs
+++ b/server/src/handlers/process/tests.rs
@@ -1712,6 +1712,26 @@ async fn pipe_sigkill_discards_unread_output_after_reaping_direct_child() {
 }
 
 #[tokio::test]
+async fn wait_pipe_child_reaps_through_tokio() {
+    let _test_lock = test_process_map_lock().await;
+    let pid = start_pipe_process("exit 0").await;
+
+    let status = wait_pipe_child(pid).await.expect("reap managed child");
+    assert!(status.is_some(), "exited child must report a status");
+
+    // Reaping must go through tokio's own `try_wait' so the child's
+    // `kill_on_drop' state is cleared.  A second reaper hides the reap from
+    // tokio, which then still believes the process is alive and can SIGKILL
+    // an already-reaped, possibly recycled PID when the entry is dropped.
+    let mut processes = get_process_map().lock().await;
+    let managed = processes.get_mut(&pid).expect("managed child");
+    assert!(
+        managed.child.try_wait().expect("tokio try_wait").is_some(),
+        "tokio must consider the child reaped"
+    );
+}
+
+#[tokio::test]
 async fn pty_kill_preserves_output_until_terminal_eof() {
     let _test_lock = test_process_map_lock().await;
     let temp = tempfile::tempdir().expect("temporary marker directory");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,7 +46,7 @@ pub(crate) const MAX_RESPONSE_OUTPUT_BYTES: usize = MAX_FRAME_SIZE - 1024 * 1024
 const FRAME_CHANNEL_SIZE: usize = 2;
 const GENERAL_TASK_LIMIT: usize = 16;
 const CONTROL_TASK_LIMIT: usize = 4;
-const PTY_WRITE_TASK_LIMIT: usize = 16;
+const WRITE_TASK_LIMIT: usize = 16;
 /// How many decoded-but-not-yet-started requests are buffered before the
 /// connection stops reading frames.  Past this point the bounded frame
 /// channel and the OS pipe throttle the client, which is the only
@@ -67,8 +67,10 @@ const DEFERRED_REQUEST_LIMIT: usize = 64;
 /// below the unbounded 6.4GiB.  Active params are separately bounded by
 /// ACTIVE_PARAM_BYTES (128MiB); active response buffers remain per-request
 /// bounded (MAX_RESPONSE_OUTPUT_BYTES each, 16 max) and require the trusted
-/// client to request 16 concurrent large outputs — mitigated by per-command
-/// timeouts and the per-batch shared output budget.
+/// client to request 16 concurrent large outputs — mitigated by the
+/// per-command deadline of `commands.run_parallel', the per-batch shared
+/// output budget, and the client's own call timeout for `process.run' (which
+/// has no server-side deadline).
 const DEFERRED_BYTE_LIMIT: usize = 32 * 1024 * 1024;
 const ERROR_RESPONSE_CHANNEL_SIZE: usize = 16;
 const EOF_TASK_JOIN_WAIT: std::time::Duration = std::time::Duration::from_millis(500);
@@ -139,13 +141,13 @@ async fn read_frames<R>(
 enum TaskClass {
     General,
     Control,
-    PtyWrite,
+    Write,
 }
 
 struct Admissions {
     general: Arc<Semaphore>,
     control: Arc<Semaphore>,
-    pty_write: Arc<Semaphore>,
+    write: Arc<Semaphore>,
 }
 
 impl Admissions {
@@ -158,7 +160,7 @@ impl Admissions {
         match class {
             TaskClass::General => &self.general,
             TaskClass::Control => &self.control,
-            TaskClass::PtyWrite => &self.pty_write,
+            TaskClass::Write => &self.write,
         }
     }
 
@@ -178,7 +180,7 @@ impl Default for Admissions {
         Self {
             general: Arc::new(Semaphore::new(GENERAL_TASK_LIMIT)),
             control: Arc::new(Semaphore::new(CONTROL_TASK_LIMIT)),
-            pty_write: Arc::new(Semaphore::new(PTY_WRITE_TASK_LIMIT)),
+            write: Arc::new(Semaphore::new(WRITE_TASK_LIMIT)),
         }
     }
 }
@@ -192,10 +194,11 @@ fn task_class(method: &str) -> TaskClass {
         | "process.close_stdin"
         | "process.kill_pty"
         | "process.close_pty" => TaskClass::Control,
-        // PTY writes can remain blocked until the remote program reads input.
-        // Isolate them so they cannot consume every general request permit;
-        // lifecycle operations retain their separately reserved control slots.
-        "process.write_pty" => TaskClass::PtyWrite,
+        // Pipe and PTY writes can remain blocked until the remote program
+        // reads input.  Isolate them so they cannot consume every general
+        // request permit; lifecycle operations retain their separately
+        // reserved control slots.
+        "process.write" | "process.write_pty" => TaskClass::Write,
         _ => TaskClass::General,
     }
 }
@@ -432,7 +435,7 @@ async fn drain_tasks_for(tasks: &mut JoinSet<()>, wait: std::time::Duration) {
 struct AdmissionPass {
     general_waiting: bool,
     control_blocked: bool,
-    pty_write_blocked: bool,
+    write_blocked: bool,
 }
 
 impl AdmissionPass {
@@ -441,7 +444,7 @@ impl AdmissionPass {
         match class {
             TaskClass::General => false,
             TaskClass::Control => self.control_blocked,
-            TaskClass::PtyWrite => self.pty_write_blocked,
+            TaskClass::Write => self.write_blocked,
         }
     }
 
@@ -464,7 +467,7 @@ impl AdmissionPass {
                 self.general_waiting = true;
             }
             TaskClass::Control => self.control_blocked = true,
-            TaskClass::PtyWrite => self.pty_write_blocked = true,
+            TaskClass::Write => self.write_blocked = true,
         }
     }
 }

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -371,6 +371,12 @@ impl DirEntry {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProcessResult {
     pub exit_code: i32,
+    /// Signal number that terminated the process, when it was not a normal
+    /// exit.  `exit_code' keeps the historical 128 + signal value, but the
+    /// client needs the signal itself to report `process-status' as `signal'
+    /// and to distinguish a real exit of 137 from SIGKILL.
+    #[serde(default)]
+    pub signal: Option<i32>,
     /// stdout content as raw bytes
     #[serde(with = "serde_bytes")]
     pub stdout: Vec<u8>,
@@ -386,6 +392,12 @@ impl ProcessResult {
             (
                 Value::String("exit_code".into()),
                 Value::Integer(self.exit_code.into()),
+            ),
+            (
+                Value::String("signal".into()),
+                self.signal
+                    .map(|signal| Value::Integer(signal.into()))
+                    .unwrap_or(Value::Nil),
             ),
             (
                 Value::String("stdout".into()),
@@ -455,6 +467,29 @@ impl IntoValue for Value {
     fn into_value(self) -> Value {
         self
     }
+}
+
+/// Return the signal number that terminated STATUS, or nil for a normal exit.
+///
+/// Kept separate from `exit_code_from_status' because the 128 + signal
+/// convention cannot distinguish a process killed by SIGKILL from one that
+/// genuinely exited with code 137.
+pub fn exit_signal_from_status(status: std::process::ExitStatus) -> Option<i32> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        if let Some(sig) = status.signal() {
+            return Some(sig);
+        }
+        let raw = status.into_raw();
+        let termsig = raw & 0x7f;
+        if termsig != 0 && termsig != 0x7f {
+            return Some(termsig);
+        }
+    }
+    let _ = status;
+    None
 }
 
 /// Extract an exit code from a `std::process::ExitStatus`.

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -257,9 +257,10 @@ fn test_blocked_pty_writes_use_dedicated_admission() {
         .try_acquire_many(TaskClass::General, GENERAL_TASK_LIMIT)
         .expect("reserve every general permit");
 
-    assert_eq!(task_class("process.write_pty"), TaskClass::PtyWrite);
+    assert_eq!(task_class("process.write_pty"), TaskClass::Write);
+    assert_eq!(task_class("process.write"), TaskClass::Write);
     assert_eq!(task_class("process.signal"), TaskClass::Control);
-    assert!(admissions.try_acquire(TaskClass::PtyWrite).is_some());
+    assert!(admissions.try_acquire(TaskClass::Write).is_some());
     assert!(admissions.try_acquire(TaskClass::Control).is_some());
 }
 
@@ -1121,6 +1122,84 @@ async fn test_process_write_not_blocked_by_long_poll_read() {
     );
 
     let _ = read_task.await;
+    let kill_payload = make_request(
+        "process.kill",
+        Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (Value::String("signal".into()), Value::Integer(9.into())),
+        ]),
+    );
+    let _ = process_request(&kill_payload).await;
+}
+
+/// `close_stdin' must be able to rescue a write blocked on a full pipe.
+///
+/// The writer holds the stdin mutex for the whole `write_all', so without a
+/// cancellation signal `close_stdin' waits forever, its control slot is
+/// consumed, and the client's close times out and tears down the connection.
+#[tokio::test]
+async fn test_close_stdin_cancels_blocked_write() {
+    let _test_lock = handlers::process::test_process_map_lock().await;
+    let start_response = process_request(&make_request(
+        "process.start",
+        Value::Map(vec![
+            (Value::String("cmd".into()), Value::String("/bin/sh".into())),
+            (
+                Value::String("args".into()),
+                Value::Array(vec![
+                    Value::String("-c".into()),
+                    Value::String("sleep 30".into()),
+                ]),
+            ),
+        ]),
+    ))
+    .await;
+    let pid = map_get(start_response.result.as_ref().expect("start result"), "pid")
+        .and_then(Value::as_u64)
+        .expect("process.start should return pid") as u32;
+
+    // Far larger than the pipe buffer, and the child never reads it.
+    let write_payload = make_request(
+        "process.write",
+        Value::Map(vec![
+            (Value::String("pid".into()), Value::Integer(pid.into())),
+            (
+                Value::String("data".into()),
+                Value::Binary(vec![0u8; 4 * 1024 * 1024]),
+            ),
+        ]),
+    );
+    let write_task = tokio::spawn(async move { process_request(&write_payload).await });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let close_payload = make_request(
+        "process.close_stdin",
+        Value::Map(vec![(
+            Value::String("pid".into()),
+            Value::Integer(pid.into()),
+        )]),
+    );
+    let close_response = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        process_request(&close_payload),
+    )
+    .await
+    .expect("close_stdin must not block behind a blocked write");
+    assert!(
+        close_response.error.is_none(),
+        "close_stdin should succeed: {:?}",
+        close_response.error
+    );
+
+    let write_response = tokio::time::timeout(std::time::Duration::from_secs(5), write_task)
+        .await
+        .expect("cancelled write must finish")
+        .expect("write task should join");
+    assert!(
+        write_response.error.is_some(),
+        "a write cancelled by close_stdin must report an error"
+    );
+
     let kill_payload = make_request(
         "process.kill",
         Value::Map(vec![

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -1240,6 +1240,15 @@ async fn test_process_run_signal_exit_code() {
         })
         .expect("should have exit_code");
     assert_eq!(exit_code, 130, "SIGINT should produce exit code 128+2=130");
+    let signal = result
+        .as_map()
+        .and_then(|m| {
+            m.iter()
+                .find(|(k, _)| k.as_str() == Some("signal"))
+                .map(|(_, v)| v.as_i64())
+        })
+        .expect("should have signal");
+    assert_eq!(signal, Some(2), "SIGINT must be reported as a signal");
 }
 
 /// Test that process.run returns 128+signal for SIGKILL.
@@ -1271,6 +1280,15 @@ async fn test_process_run_sigkill_exit_code() {
         })
         .expect("should have exit_code");
     assert_eq!(exit_code, 137, "SIGKILL should produce exit code 128+9=137");
+    let signal = result
+        .as_map()
+        .and_then(|m| {
+            m.iter()
+                .find(|(k, _)| k.as_str() == Some("signal"))
+                .map(|(_, v)| v.as_i64())
+        })
+        .expect("should have signal");
+    assert_eq!(signal, Some(9), "SIGKILL must be reported as a signal");
 }
 
 /// Test that process.run returns the correct exit code for normal exit.

--- a/server/src/watcher/mod.rs
+++ b/server/src/watcher/mod.rs
@@ -777,12 +777,18 @@ impl WatchManager {
     ///
     /// Lock ordering: watcher -> watched_paths (same as watch()).
     pub fn unwatch(&self, path: &Path) -> Result<(), notify::Error> {
+        // A path can be registered in both watchers: the nofollow watcher
+        // tracks the symlink itself and the regular watcher tracks its
+        // canonical target.  Remove both, otherwise a single watch.remove
+        // leaves the other registration alive for the life of the server.
+        let mut removed_nofollow = false;
         {
             let mut symlink_watcher = lock_or_recover(&self.symlink_watcher);
             if let Some(watcher) = symlink_watcher.as_mut()
                 && watcher.contains(path)
             {
-                return watcher.unwatch(path);
+                watcher.unwatch(path)?;
+                removed_nofollow = true;
             }
         }
 
@@ -795,6 +801,9 @@ impl WatchManager {
 
         // Find the matching stored path using exact canonical path matching only.
         if !paths.contains_key(&canonical) {
+            if removed_nofollow {
+                return Ok(());
+            }
             return Err(notify::Error::generic(&format!(
                 "Path not being watched (canonical: {}): {}",
                 canonical.display(),

--- a/server/src/watcher/tests.rs
+++ b/server/src/watcher/tests.rs
@@ -222,6 +222,39 @@ fn test_nofollow_symlink_watch_reports_link_attribute_change() {
     assert!(found, "symlink metadata changes should be reported");
 }
 
+#[test]
+fn test_unwatch_removes_nofollow_and_regular_registrations() {
+    let manager = test_manager();
+    if lock_or_recover(&manager.symlink_watcher).is_none() {
+        return;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let target = temp.path().join("target");
+    let link = temp.path().join("link");
+    fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    manager
+        .watch_with_options(&link, false, true)
+        .expect("nofollow watch");
+    manager
+        .watch_with_options(&link, false, false)
+        .expect("regular watch");
+    assert!(!manager.list().is_empty());
+
+    // A single watch.remove must drop both registrations; returning after the
+    // nofollow one would leave the regular watch alive forever.
+    manager.unwatch(&link).expect("unwatch both registrations");
+    assert!(manager.list().is_empty());
+    assert!(
+        !lock_or_recover(&manager.symlink_watcher)
+            .as_mut()
+            .expect("symlink watcher")
+            .contains(&link),
+        "nofollow registration must be removed as well"
+    );
+}
+
 #[cfg(target_os = "linux")]
 fn set_symlink_mtime(path: &Path, seconds: i64) {
     use rustix::fs::{AtFlags, CWD, Timespec, Timestamps};

--- a/server/src/watcher/tests.rs
+++ b/server/src/watcher/tests.rs
@@ -222,6 +222,7 @@ fn test_nofollow_symlink_watch_reports_link_attribute_change() {
     assert!(found, "symlink metadata changes should be reported");
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_unwatch_removes_nofollow_and_regular_registrations() {
     let manager = test_manager();

--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -151,20 +151,27 @@ before exiting.  Do not use `kill-emacs-hook' for this: upstream
       (user-error "This function is only for use in batch mode"))
   (let ((exit-code 2))
     (unwind-protect
-        (let* ((tests (ert-select-tests selector t))
-               (selected (length tests)))
-          (unless (> selected 0)
-            (error "ERT selector %S selected zero tests" selector))
-          (let* ((stats (ert-run-tests-batch selector))
-                 (skipped (ert-stats-skipped stats))
-                 (executed (- (ert-stats-completed stats) skipped)))
-            (message "ERT counts: selected=%d executed=%d skipped=%d"
-                     selected executed skipped)
-            (when (= executed 0)
-              (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
-                     selector skipped))
-            (setq exit-code
-                  (if (zerop (ert-stats-completed-unexpected stats)) 0 1))))
+        ;; Catch guard failures so their diagnostic is logged before
+        ;; `kill-emacs' runs; otherwise batch mode exits with code 2 and the
+        ;; reason is lost.
+        (condition-case err
+            (let* ((tests (ert-select-tests selector t))
+                   (selected (length tests)))
+              (unless (> selected 0)
+                (error "ERT selector %S selected zero tests" selector))
+              (let* ((stats (ert-run-tests-batch selector))
+                     (skipped (ert-stats-skipped stats))
+                     (executed (- (ert-stats-completed stats) skipped)))
+                (message "ERT counts: selected=%d executed=%d skipped=%d"
+                         selected executed skipped)
+                (when (= executed 0)
+                  (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
+                         selector skipped))
+                (setq exit-code
+                      (if (zerop (ert-stats-completed-unexpected stats)) 0 1))))
+          (error
+           (message "ERT run failed: %s" (error-message-string err))
+           (setq exit-code 2)))
       (tramp-rpc-test--write-debug-buffers)
       (kill-emacs exit-code))))
 

--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -151,9 +151,20 @@ before exiting.  Do not use `kill-emacs-hook' for this: upstream
       (user-error "This function is only for use in batch mode"))
   (let ((exit-code 2))
     (unwind-protect
-        (let ((stats (ert-run-tests-batch selector)))
-          (setq exit-code
-                (if (zerop (ert-stats-completed-unexpected stats)) 0 1)))
+        (let* ((tests (ert-select-tests selector t))
+               (selected (length tests)))
+          (unless (> selected 0)
+            (error "ERT selector %S selected zero tests" selector))
+          (let* ((stats (ert-run-tests-batch selector))
+                 (skipped (ert-stats-skipped stats))
+                 (executed (- (ert-stats-completed stats) skipped)))
+            (message "ERT counts: selected=%d executed=%d skipped=%d"
+                     selected executed skipped)
+            (when (= executed 0)
+              (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
+                     selector skipped))
+            (setq exit-code
+                  (if (zerop (ert-stats-completed-unexpected stats)) 0 1))))
       (tramp-rpc-test--write-debug-buffers)
       (kill-emacs exit-code))))
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1895,6 +1895,40 @@ This matches the behavior expected by `tramp-test28-process-file'."
       (dolist (buf (list buffer replacement-buffer))
         (when (buffer-live-p buf) (kill-buffer buf))))))
 
+(ert-deftest tramp-rpc-mock-test-generation-cleanup-survives-failing-hooks ()
+  "A failing terminate or cleanup hook must not strand a generation.
+`cleanup-started' is claimed before the hooks run, so an error or quit in
+them would otherwise leave the generation permanently un-cleanable with its
+async callbacks and local relays leaked."
+  (let* ((vec (tramp-dissect-file-name "/rpc:cleanup-hook:/tmp/"))
+         (buffer (generate-new-buffer " *tramp-rpc-cleanup-hook*"))
+         (connection (start-process "tramp-rpc-cleanup-hook" buffer "sleep" "10"))
+         (conn (tramp-rpc--make-connection :process connection :buffer buffer
+                                           :vec vec))
+         (tramp-rpc--connections (make-hash-table :test 'equal))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         (tramp-rpc-transport-terminate-functions
+          (list (lambda (&rest _) (error "terminate hook failed"))))
+         (tramp-rpc-transport-cleanup-functions
+          (list (lambda (&rest _) (error "cleanup hook failed"))))
+         (callbacks 0))
+    (unwind-protect
+        (progn
+          (puthash (tramp-rpc--connection-key vec) conn tramp-rpc--connections)
+          (tramp-rpc--attach-connection conn)
+          (puthash 7 (lambda (_response) (setq callbacks (1+ callbacks)))
+                   (tramp-rpc-connection-async-callbacks conn))
+          (tramp-rpc--cleanup-connection-generation
+           connection vec "hook failure\n" :explicit-disconnect t)
+          (should (tramp-rpc-connection-transport-dead conn))
+          (should (tramp-rpc-connection-transport-cleaned conn))
+          (should (= callbacks 1))
+          (should-not (process-live-p connection)))
+      (when (process-live-p connection) (delete-process connection))
+      (when (buffer-live-p buffer) (kill-buffer buffer)))))
+
 (ert-deftest tramp-rpc-mock-test-pty-read-error-is-terminal ()
   "PTY RPC errors and malformed responses terminate without another poll."
   (dolist (response '((:error (:code -32004 :message "read failed"))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -3937,7 +3937,11 @@ status to be consulted, which is why a direct property test would miss it."
           (should (string-match-p
                    "DONE"
                    (with-current-buffer stdout-buffer (buffer-string))))
-          (should (> (with-current-buffer stderr-buffer (buffer-size)) 100000)))
+          ;; A full 200000-byte stderr stream must have been drained (or the
+          ;; child would still be blocked on a full pipe), and the retained
+          ;; buffer is bounded to its configured tail.
+          (should (= (with-current-buffer stderr-buffer (buffer-size))
+                     tramp-rpc-stderr-buffer-limit)))
       (when (process-live-p process)
         (delete-process process))
       (ignore-errors

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -142,6 +142,26 @@
       (msgpack-bin-string data)
     data))
 
+(defun tramp-rpc-mock-test--run-guarded (selector)
+  "Run SELECTOR with ERT, failing when it selects or executes nothing.
+CI uses this instead of a bare `ert-run-tests-batch-and-exit' so a renamed
+tag, a load error, or a broken environment cannot turn a job green while
+it exercised no tests.  Skipped tests count as expected results in ERT, so
+the executed count excludes them."
+  (let* ((tests (ert-select-tests selector t))
+         (selected (length tests)))
+    (unless (> selected 0)
+      (error "ERT selector %S selected zero tests" selector))
+    (let* ((stats (ert-run-tests-batch selector))
+           (skipped (ert-stats-skipped stats))
+           (executed (- (ert-stats-completed stats) skipped)))
+      (message "ERT counts: selected=%d executed=%d skipped=%d"
+               selected executed skipped)
+      (when (= executed 0)
+        (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
+               selector skipped))
+      (kill-emacs (if (> (ert-stats-completed-unexpected stats) 0) 1 0)))))
+
 (defun tramp-rpc-mock-test--wait-for (predicate description &optional process)
   "Run the event loop until PREDICATE succeeds or report DESCRIPTION."
   (let ((deadline (+ (float-time) 1.0)))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -5274,6 +5274,43 @@ issue #268 (0.13 fails to download prebuilt binary)."
                              built)))))
       (delete-directory dir t))))
 
+(ert-deftest tramp-rpc-mock-test-deploy-source-build-output-requires-provenance ()
+  "Source-id mode trusts a target artifact only with a matching sidecar."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((dir (make-temp-file "tramp-rpc-source" t))
+         (target (expand-file-name
+                  "target/x86_64-unknown-linux-musl/release/tramp-rpc-server"
+                  dir)))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name ".git" dir))
+          (make-directory (expand-file-name "server/src" dir) t)
+          (with-temp-file (expand-file-name "Cargo.toml" dir)
+            (insert "[workspace]\nmembers = [\"server\"]\n"))
+          (with-temp-file (expand-file-name "server/src/main.rs" dir)
+            (insert "fn main() {}\n"))
+          (make-directory (file-name-directory target) t)
+          (with-temp-file target (insert "binary\n"))
+          (set-file-modes target #o755)
+          (let ((tramp-rpc-deploy-source-directory dir)
+                (tramp-rpc-deploy-git-build-policy 'auto))
+            (cl-letf (((symbol-function 'tramp-rpc-deploy--git-revision)
+                       (lambda () "abcdef123456")))
+              ;; The artifact is newer than the sources, but without recorded
+              ;; provenance the mtime heuristic must not authorize it.
+              (should-not (tramp-rpc-deploy--source-build-output-path
+                           "x86_64-linux"))
+              (let ((sidecar (tramp-rpc-deploy--source-build-id-path target)))
+                (with-temp-file sidecar (insert "git-other\n"))
+                (should-not (tramp-rpc-deploy--source-build-output-path
+                             "x86_64-linux"))
+                (tramp-rpc-deploy--record-source-build-id target)
+                (should (equal (tramp-rpc-deploy--source-build-output-path
+                                "x86_64-linux")
+                               target))))))
+      (delete-directory dir t))))
+
 (ert-deftest tramp-rpc-mock-test-deploy-binary-id-source-hash ()
   "Test that git checkouts key binary ids by server source content."
   :tags '(:deploy)

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -2615,10 +2615,10 @@ status to be consulted, which is why a direct property test would miss it."
          (emacs (or (executable-find "emacs")
                     (error "Cannot find Emacs executable")))
          (wrapper (expand-file-name "emacs-wrapper" runner-temp-directory))
-         (supported-source (getenv "TRAMP_SOURCE"))
          (skipped (expand-file-name "skipped.el" runner-temp-directory))
          (empty (expand-file-name "empty.el" runner-temp-directory))
-         (unsupported (expand-file-name "unsupported" runner-temp-directory)))
+         (unsupported (expand-file-name "unsupported" runner-temp-directory))
+         (supported (expand-file-name "supported" runner-temp-directory)))
     (unwind-protect
         (progn
           (with-temp-file wrapper
@@ -2636,6 +2636,11 @@ status to be consulted, which is why a direct property test would miss it."
           (make-directory (expand-file-name "lisp" unsupported) t)
           (with-temp-file (expand-file-name "lisp/tramp.el" unsupported)
             (insert "(defvar tramp-version \"0\")\n(provide 'tramp)\n"))
+          ;; A fake supported Tramp keeps the guard checks independent of the
+          ;; bundled Tramp version, which is older than the minimum on Emacs 30.
+          (make-directory (expand-file-name "lisp" supported) t)
+          (with-temp-file (expand-file-name "lisp/tramp.el" supported)
+            (insert "(defvar tramp-version \"99.0\")\n(provide 'tramp)\n"))
           (cl-labels
               ((run (test-file &optional tramp-source)
                  (with-temp-buffer
@@ -2654,11 +2659,11 @@ status to be consulted, which is why a direct property test would miss it."
                                    process-environment))))
                      (list (call-process runner nil t nil "--protocol")
                            (buffer-string))))))
-            (pcase-let ((`(,status ,output) (run skipped supported-source)))
+            (pcase-let ((`(,status ,output) (run skipped supported)))
               (should (/= status 0))
               (should (string-match-p
                        "ERT counts: selected=2 executed=0 skipped=2" output)))
-            (pcase-let ((`(,status ,output) (run empty supported-source)))
+            (pcase-let ((`(,status ,output) (run empty supported)))
               (should (/= status 0))
               (should (string-match-p "selected zero tests" output)))
             (pcase-let ((`(,status ,output) (run skipped unsupported)))
@@ -5729,6 +5734,26 @@ issue #268 (0.13 fails to download prebuilt binary)."
               (should (equal (tramp-rpc-deploy--ensure-local-binary arch) cache)))))
       (delete-directory dir t)))))
 
+(ert-deftest tramp-rpc-mock-test-deploy-build-rejects-source-changed-during-build ()
+  "A source change during the build must not be cached under a later id."
+  :tags '(:deploy)
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((dir (make-temp-file "tramp-rpc-build-source" t))
+        built)
+    (unwind-protect
+        (let ((tramp-rpc-deploy-source-directory dir))
+          (cl-letf (((symbol-function 'tramp-rpc-deploy--source-binary-id)
+                     (lambda () (if built "git-changed" "git-same")))
+                    ((symbol-function 'tramp-rpc-deploy--cargo-available-p)
+                     (lambda () t))
+                    ((symbol-function 'tramp-rpc-deploy--can-build-for-arch-p)
+                     (lambda (_arch) t))
+                    ((symbol-function 'call-process)
+                     (lambda (&rest _args) (setq built t) 0)))
+            (should-error (tramp-rpc-deploy--build-binary "x86_64-linux")
+                          :type 'remote-file-error)))
+      (delete-directory dir t))))
+
 (ert-deftest tramp-rpc-mock-test-deploy-modified-source-cache-is-invalidated ()
   "A modified source-built cache binary is removed rather than reused."
   :tags '(:deploy)
@@ -7051,8 +7076,10 @@ background, which can precede the socket becoming visible."
           (process-put proc :tramp-rpc-exited t)
           (cl-letf (((symbol-function 'tramp-run-real-handler)
                      (lambda (&rest _) (error "Unexpected process state"))))
+            ;; Pass PROC explicitly so the check does not depend on
+            ;; `get-buffer-process' picking the relay out of the buffer.
             (tramp-rpc-handle-vc-exec-after
-             (lambda () (setq ran t))))
+             (lambda () (setq ran t)) nil proc))
           (should ran))
       (when (process-live-p proc)
         (delete-process proc))

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -982,7 +982,7 @@ literally finds nothing."
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-locate-dominating-file-depth-limit ()
-  "Ensure dominating-file helper errors after 100 ancestor levels."
+  "Ensure dominating-file helper reports not-found after 100 ancestor levels."
   :tags '(:server)
   (skip-unless tramp-rpc-mock-test--msgpack-available)
   (skip-unless (tramp-rpc-mock-test--find-server))
@@ -1001,10 +1001,8 @@ literally finds nothing."
                          "highlevel.locate_dominating_file_multi"
                          `((file . ,(encode-coding-string file 'utf-8))
                            (names . [".git"])))))
-            (should (stringp (plist-get result :error)))
-            (should (string-match-p
-                     "Maximum ancestor traversal depth (100) exceeded"
-                     (plist-get result :error))))))
+            ;; Hitting the bound is "not found", not a remote error.
+            (should (zerop (length result))))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-test-files-in-dir ()
@@ -1086,7 +1084,7 @@ literally finds nothing."
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-highlevel-dir-locals-cache-update-depth-limit ()
-  "Ensure dir-locals cache helper errors after 100 ancestor levels."
+  "Ensure dir-locals cache helper reports not-found after 100 ancestor levels."
   :tags '(:server)
   (skip-unless tramp-rpc-mock-test--msgpack-available)
   (skip-unless (tramp-rpc-mock-test--find-server))
@@ -1105,10 +1103,11 @@ literally finds nothing."
                          `((file . ,(encode-coding-string file 'utf-8))
                            (names . [".dir-locals.el"])
                            (cache_dirs . [])))))
-            (should (stringp (plist-get result :error)))
-            (should (string-match-p
-                     "Maximum ancestor traversal depth (100) exceeded"
-                     (plist-get result :error))))))
+            ;; Hitting the bound is "not found", not a remote error.
+            (should-not (plist-get result :error))
+            (should (alist-get 'file result))
+            (should-not (alist-get 'locals result))
+            (should-not (alist-get 'cache result)))))
     (tramp-rpc-mock-test--stop-server)))
 
 (ert-deftest tramp-rpc-mock-test-server-process-run ()

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -1993,6 +1993,76 @@ async callbacks and local relays leaked."
       (remhash process tramp-rpc--pty-processes)
       (when (process-live-p process) (delete-process process)))))
 
+(ert-deftest tramp-rpc-mock-test-process-signal-status-and-exit-status ()
+  "A signal-killed remote process reports `signal' and its signal number.
+Local processes report `signal'/9 for SIGKILL; callers such as LSP and
+compile branch on that, so the 128 + signal exit code alone is not enough."
+  (let ((process (start-process "tramp-rpc-signal-status" nil "cat")))
+    (unwind-protect
+        (progn
+          (process-put process :tramp-rpc-pid 42)
+          (process-put process :tramp-rpc-exit-code 137)
+          (process-put process :tramp-rpc-exit-signal 9)
+          (process-put process :tramp-rpc-exited t)
+          (should (eq (tramp-rpc-handle-process-status process) 'signal))
+          (should (= (tramp-rpc-handle-process-exit-status process) 9)))
+      (when (process-live-p process) (delete-process process)))))
+
+(ert-deftest tramp-rpc-mock-test-signal-description-matches-emacs ()
+  "Signal descriptions match the strings local Emacs uses."
+  (should (equal (tramp-rpc-protocol-signal-description 9) "Killed"))
+  (should (equal (tramp-rpc-protocol-signal-description 15) "Terminated"))
+  (should (equal (tramp-rpc-protocol-signal-description 11) "Segmentation fault"))
+  (should (equal (tramp-rpc-protocol-signal-description 99) "Signal 99")))
+
+(ert-deftest tramp-rpc-mock-test-signal-exit-still-sends-relay-eof ()
+  "A signal-killed process must still send EOF to its local relay.
+`tramp-rpc--handle-process-exit' marks the process terminal, and the advised
+`process-status' then reports `signal', so setting the signal before the EOF
+would make `process-live-p' false and leave the relay (and its sentinel)
+alive forever.  The `tramp-vector' property is required for the advised
+status to be consulted, which is why a direct property test would miss it."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/rpc:user@host:/tmp/"))
+         (process (start-process "tramp-rpc-signal-eof" nil "cat"))
+         (tramp-rpc--async-processes (make-hash-table :test 'eq))
+         (tramp-rpc--process-write-queues (make-hash-table :test 'equal))
+         eof-sent)
+    (unwind-protect
+        (progn
+          (process-put process 'tramp-vector vec)
+          (process-put process :tramp-rpc-pid 42)
+          (puthash process (list :vec vec :pid 42 :connection-process nil)
+                   tramp-rpc--async-processes)
+          (cl-letf (((symbol-function 'process-send-eof)
+                     (lambda (proc) (setq eof-sent proc))))
+            (tramp-rpc--handle-process-exit process 137 9))
+          (should (eq eof-sent process))
+          (should (eq (process-get process :tramp-rpc-exit-signal) 9))
+          (should (process-get process :tramp-rpc-exited)))
+      (when (processp process) (ignore-errors (delete-process process))))))
+
+(ert-deftest tramp-rpc-mock-test-pty-signal-exit-still-sends-relay-eof ()
+  "A signal-killed PTY process must still send EOF to its local relay."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let* ((vec (tramp-dissect-file-name "/rpc:user@host:/tmp/"))
+         (process (start-process "tramp-rpc-pty-signal-eof" nil "cat"))
+         (tramp-rpc--pty-processes (make-hash-table :test 'eq))
+         eof-sent)
+    (unwind-protect
+        (progn
+          (process-put process 'tramp-vector vec)
+          (process-put process :tramp-rpc-pid 42)
+          (process-put process :tramp-rpc-pty t)
+          (puthash process '(:poll-timer nil) tramp-rpc--pty-processes)
+          (cl-letf (((symbol-function 'process-send-eof)
+                     (lambda (proc) (setq eof-sent proc))))
+            (tramp-rpc--handle-pty-exit process 137 9))
+          (should (eq eof-sent process))
+          (should (eq (process-get process :tramp-rpc-exit-signal) 9))
+          (should (process-get process :tramp-rpc-exited)))
+      (when (processp process) (ignore-errors (delete-process process))))))
+
 (ert-deftest tramp-rpc-mock-test-pty-terminal-read-error-calls-user-sentinel-once ()
   "A terminal PTY read error invokes the real user sentinel exactly once."
   (let* ((process (start-process "tramp-rpc-pty-terminal-error" nil "cat"))
@@ -7665,6 +7735,52 @@ discard it for being unreadable."
               (insert-file-contents stderr-file)
               (should (string-match-p "missing executable" (buffer-string))))))
       (ignore-errors (delete-file stderr-file)))))
+
+(ert-deftest tramp-rpc-mock-test-process-file-signal-and-exit-codes ()
+  "`process-file' returns the raw exit code unless signal strings are opted in.
+This matches tramp-sh and upstream `tramp-test28-process-file', which requires
+128 + signal by default and a description only when
+`process-file-return-signal-string' is set."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((default-directory "/rpc:user@host:/work/")
+        (process-file-side-effects nil)
+        (result '((exit_code . 0) (stdout . "") (stderr . ""))))
+    (cl-letf (((symbol-function 'tramp-rpc--cached-remote-path)
+               (lambda (_vec) '("/usr/bin")))
+              ((symbol-function 'tramp-rpc--get-direnv-environment)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--caller-environment)
+               (lambda () nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-lookup)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc-magit--process-cache-store)
+               (lambda (&rest _) nil))
+              ((symbol-function 'tramp-rpc--get-signal-strings)
+               (lambda (_vec)
+                 (vector 0 "Hangup" "Interrupt" nil nil nil nil nil nil
+                         "Killed" nil "Segmentation fault" nil nil nil
+                         "Terminated")))
+              ((symbol-function 'tramp-rpc--call)
+               (lambda (&rest _) (copy-tree result))))
+      ;; A real signal stays an integer by default, exactly as tramp-sh does.
+      (setq result '((exit_code . 137) (signal . 9)
+                     (stdout . "") (stderr . "")))
+      (should (= (tramp-rpc-handle-process-file "cmd" nil nil nil) 137))
+      ;; Opting in produces the description from the real signal.
+      (let ((process-file-return-signal-string t))
+        (should (equal (tramp-rpc-handle-process-file "cmd" nil nil nil)
+                       "Killed")))
+      ;; A plain exit above 128 stays an integer by default and is described
+      ;; under the legacy interpretation only when opted in.
+      (setq result '((exit_code . 137) (stdout . "") (stderr . "")))
+      (should (= (tramp-rpc-handle-process-file "cmd" nil nil nil) 137))
+      (let ((process-file-return-signal-string t))
+        (should (equal (tramp-rpc-handle-process-file "cmd" nil nil nil)
+                       "Killed")))
+      ;; Exit 128 is not a signal, even when opted in.
+      (setq result '((exit_code . 128) (stdout . "") (stderr . "")))
+      (let ((process-file-return-signal-string t))
+        (should (= (tramp-rpc-handle-process-file "cmd" nil nil nil) 128))))))
 
 (ert-deftest tramp-rpc-mock-test-process-file-preserves-other-rpc-errors ()
   "A process cwd ENOENT remains a remote-file-error, not status 127."

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -7,6 +7,12 @@
 
 (declare-function tramp-rpc--invalidate-timed-out-connection "tramp-rpc-transport"
                   (process vec event))
+(declare-function tramp-rpc--track-pending-request "tramp-rpc-transport"
+                  (conn id))
+(declare-function tramp-rpc--connection-filter "tramp-rpc-transport"
+                  (process output))
+(declare-function tramp-rpc--drain-connection-stderr "tramp-rpc-transport"
+                  (conn))
 (declare-function tramp-rpc-mock-test--wait-for "tramp-rpc-mock-tests"
                   (predicate description &optional process))
 

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -78,6 +78,29 @@ SPEC is (PROCESS BUFFER [CONNECTION]); CONNECTION defaults to `connection'."
         (should (zerop (hash-table-count
                         (tramp-rpc-connection-pending-responses connection))))))))
 
+(ert-deftest tramp-rpc-mock-test-request-id-less-error-reaches-oldest-waiter ()
+  "An id-less protocol error must wake the oldest synchronous waiter.
+The server answers an oversized or malformed frame with an error that has no
+id.  Discarding it leaves that waiter to burn the whole call timeout and
+tear down the connection."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    ;; Track order is newest-first, so 202 is the oldest waiter.
+    (tramp-rpc--track-pending-request connection 202)
+    (tramp-rpc--track-pending-request connection 101)
+    (let ((messages (list '(:id nil :error (:code -32600
+                                            :message "frame too large")))))
+      (cl-letf (((symbol-function 'tramp-rpc-protocol-try-read-message)
+                 (lambda (_buffer)
+                   (set-marker (mark-marker) (point-max))
+                   (pop messages))))
+        (tramp-rpc--connection-filter process "error")))
+    (should (equal (plist-get (gethash 202 (tramp-rpc-connection-pending-responses
+                                            connection))
+                              :error)
+                   '(:code -32600 :message "frame too large")))
+    (should-not (gethash 101 (tramp-rpc-connection-pending-responses
+                              connection)))))
+
 (defun tramp-rpc-mock-test-request--check-wait-quit (kind)
   "Abandon a KIND wait without disrupting other users of its transport."
   (tramp-rpc-mock-test-request--with-connection (process buffer)

--- a/test/tramp-rpc-request-tests.el
+++ b/test/tramp-rpc-request-tests.el
@@ -101,6 +101,27 @@ tear down the connection."
     (should-not (gethash 101 (tramp-rpc-connection-pending-responses
                               connection)))))
 
+(ert-deftest tramp-rpc-mock-test-stderr-buffer-is-bounded ()
+  "Long-lived SSH stderr output must not grow without bound."
+  (tramp-rpc-mock-test-request--with-connection (process buffer)
+    (let ((stderr-buffer (generate-new-buffer " *tramp-rpc-stderr-test*"))
+          (stderr-process nil))
+      (unwind-protect
+          (progn
+            (setq stderr-process
+                  (make-pipe-process :name "tramp-rpc-stderr-test"
+                                     :buffer stderr-buffer :noquery t))
+            (setf (tramp-rpc-connection-stderr-buffer connection) stderr-buffer)
+            (with-current-buffer stderr-buffer
+              (insert (make-string (* 2 tramp-rpc-stderr-buffer-limit) ?x))
+              (insert "TAIL-MARKER"))
+            (tramp-rpc--drain-connection-stderr connection)
+            (with-current-buffer stderr-buffer
+              (should (= (buffer-size) tramp-rpc-stderr-buffer-limit))
+              (should (string-suffix-p "TAIL-MARKER" (buffer-string)))))
+        (when (process-live-p stderr-process) (delete-process stderr-process))
+        (when (buffer-live-p stderr-buffer) (kill-buffer stderr-buffer))))))
+
 (defun tramp-rpc-mock-test-request--check-wait-quit (kind)
   "Abandon a KIND wait without disrupting other users of its transport."
   (tramp-rpc-mock-test-request--with-connection (process buffer)

--- a/test/tramp-rpc-tests.el
+++ b/test/tramp-rpc-tests.el
@@ -315,6 +315,25 @@ Returns non-nil if tests can run."
                   (error nil)))))
   (cdr tramp-rpc-test-enabled-checked))
 
+(defun tramp-rpc-test--run-guarded (selector)
+  "Run SELECTOR with ERT, failing when it selects or executes nothing.
+This suite skips most tests when the remote host is unreachable, and ERT
+reports skips as expected results, so a bare batch run would exit 0 after
+exercising almost nothing."
+  (let* ((tests (ert-select-tests selector t))
+         (selected (length tests)))
+    (unless (> selected 0)
+      (error "ERT selector %S selected zero tests" selector))
+    (let* ((stats (ert-run-tests-batch selector))
+           (skipped (ert-stats-skipped stats))
+           (executed (- (ert-stats-completed stats) skipped)))
+      (message "ERT counts: selected=%d executed=%d skipped=%d"
+               selected executed skipped)
+      (when (= executed 0)
+        (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
+               selector skipped))
+      (kill-emacs (if (> (ert-stats-completed-unexpected stats) 0) 1 0)))))
+
 (defun tramp-rpc-test--make-remote-path-2 (filename)
   "Make a full TRAMP RPC path on the second host for FILENAME."
   (format "/rpc:%s:%s/%s"


### PR DESCRIPTION
An adversarial review of the server, client, and CI turned up a set of
correctness, lifecycle, and trust issues. This fixes them, one commit per
issue.

The problems, roughly in order of severity:

- CI ran only 96 of 349 mock tests, and ERT exits 0 when a selector matches
  nothing or when every selected test skips, so the suite could pass without
  exercising anything.
- Process lifecycle: a second reaper could signal an already-recycled PID, a
  write blocked on a full pipe could wedge the whole connection, signal death
  was reported as an ordinary exit code, and children removed before they were
  confirmed reaped leaked as zombies.
- Connection teardown could be left half-cleaned by a failing hook, and an
  id-less protocol error was dropped instead of waking its waiter.
- Deployment trusted a source-tree binary by mtime alone, and non-overwriting
  copies had a check/use race.
- Smaller fixes: unbounded SSH stderr and directory listings, a watcher
  registration leak, an ancestor-scan depth error, the PTY cancel path, and the
  benchmark's unreachable batch tests.

The solutions stay close to the existing design: dedicated admission for
blocking writes, tokio-owned reaping, signal numbers carried alongside the
historical exit code, provenance sidecars for reused build output, staged
renames for copies, and guarded test runners in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Process results now report terminating signals with human-readable descriptions.
  - Closing standard input can cancel blocked writes.
  - Directory listings enforce a predictable size limit.
  - Source-built artifacts are validated against their source version before reuse.

- **Bug Fixes**
  - File copies avoid truncating destinations when overwrite is disallowed.
  - PTY operations remain usable after failed signal requests.
  - Unwatching symlink paths now removes associated watches correctly.
  - Deep path searches and protocol errors fail more gracefully.
  - SSH error output is bounded to prevent excessive buffering.
  - Process cleanup is more reliable after forced termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->