### PR TITLE
ci: fail loudly when upstream Tramp tests cannot reach the remote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,7 @@ jobs:
         run: |
           # Exclude known unfixable tests:
           #   :unstable: not recommended by upstream Tramp
-          #   tramp-test45-asynchronous-requests: upstream stress test is
+          #   tramp-test46-asynchronous-requests: upstream stress test is
           #     timing-sensitive with tramp-rpc's RPC process relay in CI.
           emacs -Q --batch \
             -L lisp \
@@ -652,7 +652,7 @@ jobs:
             --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
             --eval "(package-initialize)" \
             -l test/run-tramp-tests.el \
-            --eval "(tramp-rpc-test-run-tests-batch-and-exit '(and (not (tag :unstable)) (not tramp-test45-asynchronous-requests)))"
+            --eval "(tramp-rpc-test-run-tests-batch-and-exit '(and (not (tag :unstable)) (not tramp-test46-asynchronous-requests)) t)"
 
       - name: Clone Emacs 31 tests
         if: matrix.emacs_version == 'release-snapshot'

--- a/test/run-tramp-tests.el
+++ b/test/run-tramp-tests.el
@@ -142,18 +142,47 @@
   (message "TRAMP-RPC debug logging enabled; logs will be written to %s"
            tramp-rpc-test-debug-directory))
 
-(defun tramp-rpc-test-run-tests-batch-and-exit (&optional selector)
+(defun tramp-rpc-test-run-tests-batch-and-exit (&optional selector require-remote)
   "Run ERT tests matching SELECTOR, write debug logs, then exit Emacs.
 This mirrors `ert-run-tests-batch-and-exit', but writes TRAMP-RPC debug logs
 before exiting.  Do not use `kill-emacs-hook' for this: upstream
-`tramp-test52-unload' asserts that no Tramp-related function remains on hooks."
+`tramp-test52-unload' asserts that no Tramp-related function remains on hooks.
+
+When REQUIRE-REMOTE is non-nil, fail before running if the remote test
+directory is inaccessible.  Upstream marks `tramp-test00-availability' as an
+expected failure in that case and caches the result in `tramp--test-enabled',
+so every remote test then skips while the batch still exits zero."
   (or noninteractive
       (user-error "This function is only for use in batch mode"))
   (let ((exit-code 2))
     (unwind-protect
-        (let ((stats (ert-run-tests-batch selector)))
-          (setq exit-code
-                (if (zerop (ert-stats-completed-unexpected stats)) 0 1)))
+        ;; Catch guard failures so their diagnostic is logged before
+        ;; `kill-emacs' runs; otherwise batch mode exits with code 2 and the
+        ;; reason is lost.
+        (condition-case err
+            (progn
+              (when (and require-remote
+                         (fboundp 'tramp--test-enabled)
+                         (not (tramp--test-enabled)))
+                (error "Remote directory %s is not accessible"
+                       ert-remote-temporary-file-directory))
+              (let* ((tests (ert-select-tests selector t))
+                     (selected (length tests)))
+                (unless (> selected 0)
+                  (error "ERT selector %S selected zero tests" selector))
+                (let* ((stats (ert-run-tests-batch selector))
+                       (skipped (ert-stats-skipped stats))
+                       (executed (- (ert-stats-completed stats) skipped)))
+                  (message "ERT counts: selected=%d executed=%d skipped=%d"
+                           selected executed skipped)
+                  (when (= executed 0)
+                    (error "ERT selector %S executed zero tests (all %d selected tests skipped)"
+                           selector skipped))
+                  (setq exit-code
+                        (if (zerop (ert-stats-completed-unexpected stats)) 0 1)))))
+          (error
+           (message "ERT run failed: %s" (error-message-string err))
+           (setq exit-code 2)))
       (tramp-rpc-test--write-debug-buffers)
       (kill-emacs exit-code))))
 


### PR DESCRIPTION
When the remote test directory is unavailable in CI, upstream marks
tramp-test00-availability as an *expected* failure and caches the result
in tramp--test-enabled, so every remote test then skips while the batch
still exits zero.  GitHub Actions reported green with 94 of 110 upstream
tests silently skipped.

tramp-rpc-test-run-tests-batch-and-exit now takes a REQUIRE-REMOTE
argument that fails the batch before running when tramp--test-enabled is
nil, and additionally errors when the selector selects zero tests or all
selected tests skip.  Guard failures are caught so the diagnostic is
logged before kill-emacs exits with code 2.  The upstream test job passes
REQUIRE-REMOTE, so a broken remote setup turns the job red instead of
silently skipping the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated test execution so failures return a non-success status instead of being silently overlooked.
  - Added validation for selectors that match no tests or produce only skipped tests.
  - Remote test runs now fail explicitly when the required remote directory is inaccessible.
  - Updated test selection to remain reliable when upstream test numbering changes.
  - Updated the upstream test workflow to require remote test execution where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->