### PR TITLE
Cache capability probes whose command is missing

### DIFF
--- a/lisp/tramp-rpc-transport.el
+++ b/lisp/tramp-rpc-transport.el
@@ -1596,6 +1596,17 @@ MESSAGE describes the error."
     (signal 'remote-file-error
             (tramp-rpc--error-args operation nil message filename data)))))
 
+(defun tramp-rpc--spawn-not-found-error-p (err)
+  "Return non-nil when ERR reports that a command's executable was missing.
+ERR is a signalled error object.  `tramp-rpc--signal-rpc-error' appends the
+server's structured data as the last element of the error data, and the
+server sets `spawn_not_found' only when the executable itself could not be
+found -- not when the cwd is missing or the command ran and failed."
+  (seq-some (lambda (datum)
+              (and (consp datum)
+                   (eq (cdr (assq 'spawn_not_found datum)) t)))
+            (cdr err)))
+
 (defun tramp-rpc--signal-batch-failure (operation filename error)
   "Signal ERROR returned by a batched RPC for OPERATION on FILENAME."
   (tramp-rpc--signal-rpc-error

--- a/lisp/tramp-rpc.el
+++ b/lisp/tramp-rpc.el
@@ -1980,15 +1980,17 @@ VEC is the TRAMP connection vector."
 
 (defun tramp-rpc--cached-capability-probe (vec property command args)
   "Return cached capability PROPERTY for VEC, probing COMMAND with ARGS.
-PROPERTY must start with a space so TRAMP keeps it ephemeral.  Successful
-probes cache both enabled and disabled results.  Transport and RPC errors
-return nil without caching so a later operation can retry."
+PROPERTY must start with a space so TRAMP keeps it ephemeral.  A probe that
+runs caches its answer, and so does one that fails because COMMAND does not
+exist on the host: both are settled facts about the host.  Any other
+transport or RPC error may be transient, so it returns nil without caching
+and a later operation retries."
   (let* ((missing (make-symbol "missing"))
          (cached (tramp-rpc--get-route-connection-property
                   vec property missing)))
     (if (not (eq cached missing))
         cached
-      (condition-case nil
+      (condition-case err
           (let* ((result (tramp-rpc--call vec "process.run"
                                           `((cmd . ,command)
                                             (args . ,args)
@@ -1996,11 +1998,14 @@ return nil without caching so a later operation can retry."
                  (enabled (zerop (alist-get 'exit_code result))))
             (tramp-rpc--set-route-connection-property vec property enabled)
             enabled)
-        (error nil)))))
+        (error
+         (when (tramp-rpc--spawn-not-found-error-p err)
+           (tramp-rpc--set-route-connection-property vec property nil))
+         nil)))))
 
 (defun tramp-rpc--acl-enabled-p (vec)
   "Check if ACL is available on the remote host VEC.
-Cache successful probe results for the connection lifetime."
+Cache the answer for the connection lifetime."
   (tramp-rpc--cached-capability-probe
    vec " rpc-acl-enabled" "getfacl" ["--version"]))
 
@@ -2045,7 +2050,7 @@ Returns t on success, nil on failure."
 
 (defun tramp-rpc--selinux-enabled-p (vec)
   "Check if SELinux is enabled on the remote host VEC.
-Cache successful probe results for the connection lifetime."
+Cache the answer for the connection lifetime."
   (tramp-rpc--cached-capability-probe
    vec " rpc-selinux-enabled" "selinuxenabled" []))
 

--- a/test/tramp-rpc-mock-tests.el
+++ b/test/tramp-rpc-mock-tests.el
@@ -6846,6 +6846,50 @@ background, which can precede the socket becoming visible."
                       nil)))
       (tramp-flush-connection-properties vec))))
 
+(ert-deftest tramp-rpc-mock-test-capability-probe-caches-only-missing-command ()
+  "A probe caches an absent command but still retries other ENOENT errors."
+  (skip-unless tramp-rpc-mock-test--tramp-rpc-loaded)
+  (let ((absent (tramp-dissect-file-name "/rpc:absent-command:/"))
+        (unreadable (tramp-dissect-file-name "/rpc:unreadable-cwd:/"))
+        (absent-calls 0)
+        (unreadable-calls 0))
+    (unwind-protect
+        (cl-letf (((symbol-function 'tramp-rpc--call)
+                   (lambda (vec method params)
+                     (should (equal method "process.run"))
+                     (should (equal (alist-get 'cmd params) "selinuxenabled"))
+                     ;; The server marks a failed spawn of the executable
+                     ;; itself; the same errno without that marker can mean
+                     ;; the cwd went away, which may not be permanent.
+                     (if (equal (tramp-file-name-host vec) "absent-command")
+                         (progn
+                           (setq absent-calls (1+ absent-calls))
+                           (signal 'file-missing
+                                   (list "RPC" "No such file"
+                                         "Failed to spawn process"
+                                         '((os_errno . 2)
+                                           (spawn_not_found . t)))))
+                       (setq unreadable-calls (1+ unreadable-calls))
+                       (signal 'file-missing
+                               (list "RPC" "No such file"
+                                     "Failed to spawn process"
+                                     '((os_errno . 2))))))))
+          (should-not (tramp-rpc--selinux-enabled-p absent))
+          (should-not (tramp-rpc--selinux-enabled-p absent))
+          (should-not (tramp-rpc--selinux-enabled-p absent))
+          (should (= absent-calls 1))
+          (should (eq (tramp-rpc--get-route-connection-property
+                       absent " rpc-selinux-enabled" t)
+                      nil))
+          (should-not (tramp-rpc--selinux-enabled-p unreadable))
+          (should-not (tramp-rpc--selinux-enabled-p unreadable))
+          (should (= unreadable-calls 2))
+          (should (eq (tramp-rpc--get-route-connection-property
+                       unreadable " rpc-selinux-enabled" 'missing)
+                      'missing)))
+      (tramp-flush-connection-properties absent)
+      (tramp-flush-connection-properties unreadable))))
+
 (ert-deftest tramp-rpc-mock-test-password-string-unwraps-auth-source-entry ()
   "Normalize auth-source plist secrets before sending them to sudo -S."
   :tags '(:sudo)


### PR DESCRIPTION
Follow-up to c115cf5. A probe whose command doesn't exist on the host *signals*
rather than returning a non-zero exit code, so it lands on the "transport or RPC
error, retry later" path and is never cached: on a host without `selinuxenabled`,
`file-selinux-context` re-runs the probe on every operation that touches extended
attributes, and TRAMP's `signal-hook-function` logs the caught `file-missing` to
`*Messages*` each time — invisibly, since it messages with `inhibit-message`.

The server already marks that case with `spawn_not_found`, which tells it apart
from a missing cwd or a transient failure, so this caches it as a settled
negative answer and the probe runs once per connection instead of once per
operation. Test added alongside the existing one, covering both halves: an absent
command is cached, while the same errno without the marker still retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Capability checks now remember when a required command is unavailable, avoiding repeated failed checks.
  * Other transport or RPC failures continue to be retried so temporary issues can recover.

* **Tests**
  * Added coverage confirming that only missing-command results are cached, while other failures are retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->